### PR TITLE
DB error handling in one location

### DIFF
--- a/management_api_app/api/dependencies/workspaces.py
+++ b/management_api_app/api/dependencies/workspaces.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, HTTPException, Path
+from pydantic import UUID4
 from starlette.status import HTTP_404_NOT_FOUND
 
 from db.errors import EntityDoesNotExist
@@ -8,7 +9,7 @@ from models.domain.resource import Resource
 from resources import strings
 
 
-async def get_workspace_by_workspace_id_from_path(workspace_id: str = Path(..., min_length=1), workspaces_repo: WorkspaceRepository = Depends(get_repository(WorkspaceRepository))) -> Resource:
+async def get_workspace_by_workspace_id_from_path(workspace_id: UUID4 = Path(...), workspaces_repo: WorkspaceRepository = Depends(get_repository(WorkspaceRepository))) -> Resource:
     try:
         return workspaces_repo.get_workspace_by_workspace_id(workspace_id)
     except EntityDoesNotExist:

--- a/management_api_app/api/routes/workspaces.py
+++ b/management_api_app/api/routes/workspaces.py
@@ -1,8 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from starlette import status
 
 from api.dependencies.workspaces import get_repository, get_workspace_by_workspace_id_from_path
-from db.errors import UnableToAccessDatabase
 from db.repositories.workspaces import WorkspaceRepository
 from models.domain.resource import Resource
 from models.schemas.resource import ResourcesInList, ResourceInResponse, ResourceInCreate
@@ -14,20 +13,14 @@ router = APIRouter()
 
 @router.get("/workspaces", response_model=ResourcesInList, name=strings.API_GET_ALL_WORKSPACES)
 async def retrieve_active_workspaces(workspace_repo: WorkspaceRepository = Depends(get_repository(WorkspaceRepository))) -> ResourcesInList:
-    try:
-        workspaces = workspace_repo.get_all_active_workspaces()
-        return ResourcesInList(resources=workspaces)
-    except UnableToAccessDatabase:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=strings.STATE_STORE_ENDPOINT_NOT_RESPONDING)
+    workspaces = workspace_repo.get_all_active_workspaces()
+    return ResourcesInList(resources=workspaces)
 
 
 @router.post("/workspaces", status_code=status.HTTP_202_ACCEPTED, response_model=ResourceInResponse, name=strings.API_CREATE_WORKSPACE)
 async def create_workspace(workspace_create: ResourceInCreate, workspace_repo: WorkspaceRepository = Depends(get_repository(WorkspaceRepository))) -> ResourceInResponse:
-    try:
-        workspace = workspace_repo.create_workspace(workspace_create)
-        return ResourceInResponse(resource=workspace)
-    except UnableToAccessDatabase:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=strings.STATE_STORE_ENDPOINT_NOT_RESPONDING)
+    workspace = workspace_repo.create_workspace(workspace_create)
+    return ResourceInResponse(resource=workspace)
 
 
 @router.get("/workspaces/{workspace_id}", response_model=ResourceInResponse, name=strings.API_GET_WORKSPACE_BY_ID)

--- a/management_api_app/db/repositories/base.py
+++ b/management_api_app/db/repositories/base.py
@@ -5,7 +5,7 @@ from db.errors import UnableToAccessDatabase
 
 
 class BaseRepository:
-    def __init__(self, client: CosmosClient, container_name: str) -> None:
+    def __init__(self, client: CosmosClient, container_name: str = None) -> None:
         self._client: CosmosClient = client
         self._container: ContainerProxy = self.get_container(container_name)
 

--- a/management_api_app/db/repositories/workspaces.py
+++ b/management_api_app/db/repositories/workspaces.py
@@ -2,9 +2,10 @@ import uuid
 from typing import List
 
 from azure.cosmos import ContainerProxy, CosmosClient
+from pydantic import UUID4
 
 from core.config import STATE_STORE_RESOURCES_CONTAINER
-from db.errors import EntityDoesNotExist, UnableToAccessDatabase
+from db.errors import EntityDoesNotExist
 from db.repositories.base import BaseRepository
 from models.domain.resource import Resource, ResourceSpec, ResourceType, Status
 from models.schemas.resource import ResourceInCreate
@@ -20,24 +21,18 @@ class WorkspaceRepository(BaseRepository):
         return self._container
 
     def get_all_active_workspaces(self) -> List[Resource]:
-        try:
-            query = f'SELECT * from c ' \
-                    f'WHERE c.resourceType = "{strings.RESOURCE_TYPE_WORKSPACE}" ' \
-                    f'AND c.isDeleted = false'
-            workspaces = list(self.container.query_items(query=query, enable_cross_partition_query=True))
-            return workspaces
-        except Exception:
-            raise UnableToAccessDatabase
+        query = f'SELECT * from c ' \
+                f'WHERE c.resourceType = "{strings.RESOURCE_TYPE_WORKSPACE}" ' \
+                f'AND c.isDeleted = false'
+        workspaces = list(self.container.query_items(query=query, enable_cross_partition_query=True))
+        return workspaces
 
