### PR TITLE
Add certbot pre-req check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ build-cnab-image:
 
 push-api-image:
 	echo -e "\n\e[34m»»» 🧩 \e[96mPushing Images\e[0m..." \
-	. ./devops/scripts/check_dependencies.sh \
+	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
 	&& ./devops/scripts/push_images.sh api
 
 push-cnab-image:
 	echo -e "\n\e[34m»»» 🧩 \e[96mPushing Images\e[0m..." \
-	. ./devops/scripts/check_dependencies.sh \
+	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/terraform/.env \
 	&& ./devops/scripts/push_images.sh cnab
 
@@ -55,6 +55,7 @@ tre-deploy:
 
 letsencrypt:
 	echo -e "\n\e[34m»»» 🧩 \e[96mRequesting LetsEncrypt SSL certificate\e[0m..." \
+	&& . ./devops/scripts/check_dependencies.sh nodocker,certbot \
 	&& chmod 755 ./devops/scripts/letsencrypt.sh ./devops/scripts/auth-hook.sh ./devops/scripts/cleanup-hook.sh \
 	&& . ./devops/scripts/get-coreenv.sh \
 	&& ./devops/scripts/letsencrypt.sh

--- a/devops/scripts/check_dependencies.sh
+++ b/devops/scripts/check_dependencies.sh
@@ -14,11 +14,16 @@ if [ $? -ne 0 ]; then
 fi
 
 docker version > /dev/null 2>&1
-if [ $? -ne 0 ] && [ "$1" != "nodocker" ]; then
+if [ $? -ne 0 ] && [[ "$1" != *"nodocker"* ]]; then
   echo -e "\e[31m»»» ⚠️ Docker is not installed! 😥 Please go to https://docs.docker.com/engine/install/ to set it up"
   exit
 fi
 
+/opt/certbot/bin/certbot --version > /dev/null 2>&1
+if [ $? -ne 0 ] && [[ "$1" == *"certbot"* ]]; then
+  echo -e "\e[31m»»» ⚠️ Certbot is not installed! 😥 Please go to https://certbot.eff.org/lets-encrypt/pip-other to set it up"
+  exit
+fi
 
 export SUB_NAME=$(az account show --query name -o tsv)
 export SUB_ID=$(az account show --query id -o tsv)


### PR DESCRIPTION
# PR for issue #143

## What is being addressed

Adds check for certbot being installed

## How is this addressed

- add check for certbot if `certbot` is in first argument
- make `nodocker` checks search the string