### PR TITLE
Configure the appgw backend setting for api to use custom probe

### DIFF
--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -49,6 +49,7 @@ resource "azurerm_application_gateway" "agw" {
     protocol              = "Https"
     request_timeout       = 60
     pick_host_name_from_backend_address = true
+    probe_name            = local.probe_name
   }
 
   http_listener {
@@ -59,7 +60,7 @@ resource "azurerm_application_gateway" "agw" {
   }
 
   probe {
-    name                                      = "management-api"
+    name                                      = local.probe_name
     pick_host_name_from_backend_http_settings = true
     interval                                  = 10
     protocol                                  = "Https"

--- a/templates/core/terraform/appgateway/locals.tf
+++ b/templates/core/terraform/appgateway/locals.tf
@@ -8,4 +8,5 @@ locals {
   listener_name                  = "httplstn-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
   request_routing_rule_name      = "rqrt-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
   redirect_configuration_name    = "rdrcfg-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
+  probe_name                     = "probe-management-api"
 }


### PR DESCRIPTION
# PR for issue #100 

App GW backend http setting configured to use the custom probe

Closes #100 
