### PR TITLE
Adds the vanilla workspace bundle to ACR

### DIFF
--- a/.github/workflows/tre-CD.yml
+++ b/.github/workflows/tre-CD.yml
@@ -51,7 +51,7 @@ jobs:
           TF_VAR_address_space=${{ env.TF_VAR_address_space }}
           EOF
 
-    - name: Make bootstrap for terraform
+    - name: Make bootstrap for Terraform
       shell: bash
       env:
         AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
@@ -62,3 +62,15 @@ jobs:
           export ARM_TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
 
           make
+
+    - name: Publish vanilla workspace bundle
+      shell: bash
+      env:
+        AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+      run: |
+          export ARM_CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
+          export ARM_CLIENT_SECRET=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientSecret')
+          export ARM_SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
+          export ARM_TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
+
+          make publish-vanilla-workspace

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ mgmt-deploy:
 	echo -e "\n\e[34m»»» 🧩 \e[96mDeploying management infrastructure\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
-	&& cd ./devops/terraform  &&  ./deploy.sh  
+	&& cd ./devops/terraform && ./deploy.sh
 
 mgmt-destroy:
 	echo -e "\n\e[34m»»» 🧩 \e[96mDestroying management infrastructure\e[0m..." \
 	. ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
-	&& cd ./devops/terraform  && ./destroy.sh
+	&& cd ./devops/terraform && ./destroy.sh
 
 build-images:
 	echo -e "\n\e[34m»»» 🧩 \e[96mBuilding Images\e[0m..." \
@@ -39,11 +39,18 @@ tre-deploy:
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
 	&& . ./devops/scripts/load_env.sh ./templates/core/terraform/.env \
-	&& cd ./templates/core/terraform/ && ./deploy.sh 
+	&& cd ./templates/core/terraform/ && ./deploy.sh
 
 tre-destroy:
 	echo -e "\n\e[34m»»» 🧩 \e[96mDestroying TRE\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
 	&& . ./devops/scripts/load_env.sh ./templates/core/terraform/.env \
-	&& cd ./templates/core/terraform/ && ./destroy.sh 
+	&& cd ./templates/core/terraform/ && ./destroy.sh
+
+publish-vanilla-workspace:
+	echo -e "\n\e[34m»»» 🧩 \e[96mPublishing vanilla workspace bundle\e[0m..." \
+	&& . ./devops/scripts/check_dependencies.sh \
+	&& . ./devops/scripts/install_porter.sh \
+	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
+	&& ./devops/scripts/publish_vanilla_workspace.sh

--- a/devops/scripts/install_porter.sh
+++ b/devops/scripts/install_porter.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+# This script is a modified version of https://cdn.porter.sh/latest/install-linux.sh
+#
 # Installs the porter CLI for a single user.
 # PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
 # PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
@@ -23,13 +25,9 @@ cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
 echo Installed `$PORTER_HOME/porter version`
 
 $PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
 $PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
-$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
 
 $PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
 

--- a/devops/scripts/install_porter.sh
+++ b/devops/scripts/install_porter.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Installs the porter CLI for a single user.
+# PORTER_HOME:      Location where Porter is installed (defaults to ~/.porter).
+# PORTER_MIRROR:       Base URL where Porter assets, such as binaries and atom feeds, are downloaded. This lets you
+#                   setup an internal mirror.
+# PORTER_PERMALINK: The version of Porter to install, such as vX.Y.Z, latest or canary.
+# PKG_PERMALINK:    The version of mixins and plugins to install, such as latest or canary.
+
+export PORTER_HOME=${PORTER_HOME:-~/.porter}
+export PORTER_MIRROR=${PORTER_MIRROR:-https://cdn.porter.sh}
+PORTER_PERMALINK=${PORTER_PERMALINK:-v0.38.1}
+PKG_PERMALINK=${PKG_PERMALINK:-latest}
+
+echo "Installing porter@$PORTER_PERMALINK to $PORTER_HOME from $PORTER_MIRROR"
+
+mkdir -p $PORTER_HOME/runtimes
+
+curl -fsSLo $PORTER_HOME/porter $PORTER_MIRROR/$PORTER_PERMALINK/porter-linux-amd64
+chmod +x $PORTER_HOME/porter
+cp $PORTER_HOME/porter $PORTER_HOME/runtimes/porter-runtime
+echo Installed `$PORTER_HOME/porter version`
+
+$PORTER_HOME/porter mixin install exec --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install kubernetes --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install helm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install arm --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install terraform --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install az --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install aws --version $PKG_PERMALINK
+$PORTER_HOME/porter mixin install gcloud --version $PKG_PERMALINK
+
+$PORTER_HOME/porter plugin install azure --version $PKG_PERMALINK
+
+export PATH=$PATH:~/.porter
+
+echo "Installation complete."

--- a/devops/scripts/publish_vanilla_workspace.sh
+++ b/devops/scripts/publish_vanilla_workspace.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+ACR_NAME="${TF_VAR_resource_name_prefix}acr"
+az acr login --name $ACR_NAME
+porter publish --dir ./workspaces/vanilla/ --file ./workspaces/vanilla/porter.yaml --registry "$ACR_NAME.azurecr.io/microsoft/azuretre/workspaces" --debug


### PR DESCRIPTION
## What is being addressed

Adds the DevOps implementation to publish the vanilla workspace bundle to ACR.

## How is this addressed

- The bundle shares the ACR with the management API
- Adds a `publish-vanilla-workspace` step in `Makefile` that in turn uses the newly added scripts:
  - `/devops/scripts/install_porter.sh`: Installs and sets up Porter for the workflow
  - `/devops/scripts/publish_vanilla_workspace.sh`: Authorizes Porter to publish the workspace bundle to the ACR
