### PR TITLE
get current workspace template by name

### DIFF
--- a/management_api_app/api/routes/workspace_templates.py
+++ b/management_api_app/api/routes/workspace_templates.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter, Depends
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from starlette import status
 
 from api.dependencies.database import get_repository
+from db.errors import EntityDoesNotExist
 from db.repositories.workspace_templates import WorkspaceTemplateRepository
-from models.schemas.workspace_template import WorkspaceTemplateNamesInList
+from models.schemas.workspace_template import WorkspaceTemplateNamesInList, WorkspaceTemplateInResponse
 from resources import strings
 
 
@@ -13,3 +17,15 @@ router = APIRouter()
 async def get_workspace_templates(workspace_template_repo: WorkspaceTemplateRepository = Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateNamesInList:
     workspace_template_names = workspace_template_repo.get_workspace_template_names()
     return WorkspaceTemplateNamesInList(templateNames=workspace_template_names)
+
+
+@router.get("/workspace-templates/{template_name}", response_model=WorkspaceTemplateInResponse, name=strings.API_GET_WORKSPACE_TEMPLATE_BY_NAME)
+async def get_current_workspace_template_by_name(template_name: str, workspace_template_repo: WorkspaceTemplateRepository = Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateInResponse:
+    try:
+        template = workspace_template_repo.get_current_workspace_template_by_name(template_name)
+        return WorkspaceTemplateInResponse(workspaceTemplate=template)
+    except EntityDoesNotExist:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.WORKSPACE_TEMPLATE_DOES_NOT_EXIST)
+    except Exception as e:
+        logging.debug(e)
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=strings.STATE_STORE_ENDPOINT_NOT_RESPONDING)

--- a/management_api_app/db/bootstrapping_data/resource_templates.json
+++ b/management_api_app/db/bootstrapping_data/resource_templates.json
@@ -5,7 +5,7 @@
       "name": "tre-workspace-vanilla",
       "description": "vanilla workspace bundle",
       "version": "0.1.0", 
