### PR TITLE
Add NSG rules to workspace services subnet, add bastion

### DIFF
--- a/templates/core/terraform/bastion/bastion.tf
+++ b/templates/core/terraform/bastion/bastion.tf
@@ -1,5 +1,5 @@
 resource "azurerm_public_ip" "bastion" {
-  name                  = "pip-bas-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
+  name                = "pip-bas-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
   resource_group_name = var.resource_group_name
   location            = var.location
   allocation_method   = "Static"
@@ -17,4 +17,4 @@ resource "azurerm_bastion_host" "bastion" {
     public_ip_address_id = azurerm_public_ip.bastion.id
   }
 }
-    
+

--- a/templates/core/terraform/bastion/bastion.tf
+++ b/templates/core/terraform/bastion/bastion.tf
@@ -1,0 +1,20 @@
+resource "azurerm_public_ip" "bastion" {
+  name                  = "pip-bas-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_bastion_host" "bastion" {
+  name                = "bas-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = var.bastion_subnet
+    public_ip_address_id = azurerm_public_ip.bastion.id
+  }
+}
+    

--- a/templates/core/terraform/bastion/variables.tf
+++ b/templates/core/terraform/bastion/variables.tf
@@ -1,0 +1,6 @@
+variable "resource_name_prefix" {}
+variable "environment" {}
+variable "tre_id" {}
+variable "location" {}
+variable "resource_group_name" {}
+variable "bastion_subnet" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -127,3 +127,13 @@ module "state-store" {
   shared_subnet        = module.network.shared
   core_vnet            = module.network.core
 }
+
+module "bastion" {
+  source               = "./bastion"
+  resource_name_prefix = var.resource_name_prefix
+  environment          = var.environment
+  tre_id               = local.tre_id
+  location             = var.location
+  resource_group_name  = azurerm_resource_group.core.name
+  bastion_subnet        = module.network.bastion
+}

--- a/templates/workspaces/base_workspace/terraform/network/network.tf
+++ b/templates/workspaces/base_workspace/terraform/network/network.tf
@@ -72,12 +72,12 @@ resource "azurerm_network_security_rule" "deny-outbound-override" {
   source_port_range           = "*"
 }
 
