### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT="3"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Install requirements
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+	"name": "Python 3",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": {
+			"VARIANT": "3.8",
+			"INSTALL_NODE": "false",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "/bin/bash",
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": ["ms-python.python"],
+	"forwardPorts": []
+}

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -6,12 +6,12 @@ Pre commit hooks help you lint your python code on each git commit, to avoid hav
 
 1. Install flake8, pre-commit etc.
 
-```cmd
-pip install -r requirements.txt
-```
+    ```cmd
+    pip install -r requirements.txt
+    ```
 
 2. Enable pre-commit hooks
 
-```cmd
-pre-commit install
-```
+    ```cmd
+    pre-commit install
+    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+Click==7.1.2
+fastapi[all]==0.63.0
+uvicorn[standard]==0.13.4
+gunicorn==20.1.0
 pytest==6.2.4
 flake8==3.9.1
 pre-commit==2.12.1


### PR DESCRIPTION
# PR for AzDO task #5492

## What is being addressed

- Adds a dev container so that you can test and run the application locally without installing anything

## Verify PR

- Open the project in VS Code, it should detect that there is a dev container and ask you to start in the container
- Run pytest (check that the tests pass)
- Go to the core directory and run `uvicorn api.main:app` to start a dev web server with the API (navigate to 127.0.0.1:8000/docs for swagger)
