### PR TITLE
Improvements to Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,15 +9,11 @@ ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# Install requirements
-COPY requirements.txt /tmp/pip-tmp/
-RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp
-
 # Install terraform
-RUN apt-get update &&  apt-get install -y gnupg software-properties-common curl \
+RUN apt-get update && apt-get install -y gnupg software-properties-common curl \
     && curl -fsSL https://apt.releases.hashicorp.com/gpg |  apt-key add - \
     && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
-    && apt-get update &&  apt-get install -y terraform 
+    && apt-get update && apt-get install -y terraform 
 
 # Install Azure CLI
 RUN apt-get update \
@@ -27,8 +23,11 @@ RUN apt-get update \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list \
     && apt-get update && apt-get -y install azure-cli 
 
+# Make sure docker group id matches that on WSL.
+RUN groupadd --gid 1001 docker
+
 # Install Docker
- RUN apt-get update &&  sudo apt-get install -y  apt-transport-https ca-certificates curl gnupg  lsb-release \
+RUN apt-get update &&  sudo apt-get install -y  apt-transport-https ca-certificates curl gnupg  lsb-release \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null \
@@ -42,3 +41,11 @@ RUN apt-get install -y python3 python3-venv libaugeas0 \
     && python3 -m venv /opt/certbot/ \
     && /opt/certbot/bin/pip install --upgrade pip \
     && /opt/certbot/bin/pip install certbot
+
+# Install requirements
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp
+
+RUN usermod -a -G docker vscode
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,13 @@
 	"extensions": ["ms-python.python", "hashicorp.terraform", "github.vscode-pull-request-github"],
 	"forwardPorts": [],
 	"runArgs": [
-        // Keep command history 
-        "-v", "load-tests-bashhistory:/home/vscode/commandhistory",
-        // Mount docker socket for docker builds
-        "-v", "/var/run/docker.sock:/var/run/docker.sock"
+		"--name", "tre"
+	],
+	// If .bash_history file doesn't exist, docker will create it as root and the vscode user won't have permission, so we need to create it first.
+	"initializeCommand": "touch .bash_history",
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+		"source=${localEnv:HOME}/.azure,target=/home/vscode/.azure,type=bind,consistency=cached",
+		"source=${localWorkspaceFolder}/.bash_history,target=/home/vscode/.bash_history,type=bind"
 	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ sample.dat
 
 # CNAB
 .cnab/
+
+# Dev container shell history
+.bash_history


### PR DESCRIPTION
This PR just contains a few changes to the Dev Container configuration that I found helpful working with it.

 * The container now mounts the ~/.azure directory, so that it uses the same Azure CLI profile that is configured on the host. (means you don't have to keep doing an `az login --use-device-code`.
 * The container mounts the bash history file from the host, so command history is preserved and specific to the project.
 * The Dev container now runs as the __vscode__ user, not __root__.
   - When using WSL this mean that new files are not created as root, so you still have access when outside the container.
   - It's also good practice not to develop as root.
  * The `pip install requirements.txt` is moved to the end of the Docker file so that changes to __requirements.txt__ doesn't cause all the `apt install`s to run again.
  * The running container is named `tre`. This is a bit of a personal preference and does have a trade-off.
    - The benefit is it make it easy to set up a profile in Window Terminal to run `docker exec -it tre bash` so you can have dev container shell outside VS Code.
    - The slight downside is the fixed name means you can only have one instance of the dev container running.