### PR TITLE
Add a sub doc in Resources for deployments

### DIFF
--- a/management_api_app/db/repositories/workspaces.py
+++ b/management_api_app/db/repositories/workspaces.py
@@ -5,12 +5,13 @@ from azure.cosmos import CosmosClient
 from pydantic import UUID4
 
 from core import config
+from resources import strings
 from db.errors import EntityDoesNotExist
-from db.repositories.base import BaseRepository
-from db.repositories.workspace_templates import WorkspaceTemplateRepository
-from models.domain.resource import Status
 from models.domain.workspace import Workspace
+from db.repositories.base import BaseRepository
+from models.domain.resource import Deployment, Status
 from models.schemas.workspace import WorkspaceInCreate
+from db.repositories.workspace_templates import WorkspaceTemplateRepository
 
 
 class WorkspaceRepository(BaseRepository):
@@ -64,7 +65,7 @@ class WorkspaceRepository(BaseRepository):
             resourceTemplateName=workspace_create.workspaceType,
             resourceTemplateVersion=template_version,
             resourceTemplateParameters=resource_spec_parameters,
-            status=Status.NotDeployed
+            deployment=Deployment(status=Status.NotDeployed, message=strings.RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE)
         )
 
         return workspace

--- a/management_api_app/models/domain/resource.py
+++ b/management_api_app/models/domain/resource.py
@@ -24,6 +24,11 @@ class ResourceType(str, Enum):
     Service = strings.RESOURCE_TYPE_SERVICE
 
 
+class Deployment(AzureTREModel):
+    status: Status
+    message: str
+
+
 class Resource(AzureTREModel):
     """
     Resource request
@@ -34,5 +39,5 @@ class Resource(AzureTREModel):
     resourceTemplateName: str = Field(title="Resource template name", description="The resource template (bundle) to deploy")
     resourceTemplateVersion: str = Field(title="Resource template version", description="The version of the resource template (bundle) to deploy")
     resourceTemplateParameters: dict = Field({}, title="Resource template parameters", description="Parameters for the deployment")
-    status: Status = Field(Status.NotDeployed, title="Deployment status")
+    deployment: Deployment = Field("", title="Deployment", description="Fields related to deployment of this resource")
     isDeleted: bool = Field(False, title="Is deleted", description="Marks the resource request as deleted (NOTE: this is not the deployment status)")

--- a/management_api_app/models/schemas/workspace.py
+++ b/management_api_app/models/schemas/workspace.py
@@ -17,7 +17,10 @@ def get_sample_workspace(workspace_id: str, spec_workspace_id: str = "0001") -> 
             "tre_id": "mytre-dev-1234",
             "address_space": "10.2.1.0/24"
         },
-        "status": "not_deployed",
+        "deployment": {
+            "status": "not_deployed",
+            "message": "This resource is not yet deployed"
+        },
         "isDeleted": False,
         "resourceType": "workspace",
         "workspaceURL": ""

--- a/management_api_app/resources/strings.py
+++ b/management_api_app/resources/strings.py
@@ -36,5 +36,8 @@ RESOURCE_STATUS_DELETED = "deleted"
 RESOURCE_TYPE_WORKSPACE = "workspace"
 RESOURCE_TYPE_SERVICE = "service"
 
+# Deployments
+RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE = "This resource has not yet been deployed"
+
 # Service bus
 SERVICE_BUS_GENERAL_ERROR_MESSAGE = "Service bus failure"

--- a/management_api_app/tests/test_db/test_repositories/test_workpaces_repository.py
+++ b/management_api_app/tests/test_db/test_repositories/test_workpaces_repository.py
@@ -60,7 +60,7 @@ def test_create_workspace_item_creates_a_workspace_with_the_right_values(cosmos_
     assert workspace.description == description
     assert workspace.resourceTemplateName == workspace_type
     assert workspace.resourceType == ResourceType.Workspace
-    assert workspace.status == Status.NotDeployed
+    assert workspace.deployment.status == Status.NotDeployed
     assert "azure_location" in workspace.resourceTemplateParameters
     assert "workspace_id" in workspace.resourceTemplateParameters
     assert "tre_id" in workspace.resourceTemplateParameters


### PR DESCRIPTION
# PR for issue #135

Preparing for Resource processor reports bundle execution events to state store ---> Bundle execution events persisted in state store

This patch adds a deployment sub document which tracks the status of deployment and a possible error message which is received from the resource processor.

All tests pass