### PR TITLE
Add wiring for POST route for creating workspace templates

### DIFF
--- a/management_api_app/api/routes/workspace_templates.py
+++ b/management_api_app/api/routes/workspace_templates.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends
+from starlette import status
 
 from api.dependencies.database import get_repository
 from db.repositories.workspace_templates import WorkspaceTemplateRepository
-from models.schemas.workspace_template import WorkspaceTemplateNamesInList
+from models.schemas.workspace_template import WorkspaceTemplateNamesInList, WorkspaceTemplateIdInResponse, WorkspaceTemplateInCreate
 from resources import strings
 
 
@@ -13,3 +14,11 @@ router = APIRouter()
 async def get_workspace_templates(workspace_template_repo: WorkspaceTemplateRepository = Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateNamesInList:
     workspace_template_names = workspace_template_repo.get_workspace_template_names()
     return WorkspaceTemplateNamesInList(templateNames=workspace_template_names)
+
+
+@router.post("/workspace-templates", status_code=status.HTTP_201_CREATED,
+             response_model=WorkspaceTemplateIdInResponse,
+             name=strings.API_CREATE_WORKSPACE_TEMPLATES)
+async def create_workspace_template(workspace_template_create: WorkspaceTemplateInCreate, workspace_template_repo: WorkspaceTemplateRepository =
+                                    Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateIdInResponse:
+    pass

--- a/management_api_app/db/events.py
+++ b/management_api_app/db/events.py
@@ -12,7 +12,12 @@ async def connect_to_db(app: FastAPI) -> None:
     logging.debug(f"Connecting to {config.STATE_STORE_ENDPOINT}")
 
     try:
-        cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY)
+        if config.DEBUG:
+            # ignore TLS(setup is pain) when on devcontainer and connecting to cosmosdb on windows host.
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY,
+                                         connection_verify=False)
+        else:
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY)
         app.state.cosmos_client = cosmos_client
         logging.debug("Connection established")
     except Exception as e:

--- a/management_api_app/models/schemas/workspace_template.py
+++ b/management_api_app/models/schemas/workspace_template.py
@@ -1,5 +1,5 @@
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class WorkspaceTemplateNamesInList(BaseModel):
@@ -9,5 +9,39 @@ class WorkspaceTemplateNamesInList(BaseModel):
         schema_extra = {
             "example": {
                 "templateNames": ["tre-workspace-vanilla", "tre-workspace-base"]
+            }
+        }
+
+
+class WorkspaceTemplateInCreate(BaseModel):
+
+    name: str = Field(title="Name of workspace template")
+    version: str = Field(title="Version of workspace template")
+    description: str = Field(title=" Description of workspace template")
+    properties: dict = Field({}, title="Workspace template properties",
+                             description="Values for the properties required by the workspace template")
+    resourceType: str = Field(title="Type of workspace template")
+    current: bool = Field(title="Mark this version as current")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "name": "My workspace template",
+                "version": "0.0.1",
+                "description": "workspace template for great product",
+                "properties": {},
+                "resourceType": "workspace",
+                "current": "true"
+            }
+        }
+
+
+class WorkspaceTemplateIdInResponse(BaseModel):
+    resourceTemplateId: str
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "resourceTemplateId": "49a7445c-aae6-41ec-a539-30dfa90ab1ae",
             }
         }

--- a/management_api_app/resources/strings.py
+++ b/management_api_app/resources/strings.py
@@ -10,6 +10,7 @@ API_CREATE_WORKSPACE = "Create a workspace"
 API_GET_STATUS_OF_SERVICES = "Get status of services"
 
 API_GET_WORKSPACE_TEMPLATES = "Get workspace template names"
+API_CREATE_WORKSPACE_TEMPLATES = "Create workspace template"
 
 # State store status
 OK = "OK"

--- a/management_api_app/tests/test_api/test_routes/test_workspace_templates.py
+++ b/management_api_app/tests/test_api/test_routes/test_workspace_templates.py
@@ -2,6 +2,7 @@ import pytest
 from mock import patch
 
 from fastapi import FastAPI
+from starlette import status
 from httpx import AsyncClient
 
 from resources import strings
@@ -22,3 +23,16 @@ async def test_workspace_templates_returns_template_names(get_workspace_template
     assert len(actual_template_names) == len(expected_template_names)
     for name in expected_template_names:
         assert name in actual_template_names
+
+
+@patch("api.routes.workspace_templates.WorkspaceTemplateRepository.get_current_workspace_template_by_name")
+async def test_post_workspace_templates_does_not_create_a_template_with_bad_payload(_, app: FastAPI, client: AsyncClient):
+    input_data = """
+                    {
+                        "blah": "blah"
+                    }
+    """
+
+    response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_data)
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
# PR for issue #180 

Add a route for creating workspace templates.

This patch is one of several. In this patch the wiring is setup and a test is added which checks failure when the payload is not correct.