-      "properties": [
+      "parameters": [
         {
           "name": "location",
           "type": "string"

--- a/management_api_app/models/domain/resource_template.py
+++ b/management_api_app/models/domain/resource_template.py
@@ -1,22 +1,25 @@
 from typing import List, Optional, Any
 
+from pydantic import Field
+
 from models.domain.azuretremodel import AzureTREModel
 from models.domain.resource import ResourceType
 
 
 class Parameter(AzureTREModel):
-    name: str
-    type: str
-    default: Any
-    applyTo: str = "All Actions"
-    description: Optional[str]
-    required: bool = False
+    name: str = Field(title="Parameter name")
+    type: str = Field(title="Parameter type")
+    default: Any = Field(title="Default value for the parameter")
+    applyTo: str = Field("All Actions", title="The actions that the parameter applies to e.g. install, delete etc")
+    description: Optional[str] = Field(title="Parameter description")
+    required: bool = Field(False, title="Is the parameter required")
 
 
 class ResourceTemplate(AzureTREModel):
-    name: str
-    description: str
-    version: str
-    parameters: List[Parameter]
-    resourceType: ResourceType
-    current: bool
+    id: str
+    name: str = Field(title="Unique template name")
+    description: str = Field(title="Template description")
+    version: str = Field(title="Template version")
+    parameters: List[Parameter] = Field(title="Template parameters")
+    resourceType: ResourceType = Field(title="Type of resource this template is for (workspace/service)")
+    current: bool = Field(title="Is this the current version of this template")

--- a/management_api_app/models/schemas/workspace_template.py
+++ b/management_api_app/models/schemas/workspace_template.py
@@ -1,6 +1,30 @@
 from typing import List
 from pydantic import BaseModel
 
+from models.domain.resource import ResourceType
+from models.domain.resource_template import ResourceTemplate, Parameter
+
+
+def get_sample_workspace_template_object(template_name: str = "tre-workspace-vanilla") -> ResourceTemplate:
+    return ResourceTemplate(
+        id="a7a7a7bd-7f4e-4a4e-b970-dc86a6b31dfb",
+        name=template_name,
+        description="vanilla workspace bundle",
+        version="0.1.0",
+        parameters=[
+            Parameter(name="location", type="string"),
+            Parameter(name="tre_id", type="string"),
+            Parameter(name="workspace_id", type="string"),
+            Parameter(name="address_space", type="string", default="10.2.1.0/24", description="VNet address space for the workspace services")
+        ],
+        resourceType=ResourceType.Workspace,
+        current=True,
+    )
+
+
+def get_sample_workspace_template() -> dict:
+    return get_sample_workspace_template_object().dict()
+
 
 class WorkspaceTemplateNamesInList(BaseModel):
     templateNames: List[str]
@@ -9,5 +33,16 @@ class WorkspaceTemplateNamesInList(BaseModel):
         schema_extra = {
             "example": {
                 "templateNames": ["tre-workspace-vanilla", "tre-workspace-base"]
+            }
+        }
+
+
+class WorkspaceTemplateInResponse(BaseModel):
+    workspaceTemplate: ResourceTemplate
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "workspaceTemplate": get_sample_workspace_template()
             }
         }

--- a/management_api_app/resources/strings.py
+++ b/management_api_app/resources/strings.py
@@ -10,6 +10,7 @@ API_CREATE_WORKSPACE = "Create a workspace"
 API_GET_STATUS_OF_SERVICES = "Get status of services"
 
 API_GET_WORKSPACE_TEMPLATES = "Get workspace template names"
+API_GET_WORKSPACE_TEMPLATE_BY_NAME = "Get workspace template by name"
 
 # State store status
 OK = "OK"
@@ -18,8 +19,9 @@ COSMOS_DB = "Cosmos DB"
 STATE_STORE_ENDPOINT_NOT_RESPONDING = "State Store endpoint is not responding"
 UNSPECIFIED_ERROR = "Unspecified error"
 
-# Workspace strings
+# Error strings
 WORKSPACE_DOES_NOT_EXIST = "Workspace does not exist"
+WORKSPACE_TEMPLATE_DOES_NOT_EXIST = "Workspace template does not exist"
 
 # Resource Status
 RESOURCE_STATUS_NOT_DEPLOYED = "not_deployed"

--- a/management_api_app/tests/test_api/test_routes/test_workspace_templates.py
+++ b/management_api_app/tests/test_api/test_routes/test_workspace_templates.py
@@ -3,7 +3,10 @@ from mock import patch
 
 from fastapi import FastAPI
 from httpx import AsyncClient
+from starlette import status
 
+from db.errors import EntityDoesNotExist, UnableToAccessDatabase
+from models.schemas.workspace_template import get_sample_workspace_template_object
 from resources import strings
 
 
@@ -22,3 +25,32 @@ async def test_workspace_templates_returns_template_names(get_workspace_template
     assert len(actual_template_names) == len(expected_template_names)
     for name in expected_template_names:
         assert name in actual_template_names
+
+
+# [GET] /workspace-templates/{template_name}
+@patch("api.routes.workspace_templates.WorkspaceTemplateRepository.get_current_workspace_template_by_name")
+async def test_workspace_templates_by_name_returns_workspace_template(get_workspace_template_by_name_mock, app: FastAPI, client: AsyncClient):
+    get_workspace_template_by_name_mock.return_value = get_sample_workspace_template_object(template_name="template1")
+
+    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_TEMPLATE_BY_NAME, template_name="tre-workspace-vanilla"))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["workspaceTemplate"]["name"] == "template1"
+
+
+@patch("api.routes.workspace_templates.WorkspaceTemplateRepository.get_current_workspace_template_by_name")
+async def test_workspace_templates_by_name_returns_404_if_template_does_not_exist(get_workspace_template_by_name_mock, app: FastAPI, client: AsyncClient):
+    get_workspace_template_by_name_mock.side_effect = EntityDoesNotExist
+
+    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_TEMPLATE_BY_NAME, template_name="tre-workspace-vanilla"))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@patch("api.routes.workspace_templates.WorkspaceTemplateRepository.get_current_workspace_template_by_name")
+async def test_workspace_templates_by_name_returns_503_on_database_error(get_workspace_template_by_name_mock, app: FastAPI, client: AsyncClient):
+    get_workspace_template_by_name_mock.side_effect = UnableToAccessDatabase
+
+    response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_TEMPLATE_BY_NAME, template_name="tre-workspace-vanilla"))
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/management_api_app/tests/test_db/test_repositories/test_workspace_templates_repository.py
+++ b/management_api_app/tests/test_db/test_repositories/test_workspace_templates_repository.py
@@ -9,6 +9,7 @@ from models.domain.resource_template import ResourceTemplate
 
 def get_sample_workspace_template(name: str, version: str = "1.0") -> ResourceTemplate:
     return ResourceTemplate(
+        id="a7a7a7bd-7f4e-4a4e-b970-dc86a6b31dfb",
         name=name,
         description="some description",
         version=version,


### PR DESCRIPTION
# PR for issue #182 

## What is being addressed

API endpoint for retrieving a workspace template by name

## How is this addressed

- implement GET /workspace-templates/{template_name}
- implement accompanying tests

Closes #182 
