### PR TITLE
Deploy API to App service plan and automate deployment

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,0 +1,36 @@
+name: Deploy API to Azure App Service
+
+on:
+  push:
+  pull_request:
+    branches: [develop]
+
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: Dev
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Deploy Web App
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.20.0
+        inlineScript: |
+          cd core/api
+          az webapp up --sku S1 -n TREAPIService -g TRERG --location westeurope
+
+    - name: Set startup command for Web App
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.20.0
+        inlineScript: |
+          az webapp config set -n TREAPIService -g TRERG --startup-file='gunicorn -w 2 -k uvicorn.workers.UvicornWorker main:app'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,10 +1,6 @@
 name: Deploy API to Azure App Service
 
 on:
-  push:
-  pull_request:
-    branches: [develop]
-
   workflow_dispatch:
 
 jobs:

--- a/core/README.md
+++ b/core/README.md
@@ -33,3 +33,19 @@ Run the API Tests locally
 ```cmd
 pytest
 ```
+
+### Deploy manually to Azure App Service
+
+- Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- Login to Azure with your credentials `az login`
+- Change the directory to api `cd api`
+- Deploy to Azure App Service `az webapp up --sku S1 -n MyUniqueAppName -g MyResourceGroup -l westeurope` This will create a Resource Group, App Service Plan and App Service if they do not exist. If App Service exists, it will deploy the solution to it.
+- Configure App Service startup command `az webapp config set --startup-file='gunicorn -w 2 -k uvicorn.workers.UvicornWorker main:app'`
+
+### Setup CI/CD deployment to Azure App Service
+
+- Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- Login to Azure with your credentials `az login`
+- Create a resource group that you want to automatically deploy the solution to `az group create -g MyResourceGroup -l westeurope`
+- Create a service credential to run the pipeline with `az ad sp create-for-rbac --name MySPNName --role Contributor --scope /subscriptions/{MySubscriptionId}/resourceGroups/{MyResourceGroup} --sdk-auth`
+- In your repository, use Add secret to create a new secret named AZURE_CREDENTIALS and paste the entire JSON object produced by the az ad sp create-for-rbac command as the secret value and save the secret.

--- a/core/api/main.py
+++ b/core/api/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from .routers import ping
+from routers import ping
 
 
 app = FastAPI()

--- a/core/api_tests/__init__.py
+++ b/core/api_tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_DIR = os.path.abspath(os.path.join(TEST_DIR, os.pardir, 'api'))
+sys.path.insert(0, PROJECT_DIR)


### PR DESCRIPTION
# Deploy API to App service plan and automate deployment

## What is being addressed

- Add steps for manual app service deployment
- Add github workflow for automatic deployment
- Add environment and Azure secret

## How is this addressed

- Manual and automatic deployment documented in readme.md
- API changed not to use relative path for routers because of the conflict with how App Service interprets path 
- Added API folder to system path via init.py for tests, as not to have to rely on relative path so that tests can be run from anywhere
- Added deploy_api.yml github workflow for CI/CD

Closes 5391 and 5392 issues in AzDO