-    def get_workspace_by_workspace_id(self, workspace_id: str) -> Resource:
-        try:
-            query = f'SELECT * from c ' \
-                    f'WHERE c.resourceType = "{strings.RESOURCE_TYPE_WORKSPACE}" ' \
-                    f'AND c.isDeleted = false ' \
-                    f'AND c.id = "{workspace_id}"'
-            workspaces = list(self.container.query_items(query=query, enable_cross_partition_query=True))
-        except Exception:
-            raise UnableToAccessDatabase
+    def get_workspace_by_workspace_id(self, workspace_id: UUID4) -> Resource:
+        query = f'SELECT * from c ' \
+                f'WHERE c.resourceType = "{strings.RESOURCE_TYPE_WORKSPACE}" ' \
+                f'AND c.isDeleted = false ' \
+                f'AND c.id = "{workspace_id}"'
+        workspaces = list(self.container.query_items(query=query, enable_cross_partition_query=True))
 
         if workspaces:
             return workspaces[0]
@@ -45,15 +40,12 @@ class WorkspaceRepository(BaseRepository):
             raise EntityDoesNotExist
 
     def create_workspace(self, workspace_create: ResourceInCreate) -> Resource:
-        try:
-            workspace = Resource(
-                id=str(uuid.uuid4()),
-                resourceSpec=ResourceSpec(name=workspace_create.resourceSpec.name, version=workspace_create.resourceSpec.version),
-                parameters=workspace_create.parameters,
-                resourceType=ResourceType.Workspace,
-                status=Status.NotDeployed
-            )
-            self.container.create_item(body=workspace.dict())
-            return workspace
-        except Exception:
-            raise UnableToAccessDatabase
+        workspace = Resource(
+            id=str(uuid.uuid4()),
+            resourceSpec=ResourceSpec(name=workspace_create.resourceSpec.name, version=workspace_create.resourceSpec.version),
+            parameters=workspace_create.parameters,
+            resourceType=ResourceType.Workspace,
+            status=Status.NotDeployed
+        )
+        self.container.create_item(body=workspace.dict())
+        return workspace

--- a/management_api_app/models/domain/resource.py
+++ b/management_api_app/models/domain/resource.py
@@ -1,4 +1,5 @@
 from enum import Enum
+
 from models.domain.azuretremodel import AzureTREModel
 from resources import strings
 

--- a/management_api_app/models/schemas/resource.py
+++ b/management_api_app/models/schemas/resource.py
@@ -15,3 +15,19 @@ class ResourcesInList(BaseModel):
 class ResourceInCreate(BaseModel):
     resourceSpec: ResourceSpec
     parameters: dict
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "resourceSpec": {
+                    "name": "tre-workspace-vanilla",
+                    "version": "0.1.0"
+                },
+                "parameters": {
+                    "core_id": "mytre-dev-3142",
+                    "workspace_id": "2718",
+                    "location": "westeurope",
+                    "address_space": "10.2.1.0/24",
+                }
+            }
+        }

--- a/management_api_app/tests/test_api/test_routes/test_workspaces.py
+++ b/management_api_app/tests/test_api/test_routes/test_workspaces.py
@@ -64,8 +64,17 @@ async def test_workspaces_get_list_returns_correct_data_when_resources_exist(get
 async def test_workspaces_id_get_returns_404_if_resource_is_not_found(get_workspace_mock, app: FastAPI, client: AsyncClient):
     get_workspace_mock.side_effect = EntityDoesNotExist
 
-    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id="not_important"))
+    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id="000000d3-82da-4bfc-b6e9-9a7853ef753e"))
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+# [GET] /workspaces/{workspace_id}
+@patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+async def test_workspaces_id_get_returns_422_if_workspace_id_is_not_a_uuid(get_workspace_mock, app: FastAPI, client: AsyncClient):
+    get_workspace_mock.side_effect = EntityDoesNotExist
+
+    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id="not_valid"))
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
@@ -85,6 +94,6 @@ async def test_workspaces_id_get_returns_workspace_if_found(get_workspace_mock, 
     }
     get_workspace_mock.return_value = sample_workspace
 
-    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id="not important"))
+    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id="afa000d3-82da-4bfc-b6e9-9a7853ef753e"))
     actual_resource = response.json()["resource"]
     assert actual_resource["id"] == sample_workspace["id"]


### PR DESCRIPTION
# PR for issue #145 

## What is being addressed

- Moves DB error handling to a common location
- Adds a sample schema to post so that POST /workspaces is easy to do with Swagger
- Adds UUID validation on the GET /workspace/{workspace_id}

## How is this addressed

- The dependency get_repository() throws a HTTPException 503 if repo is not found
- Sample is added to the ResourceInCreate Schema Model
- workspace_id stored as UUID in pydantic model
- test to test UUID validation

Closes #145 

NOTE: Initial suggestion was to move the database validation to a middleware, but this is already handled by the injected dependency, so in reality I just removed the unnecessary error checks in each function 