### PR TITLE
Expose api docs through app gw

### DIFF
--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -84,7 +84,7 @@ resource "azurerm_application_gateway" "agw" {
 
     path_rule {
       name = "api"
-      paths = ["/api/*"]
+      paths = ["/api/*", "/docs*", "/openapi.json"]
       backend_address_pool_name = local.management_api_backend_address_pool_name
       backend_http_settings_name = local.http_setting_name
     } 


### PR DESCRIPTION
# PR for issue #109 

## What is being addressed

App gateway terraform template updated to include required routes for FastApi OpenApi endpoint (`/docs`) to be served

Closes #109 