### PR TITLE
Harmonizes the vanilla workspace bundle and docs

### DIFF
--- a/docs/authoring-workspaces.md
+++ b/docs/authoring-workspaces.md
@@ -28,8 +28,8 @@ The credentials are provided as environment variables by the deployment runner. 
 
 * `AZURE_TENANT_ID`
 * `AZURE_SUBSCRIPTION_ID`
-* `AZURE_SP_CLIENT_ID`
-* `AZURE_SP_PASSWORD`
+* `AZURE_CLIENT_ID`
+* `AZURE_CLIENT_SECRET`
 
 The names of the Porter credentials (`name` field in `porter.yaml`) can be freely chosen by the author.
 
@@ -37,14 +37,14 @@ Example:
 
 ```yaml
 credentials:
-- name: azure_tenant_id
-  env: AZURE_TENANT_ID
-- name: azure_subscription_id
-  env: AZURE_SUBSCRIPTION_ID
-- name: azure_service_principal_client_id
-  env: AZURE_SP_CLIENT_ID
-- name: azure_service_principal_password
-  env: AZURE_SP_PASSWORD
+  - name: azure_tenant_id
+    env: AZURE_TENANT_ID
+  - name: azure_subscription_id
+    env: AZURE_SUBSCRIPTION_ID
+  - name: azure_service_principal_client_id
+    env: AZURE_CLIENT_ID
+  - name: azure_service_principal_password
+    env: AZURE_CLIENT_SECRET
 ```
 
 ### Parameters

--- a/workspaces/vanilla/README.md
+++ b/workspaces/vanilla/README.md
@@ -17,8 +17,8 @@
 
     * `AZURE_TENANT_ID`
     * `AZURE_SUBSCRIPTION_ID`
-    * `AZURE_SP_CLIENT_ID` - Service principal client ID
-    * `AZURE_SP_PASSWORD` - Service principal client password
+    * `AZURE_CLIENT_ID` - Service principal client ID
+    * `AZURE_CLIENT_SECRET` - Service principal client secret (password)
 
 1. Create credentials set named "azure":
 

--- a/workspaces/vanilla/porter.yaml
+++ b/workspaces/vanilla/porter.yaml
@@ -4,23 +4,19 @@ description: "A vanilla Azure TRE workspace"
 registry: azuretre
 
 credentials:
-- name: azure_tenant_id
-  env: AZURE_TENANT_ID
-- name: azure_subscription_id
-  env: AZURE_SUBSCRIPTION_ID
-- name: azure_service_principal_client_id
-  env: AZURE_SP_CLIENT_ID
-- name: azure_service_principal_password
-  env: AZURE_SP_PASSWORD
+  - name: azure_tenant_id
+    env: AZURE_TENANT_ID
+  - name: azure_subscription_id
+    env: AZURE_SUBSCRIPTION_ID
+  - name: azure_service_principal_client_id
+    env: AZURE_CLIENT_ID
+  - name: azure_service_principal_password
+    env: AZURE_CLIENT_SECRET
 
 parameters:
   - name: core_id
     type: string
-    description: "Unique 4-digit TRE core ID"
-  - name: core_name
-    type: string
-    description: "TRE core name prefix with environment identifier"
-    default: "tre-dev"
+    description: "The ID of the parent TRE instance e.g., mytre-dev-3142"
   - name: workspace_id
     type: string
     description: "Unique 4-digit workspace ID"
@@ -65,7 +61,6 @@ install:
         azure_service_principal_client_id: "{{ bundle.credentials.azure_service_principal_client_id }}"
         azure_service_principal_password: "{{ bundle.credentials.azure_service_principal_password }}"
         core_id: "{{ bundle.parameters.core_id }}"
-        core_name: "{{ bundle.parameters.core_name }}"
         workspace_id: "{{ bundle.parameters.workspace_id }}"
         location: "{{ bundle.parameters.location }}"
         address_space: "{{ bundle.parameters.address_space }}"
@@ -93,7 +88,6 @@ plan:
           - "'azure_service_principal_client_id={{ bundle.credentials.azure_service_principal_client_id }}'"
           - "'azure_service_principal_password={{ bundle.credentials.azure_service_principal_password }}'"
           - "'core_id={{ bundle.parameters.core_id }}'"
-          - "'core_name={{ bundle.parameters.core_name }}'"
           - "'workspace_id={{ bundle.parameters.workspace_id }}'"
           - "'location={{ bundle.parameters.location }}'"
           - "'address_space={{ bundle.parameters.address_space }}'"
@@ -107,7 +101,6 @@ uninstall:
         azure_service_principal_client_id: "{{ bundle.credentials.azure_service_principal_client_id }}"
         azure_service_principal_password: "{{ bundle.credentials.azure_service_principal_password }}"
         core_id: "{{ bundle.parameters.core_id }}"
-        core_name: "{{ bundle.parameters.core_name }}"
         workspace_id: "{{ bundle.parameters.workspace_id }}"
         location: "{{ bundle.parameters.location }}"
         address_space: "{{ bundle.parameters.address_space }}"

