### PR TITLE
Add credentials needed for connecting to state store from management api app 

### DIFF
--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -34,7 +34,8 @@ resource "azurerm_app_service" "management_api" {
     "DOCKER_REGISTRY_SERVER_USERNAME" = var.docker_registry_username
     "DOCKER_REGISTRY_SERVER_URL"      = "https://${var.docker_registry_server}"
     "DOCKER_REGISTRY_SERVER_PASSWORD" = var.docker_registry_password
-
+    "STATE_STORE_ENDPOINT"            = var.state_store_endpoint
+    "STATE_STORE_KEY"                 = var.state_store_key
   }
 
   site_config {

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -13,3 +13,6 @@ variable "management_api_image_tag" {}
 variable "docker_registry_server" {}
 variable "docker_registry_username" {}
 variable "docker_registry_password" {}
+variable "state_store_endpoint" {}
+variable "state_store_key" {}
+

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -66,10 +66,11 @@ module "api-webapp" {
   log_analytics_workspace_id      = azurerm_log_analytics_workspace.tre.id
   management_api_image_repository = var.management_api_image_repository
   management_api_image_tag        = var.management_api_image_tag
-  docker_registry_server      = var.docker_registry_server
+  docker_registry_server          = var.docker_registry_server
   docker_registry_username        = var.docker_registry_username
   docker_registry_password        = var.docker_registry_password
-
+  state_store_endpoint            = module.state-store.endpoint
+  state_store_key                 = module.state-store.primary_key
 }
 
 module "keyvault" {

--- a/templates/core/terraform/state-store/output.tf
+++ b/templates/core/terraform/state-store/output.tf
@@ -1,0 +1,7 @@
+output "endpoint" {
+  value = azurerm_cosmosdb_account.tre-db-account.endpoint
+}
+
+output "primary_key" {
+  value = azurerm_cosmosdb_account.tre-db-account.primary_key
+}


### PR DESCRIPTION
# PR for issue 104

## What is being addressed
Management API app needs credentials to cosmos store as env variables to be able to talk to the store

## How is this addressed

Use the output from state store (cosmos) deployment and pipe the values to management api app