### PR TITLE
Clean up PR docker images

### DIFF
--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Clean management-api
       uses: smartsquaregmbh/delete-old-packages@v0.3.1
       with:
-        version-pattern: "([1-9,a-z])" # The regex needs to be escaped!
+        version-pattern: "\\b[0-9a-f]{5,40}\\b" # The regex needs to be escaped!
         names: |
           management-api
+        keep: 0

--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -1,0 +1,20 @@
+name: Nightly Cleanup
+
+on:
+  schedule:
+    # 1am https://crontab.guru/#0_1_*_*_*
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly_cleanup:
+    runs-on: ubuntu-latest
+    environment: Dev
+
+    steps:
+    - name: Clean management-api
+      uses: smartsquaregmbh/delete-old-packages@v0.3.1
+      with:
+        version-pattern: "([1-9,a-z])" # The regex needs to be escaped!
+        names: |
+          management-api

--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -15,6 +15,8 @@ jobs:
     - name: Clean management-api
       uses: smartsquaregmbh/delete-old-packages@v0.3.1
       with:
+        # Regex to delete all images created as a result of PRs, i.e. tagged with git commit SHA, 
+        # e.g. ed6da1da779694ad13aae193dcc94ec7fa59786c to keep the package registry clean. 
         version-pattern: "\\b[0-9a-f]{5,40}\\b" # The regex needs to be escaped!
         names: |
           management-api


### PR DESCRIPTION
# PR for issue 78

Closes #78

## What is being addressed

Add github workflow to delete images left from PRs

## How is this addressed

- add github workflow using github action to delete packages matching ([1-9,a-z]) 
- If a PR is in progress overnight it will delete the images which is not ideal. Ideally should only delete if older than say, 24hrs, the action does have a `keep` property, we could set. Have set it to zero - so can test once merged, and then amend if necessary.

Tested using nekos act:

```
[Nightly Cleanup/nightly_cleanup] ⭐  Run Clean management-api
[Nightly Cleanup/nightly_cleanup]   ☁  git clone 'https://github.com/smartsquaregmbh/delete-old-packages' # ref=v0.3.1
[Nightly Cleanup/nightly_cleanup]   🐳  docker cp src=/root/.cache/act/smartsquaregmbh-delete-old-packages@v0.3.1/ dst=/workspaces/AzureTRE/_actions/smartsquaregmbh-delete-old-packages@v0.3.1/
[Nightly Cleanup/nightly_cleanup]   🚧  ::warning::Dry run is set. No package versions will be actually deleted.
| Fetching packages
[Nightly Cleanup/nightly_cleanup]   ❓  ::group::Found 1 packages (before filtering)
| management-api with 5 versions
[Nightly Cleanup/nightly_cleanup]   ❓  ::endgroup::
[Nightly Cleanup/nightly_cleanup]   ❓  ::group::Deleting packages
| Deleting version a0dbbdc78540abdd96881b34faceb448f3a9eeb0 of package management-api
| Deleting version 7eb1fc923ea621c44c76dc63ad0b8ea730b06001 of package management-api
[Nightly Cleanup/nightly_cleanup]   ❓  ::endgroup::
| 2 packages deleted
[Nightly Cleanup/nightly_cleanup]   ✅  Success - Clean management-api
```