--- a/workspaces/vanilla/terraform/locals.tf
+++ b/workspaces/vanilla/terraform/locals.tf
@@ -9,7 +9,6 @@ resource "random_string" "unique_id" {
 }
 
 locals {
-  core_name_and_id          = "${var.core_name}-${var.core_id}"
-  core_vnet                 = "vnet-${var.core_name}-${var.core_id}"
-  core_resource_group_name  = "rg-${var.core_name}-${var.core_id}"
+  core_vnet                 = "vnet-${var.core_id}"
+  core_resource_group_name  = "rg-${var.core_id}"
 }

--- a/workspaces/vanilla/terraform/main.tf
+++ b/workspaces/vanilla/terraform/main.tf
@@ -19,10 +19,10 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "ws" {
   location = var.location
-  name     = "rg-${local.core_name_and_id}-ws-${var.workspace_id}"
+  name     = "rg-${var.core_id}-ws-${var.workspace_id}"
   tags     = {
     project = "Azure Trusted Research Environment"
-    core_id = local.core_name_and_id
+    core_id = var.core_id
     source  = "https://github.com/microsoft/AzureTRE/"
   }
 }
@@ -30,7 +30,7 @@ resource "azurerm_resource_group" "ws" {
 module "network" {
   source                   = "./network"
   workspace_id             = var.workspace_id
-  core_name_and_id         = local.core_name_and_id
+  core_id                  = var.core_id
   location                 = var.location
   resource_group_name      = azurerm_resource_group.ws.name
   address_space            = var.address_space

--- a/workspaces/vanilla/terraform/network/network.tf
+++ b/workspaces/vanilla/terraform/network/network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "ws" {
-  name                = "vnet-${var.core_name_and_id}-ws-${var.workspace_id}"
+  name                = "vnet-${var.core_id}-ws-${var.workspace_id}"
   location            = var.location
   resource_group_name = var.resource_group_name
   address_space       = [var.address_space]
@@ -21,14 +21,14 @@ data "azurerm_virtual_network" "core" {
 }
 
 resource "azurerm_virtual_network_peering" "ws-core-peer" {
-  name                      = "ws-core-peer-${var.core_name_and_id}-ws-${var.workspace_id}"
+  name                      = "ws-core-peer-${var.core_id}-ws-${var.workspace_id}"
   resource_group_name       = var.resource_group_name
   virtual_network_name      = azurerm_virtual_network.ws.name
   remote_virtual_network_id = data.azurerm_virtual_network.core.id
 }
 
 resource "azurerm_virtual_network_peering" "core-ws-peer" {
-  name                      = "core-ws-peer-${var.core_name_and_id}-ws-${var.workspace_id}"
+  name                      = "core-ws-peer-${var.core_id}-ws-${var.workspace_id}"
   resource_group_name       = var.core_resource_group_name
   virtual_network_name      = var.core_vnet
   remote_virtual_network_id = azurerm_virtual_network.ws.id
@@ -164,7 +164,7 @@ resource "azurerm_network_security_rule" "allow-inbound-from-bastion" {
 }
 
 data "azurerm_route_table" "rt" {
-  name                = "rt-${var.core_name_and_id}"
+  name                = "rt-${var.core_id}"
   resource_group_name = var.core_resource_group_name
 }
 

--- a/workspaces/vanilla/terraform/network/variables.tf
+++ b/workspaces/vanilla/terraform/network/variables.tf
@@ -1,4 +1,4 @@
-variable "core_name_and_id" {}
+variable "core_id" {}
 variable "workspace_id" {}
 variable "location" {}
 variable "resource_group_name" {}

--- a/workspaces/vanilla/terraform/variables.tf
+++ b/workspaces/vanilla/terraform/variables.tf
@@ -19,12 +19,6 @@ variable "core_id" {
   description = "Unique 4-digit TRE core ID"
 }
 
-variable "core_name" {
-  type = string
-  description = "TRE core name prefix with environment identifier"
-  default = "tre-dev"
-}
-
 variable "workspace_id" {
   type        = string
   description = "Unique 4-digit workspace ID"


### PR DESCRIPTION
Fixes #131 

## What is being addressed

Corrects the convention/misalignment issues with the vanilla workspace and the relevant documentation.

## How is this addressed

- Environment variable convention of the credentials fixed:
    - `AZURE_SP_CLIENT_ID` -> `AZURE_CLIENT_ID`
    - `AZURE_SP_PASSWORD` -> `AZURE_CLIENT_SECRET`
    - These are fixed in `/workspaces/vanilla/porter.yaml`, `/workspaces/vanilla/README.md`, and in `/docs/authoring-workspaces.md`
- `core_id` and `core_name` combined into one `core_id`
    - Fixed in `/workspaces/vanilla/porter.yaml`, `/workspaces/vanilla/README.md`, and the Terraform files