-resource "azurerm_network_security_rule" "deny_all_inbound_override" {
+resource "azurerm_network_security_rule" "deny-all-inbound-override" {
   access                      = "Deny"
   destination_address_prefix  = "*"
   destination_port_range      = "*"
   direction                   = "Inbound"
-  name                        = "deny-all-inbound-override"
+  name                        = "deny-inbound-override"
   network_security_group_name = azurerm_network_security_group.ws.name
   priority                    = 900
   protocol                    = "*"
@@ -86,9 +86,11 @@ resource "azurerm_network_security_rule" "deny_all_inbound_override" {
   source_port_range           = "*"
 }
 
-resource "azurerm_network_security_rule" "inbound-within-services-subnet" {
+resource "azurerm_network_security_rule" "allow-inbound-within-services-subnet" {
   access                      = "Allow"
   destination_port_range      = "*"
+  destination_address_prefix  = azurerm_subnet.services.address_prefix
+  source_address_prefix       = azurerm_subnet.services.address_prefix
   direction                   = "Inbound"
   name                        = "inbound-within-services-subnet"
   network_security_group_name = azurerm_network_security_group.ws.name
@@ -98,9 +100,11 @@ resource "azurerm_network_security_rule" "inbound-within-services-subnet" {
   source_port_range           = "*"
 }
 
-resource "azurerm_network_security_rule" "outbound-within-services-subnet" {
+resource "azurerm_network_security_rule" "allow-outbound-within-services-subnet" {
   access                      = "Allow"
   destination_port_range      = "*"
+  destination_address_prefix  = azurerm_subnet.services.address_prefix
+  source_address_prefix       = azurerm_subnet.services.address_prefix
   direction                   = "Outbound"
   name                        = "outbound-within-services-subnet"
   network_security_group_name = azurerm_network_security_group.ws.name
@@ -110,7 +114,7 @@ resource "azurerm_network_security_rule" "outbound-within-services-subnet" {
   source_port_range           = "*"
 }
 
-resource "azurerm_network_security_rule" "to-shared-services" {
+resource "azurerm_network_security_rule" "allow-outbound-to-shared-services" {
   access                      = "Allow"
   destination_address_prefix  = data.azurerm_subnet.shared.address_prefix
   destination_port_range      = "*"
@@ -125,7 +129,7 @@ resource "azurerm_network_security_rule" "to-shared-services" {
 }
 
 
-resource "azurerm_network_security_rule" "to_internet" {
+resource "azurerm_network_security_rule" "allow-outbound-to-internet" {
   access                      = "Allow"
   destination_address_prefix  = "INTERNET"
   destination_port_range      = "443"

--- a/templates/workspaces/base_workspace/terraform/network/network.tf
+++ b/templates/workspaces/base_workspace/terraform/network/network.tf
@@ -146,19 +146,19 @@ resource "azurerm_network_security_rule" "allow-outbound-to-internet" {
 
 resource "azurerm_network_security_rule" "allow-inbound-from-bastion" {
   access                       = "Allow"
-  destination_address_prefixes = data.azurerm_subnet.bastion.address_prefixes
+  destination_address_prefixes = azurerm_subnet.services.address_prefixes
   destination_port_ranges = [
     "22",
     "3389",
   ]
   direction                   = "Inbound"
-  name                        = "allow-inbound-from_bastion"
+  name                        = "allow-inbound-from-bastion"
   network_security_group_name = azurerm_network_security_group.ws.name
   priority                    = 110
   protocol                    = "Tcp"
   resource_group_name         = var.resource_group_name
   source_address_prefixes = [
-    azurerm_subnet.services.address_prefix
+    data.azurerm_subnet.bastion.address_prefix
   ]
   source_port_range = "*"
 }

--- a/templates/workspaces/base_workspace/terraform/network/network.tf
+++ b/templates/workspaces/base_workspace/terraform/network/network.tf
@@ -7,10 +7,10 @@ resource "azurerm_virtual_network" "ws" {
 
 
 resource "azurerm_subnet" "services" {
-  name                                           = "ServicesSubnet"
-  virtual_network_name                           = azurerm_virtual_network.ws.name
-  resource_group_name                            = var.resource_group_name
-  address_prefixes                               = [local.services_subnet_address_prefix]
+  name                 = "ServicesSubnet"
+  virtual_network_name = azurerm_virtual_network.ws.name
+  resource_group_name  = var.resource_group_name
+  address_prefixes     = [local.services_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
   enforce_private_link_endpoint_network_policies = true
 }
@@ -32,4 +32,139 @@ resource "azurerm_virtual_network_peering" "core-ws-peer" {
   resource_group_name       = var.core_resource_group_name
   virtual_network_name      = var.core_vnet
   remote_virtual_network_id = azurerm_virtual_network.ws.id
+}
+
+data "azurerm_subnet" "shared" {
+  resource_group_name  = var.core_resource_group_name
+  virtual_network_name = var.core_vnet
+  name                 = "SharedSubnet"
+}
+
+data "azurerm_subnet" "bastion" {
+  resource_group_name  = var.core_resource_group_name
+  virtual_network_name = var.core_vnet
+  name                 = "AzureBastionSubnet"
+}
+
+resource "azurerm_network_security_group" "ws" {
+  location            = var.location
+  name                = "nsg-ws"
+  resource_group_name = var.resource_group_name
+}
+
+
+resource "azurerm_subnet_network_security_group_association" "services" {
+  network_security_group_id = azurerm_network_security_group.ws.id
+  subnet_id                 = azurerm_subnet.services.id
+}
+
+resource "azurerm_network_security_rule" "deny-outbound-override" {
+  access                      = "Deny"
+  destination_address_prefix  = "*"
+  destination_port_range      = "*"
+  direction                   = "Outbound"
+  name                        = "deny-outbound-override"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 4096
+  protocol                    = "*"
+  resource_group_name         = var.resource_group_name
+  source_address_prefix       = "*"
+  source_port_range           = "*"
+}
+
+resource "azurerm_network_security_rule" "deny_all_inbound_override" {
+  access                      = "Deny"
+  destination_address_prefix  = "*"
+  destination_port_range      = "*"
+  direction                   = "Inbound"
+  name                        = "deny-all-inbound-override"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 900
+  protocol                    = "*"
+  resource_group_name         = var.resource_group_name
+  source_address_prefix       = "*"
+  source_port_range           = "*"
+}
+
+resource "azurerm_network_security_rule" "inbound-within-services-subnet" {
+  access                      = "Allow"
+  destination_port_range      = "*"
+  direction                   = "Inbound"
+  name                        = "inbound-within-services-subnet"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 100
+  protocol                    = "*"
+  resource_group_name         = var.resource_group_name
+  source_port_range           = "*"
+}
+
+resource "azurerm_network_security_rule" "outbound-within-services-subnet" {
+  access                      = "Allow"
+  destination_port_range      = "*"
+  direction                   = "Outbound"
+  name                        = "outbound-within-services-subnet"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 100
+  protocol                    = "*"
+  resource_group_name         = var.resource_group_name
+  source_port_range           = "*"
+}
+
+resource "azurerm_network_security_rule" "to-shared-services" {
+  access                      = "Allow"
+  destination_address_prefix  = data.azurerm_subnet.shared.address_prefix
+  destination_port_range      = "*"
+  direction                   = "Outbound"
+  name                        = "to-shared-services"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 110
+  protocol                    = "*"
+  resource_group_name         = var.resource_group_name
+  source_address_prefix       = "*"
+  source_port_range           = "*"
+}
+
+
+resource "azurerm_network_security_rule" "to_internet" {
+  access                      = "Allow"
+  destination_address_prefix  = "INTERNET"
+  destination_port_range      = "443"
+  direction                   = "Outbound"
+  name                        = "to-internet"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 120
+  protocol                    = "Tcp"
+  resource_group_name         = var.resource_group_name
+  source_address_prefix       = "*"
+  source_port_range           = "*"
+}
+
+
+resource "azurerm_network_security_rule" "allow-inbound-from-bastion" {
+  access                       = "Allow"
+  destination_address_prefixes = data.azurerm_subnet.bastion.address_prefixes
+  destination_port_ranges = [
+    "22",
+    "3389",
+  ]
+  direction                   = "Inbound"
+  name                        = "allow-inbound-from_bastion"
+  network_security_group_name = azurerm_network_security_group.ws.name
+  priority                    = 110
+  protocol                    = "Tcp"
+  resource_group_name         = var.resource_group_name
+  source_address_prefixes = [
+    azurerm_subnet.services.address_prefix
+  ]
+  source_port_range = "*"
+}
+
+data "azurerm_route_table" "rt" {
+  name                = "rt-${var.core_id}"
+  resource_group_name = var.core_resource_group_name
+}
+
+resource "azurerm_subnet_route_table_association" "rt_services_subnet_association" {
+  route_table_id = data.azurerm_route_table.rt.id
+  subnet_id      = azurerm_subnet.services.id
 }


### PR DESCRIPTION
# PR for issue 53

## What is being addressed

Restrict ability to access external network locations from the workspace services subnet, but retain access to the shared subnet.

## How is this addressed

- Added NSG configuration below:
![image](https://user-images.githubusercontent.com/17089773/118193905-65937000-b440-11eb-9ebf-510bda2b5701.png)

- To troubleshoot had to add a bastion. Might want to make this optional with a variable in future. Will create an issue. Can see could access API in shared subnet, but not the internet.
![image](https://user-images.githubusercontent.com/17089773/118193794-35e46800-b440-11eb-9aa7-022109ef922d.png)

Created issue to create network flow diagram: https://github.com/microsoft/AzureTRE/issues/87