### PR TITLE
Add label 'story' to story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -2,7 +2,7 @@
 name: User story
 about: User story with acceptance criteria
 title: ''
-labels: ''
+labels: 'story'
 assignees: ''
 
 ---


### PR DESCRIPTION
# PR for issue

To be able to filter and get a quick overview of the user stories the 'story' label is added to all user stories via the story template