### PR TITLE
Add VNET delegated subnet to vanilla workspace

### DIFF
--- a/workspaces/vanilla/terraform/network/locals.tf
+++ b/workspaces/vanilla/terraform/network/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  ws_services_vnet_subnets            = cidrsubnets(var.address_space, 4)
-  services_subnet_address_prefix      = local.ws_services_vnet_subnets[0]
+  ws_services_vnet_subnets       = cidrsubnets(var.address_space, 1, 1)
+  services_subnet_address_prefix = local.ws_services_vnet_subnets[0]
+  webapps_subnet_address_prefix  = local.ws_services_vnet_subnets[1]
 }

--- a/workspaces/vanilla/terraform/network/network.tf
+++ b/workspaces/vanilla/terraform/network/network.tf
@@ -15,6 +15,24 @@ resource "azurerm_subnet" "services" {
   enforce_private_link_endpoint_network_policies = true
 }
 
+resource "azurerm_subnet" "webapps" {
+  name                 = "WebAppsSubnet"
+  virtual_network_name = azurerm_virtual_network.ws.name
+  resource_group_name  = var.resource_group_name
+  address_prefixes     = [local.webapps_subnet_address_prefix]
+  # notice that private endpoints do not adhere to NSG rules
+  enforce_private_link_endpoint_network_policies = true
+
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
 data "azurerm_virtual_network" "core" {
   name                = var.core_vnet
   resource_group_name = var.core_resource_group_name


### PR DESCRIPTION
# PR for issue #132

## What is being addressed

To deploy inner eye inference service need a subnet that is delegated to web apps. I have added this to vanilla workspace as it is a very common requirement - was on the initial diagrams - and does not cost anything.

## How is this addressed

- Added delegeted subnet
- Enlarged subnet address spaces
