### PR TITLE
Initial deployment fails with error

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,14 +92,14 @@ Copy [/templates/core/terraform/.env.sample](../templates/core/terraform/.env.sa
 ### Deploy
 
 The deployment of the Azure TRE is done via Terraform. Run:
-```
+```bash
 make tre-deploy
 ```
 
-The Azure TRE is initially deployed with an invalid self-signed SSL certificate. This certificate is stored in the deployed KeyVault. To update 
-the certificate in KeyVault needs to be repaced with one valid for the configured domain name. To use a certificate from [Let's Encrypt][letsencrypt], 
+The Azure TRE is initially deployed with an invalid self-signed SSL certificate. This certificate is stored in the deployed KeyVault. To update
+the certificate in KeyVault needs to be repaced with one valid for the configured domain name. To use a certificate from [Let's Encrypt][letsencrypt],
 simply run the command:
-```
+```bash
 make letsencrypt
 ```
 Note that there are rate limits with Let's Encrypt, so this should not be run when not needed.

--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -184,6 +184,7 @@ resource "azurerm_application_gateway" "agw" {
 }
 
 data "azurerm_public_ip" "appgwpip_data" {
+  depends_on            = [azurerm_application_gateway.agw]
   name                  = "pip-agw-${var.resource_name_prefix}-${var.environment}-${var.tre_id}"
   resource_group_name   = var.resource_group_name
 }

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -62,6 +62,7 @@ module "appgateway" {
   app_gw_subnet        = module.network.app_gw
   management_api_fqdn  = module.api-webapp.management_api_fqdn
   keyvault_id          = module.keyvault.keyvault_id
+  depends_on           = [module.keyvault] 
 }
 
 module "api-webapp" {


### PR DESCRIPTION
# PR for issue #94

## What is being addressed

Dependencies added to appgateway data block and appgateway module.
 
## How is this addressed

Without the keyvault module dependency following error happens:

**Error**: checking for presence of existing Certificate "letsencrypt" in https://...: keyvault.BaseClient#GetCertificate: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="The user, group or application 'appid=...;numgroups=94;iss=...' does not have certificates get permission on key vault '...'. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125287" InnerError={"code":"AccessDenied"}
│ 
│   with module.appgateway.azurerm_key_vault_certificate.tlscert,
│   on appgateway/certificate.tf line 15, in resource "azurerm_key_vault_certificate" "tlscert":
│   15: resource "azurerm_key_vault_certificate" "tlscert" {
│ 