### PR TITLE
Corrected the quickstart to match scripts.

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,7 +84,7 @@ Build and push the docker images required by the Azure TRE and publish them to t
 make build-api-image
 make build-cnab-image
 make push-api-image
-push-cnab-image
+make push-cnab-image
 ```
 
 ## Deploy an Azure TRE instance

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,8 @@ The Azure TRE uses Terraform infrastructure as code templates that pull down Doc
 
 The most straightforward way to get up and running is to deploy direct from the `microsoft/AzureTRE` repository. Production deployments should take advantage of your chosen DevOps CD tooling.
 
+> The quickstart assumes usage of Linux or WSL on Windows.
+
 ## Prerequisites
 
 You will require the following prerequisites installed. They will already be present if using GitHub Codespaces, or use our Dev Container in VS Code.
@@ -49,7 +51,7 @@ Copy [/devops/terraform/.env.sample](../devops/terraform/.env.sample) to `/devop
 - `TF_VAR_mgmt_res_group` - The shared resource group for all management resources, including the storage account.
 - `TF_VAR_state_container` - Name of the blob container to hold Terraform state (default: `tfstate`).
 - `TF_VAR_location` - Azure region to deploy all resources into.
-- `TF_VAR_image_tag` - Default tag for docker images that will be pushed to the container registry and deployed with the Azure TRE
+- `TF_VAR_image_tag` - Default tag for docker images that will be pushed to the container registry and deployed with the Azure TRE.
 - `TF_VAR_acr_name` - Globally unique name for the ACR that will be create to store deployment images.
 
 ### Bootstrap of back-end state
@@ -76,10 +78,14 @@ This Terraform creates & configures the following:
 
 ### Build and push docker images
 
-Build and push the docker images required by the Azure TRE and publish them to the container registry created in the previous step:
+Build and push the docker images required by the Azure TRE and publish them to the container registry created in the previous step. Run the following commands in bash:
 
-- From bash run `make build-images`
-- From bash run `make push-images`
+```bash
+make build-api-image
+make build-cnab-image
+make push-api-image
+push-cnab-image
+```
 
 ## Deploy an Azure TRE instance
 

--- a/templates/core/terraform/.env.sample
+++ b/templates/core/terraform/.env.sample
@@ -1,3 +1,3 @@
 #  Used for TRE deployment
 TF_VAR_address_space="10.1.0.0/16"
-TF_VAR_acr_name=__CHANGE_ME__
+TF_VAR_tre_id=__CHANGE_ME__


### PR DESCRIPTION
# PR for issue #178

## What is being addressed

The quickstart tutorial did not match the scripts.

## How is this addressed

- Specified that bash on Linux or WSL is required
- Changed the scripts to be executed
- Updated the sample .env files to match the documentation
