### PR TITLE
Fix paths in make_images.sh and documentation after API code restructure

### DIFF
--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -14,7 +14,8 @@
         "**/requirements.txt",
         "**/*.py",
         "**/*.yml",
-        "**/*.yaml"
+        "**/*.yaml",
+        "**/*.sh"
     ],
     "fileExtensions": [
         ".md"

--- a/devops/scripts/build_images.sh
+++ b/devops/scripts/build_images.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker build -t "${TF_VAR_resource_name_prefix}acr.azurecr.io/microsoft/azuretre/management-api:${TF_VAR_image_tag}" ./core/api/
+docker build -t "${TF_VAR_resource_name_prefix}acr.azurecr.io/microsoft/azuretre/management-api:${TF_VAR_image_tag}" ./management_api_app/

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -19,7 +19,7 @@
     pip install -r requirements.txt
     ```
 
-1. Copy `.env.tmpl` in the **core** folder to `.env` and configure the variables
+1. Copy `.env.tmpl` in the **management_api_app** folder to `.env` and configure the variables
 1. Start the web API
 
     ```cmd

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -38,6 +38,7 @@ The API will be available at [https://localhost:8000/api](https://localhost:8000
 
     ```cmd
     cd management_api_app
+    pip install -r requirements.txt
     uvicorn main:app --reload
     ```
 
@@ -51,7 +52,6 @@ Then run:
 
 ```cmd
 cd management_api_app
-pip install -r requirements.txt
 docker compose up -d app
 ```
 

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -33,7 +33,7 @@ The API will be available at [https://localhost:8000/api](https://localhost:8000
 
 1. [Create a Cosmos DB Database in Azure](https://docs.microsoft.com/en-us/azure/cosmos-db/create-cosmosdb-resources-portal)
 1. Open the project in Visual Studio Code in the DevContainer
-1. Copy `.env.tmpl` in the **core** folder to `.env` and configure the variables
+1. Copy `.env.tmpl` in the **management_api_app** folder to `.env` and configure the variables
 1. Start the web API
 
     ```cmd

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -37,7 +37,7 @@ The API will be available at [https://localhost:8000/api](https://localhost:8000
 1. Start the web API
 
     ```cmd
-    cd core
+    cd management_api_app
     uvicorn main:app --reload
     ```
 
@@ -50,8 +50,8 @@ You must have docker and docker-compose tools installed, and an Azure Cosmos DB 
 Then run:
 
 ```cmd
-cd core
-docker-compose up -d app
+cd management_api_app
+docker compose up -d app
 ```
 
 The API will be available at [https://localhost:8000/api](https://localhost:8000/api) in your browser.

--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -51,6 +51,7 @@ Then run:
 
 ```cmd
 cd management_api_app
+pip install -r requirements.txt
 docker compose up -d app
 ```
 

--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -63,7 +63,7 @@ resource "azurerm_application_gateway" "agw" {
     pick_host_name_from_backend_http_settings = true
     interval                                  = 10
     protocol                                  = "Https"
-    path                                      = "/api/health"
+    path                                      = "/api/ping"
     timeout                                   = 10
     unhealthy_threshold                       = 2
     minimum_servers                           = 0


### PR DESCRIPTION
# PR for issue

## What is being addressed

paths in make_images.sh and documentation are out of sync with the repo structure (core/api moved to management_api_app)

Closes #98 

NOTE: after this, the API is still not getting served - this is being addressed in #100 