### PR TITLE
Adds all traffic vnet route for website

### DIFF
--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -36,6 +36,7 @@ resource "azurerm_app_service" "management_api" {
     "DOCKER_REGISTRY_SERVER_PASSWORD" = var.docker_registry_password
     "STATE_STORE_ENDPOINT"            = var.state_store_endpoint
     "STATE_STORE_KEY"                 = var.state_store_key
+    "WEBSITE_VNET_ROUTE_ALL"          = 1
   }
 
   site_config {


### PR DESCRIPTION
# Adds all traffic vnet route for website

## What is being addressed

API needs to route all traffic through VNET in order to reach internal resources (e.g cosmos)

## How is this addressed

- adds WEBSITE_VNET_ROUTE_ALL to config

Closing #152 
