### PR TITLE
Fix: API does not work on deploy

### DIFF
--- a/management_api_app/api/dependencies/database.py
+++ b/management_api_app/api/dependencies/database.py
@@ -1,21 +1,45 @@
+import logging
 from typing import Callable, Type
 
 from azure.cosmos import CosmosClient
-from fastapi import Depends, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
 
+from core import config
 from db.errors import UnableToAccessDatabase
 from db.repositories.base import BaseRepository
 from resources import strings
 
 
-def _get_db_client(request: Request) -> CosmosClient:
-    return request.app.state.cosmos_client
+def connect_to_db() -> CosmosClient:
+    logging.debug(f"Connecting to {config.STATE_STORE_ENDPOINT}")
+
+    try:
+        if config.DEBUG:
+            # ignore TLS(setup is pain) when on dev container and connecting to cosmosdb on windows host.
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY,
+                                         connection_verify=False)
+        else:
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY)
+        logging.debug("Connection established")
+        return cosmos_client
+    except Exception as e:
+        logging.debug(f"Connection to state store could not be established: {e}")
+
+
+def get_db_client(app: FastAPI) -> CosmosClient:
+    if not app.state.cosmos_client:
+        app.state.cosmos_client = connect_to_db()
+    return app.state.cosmos_client
+
+
+def get_db_client_from_request(request: Request) -> CosmosClient:
+    return get_db_client(request.app)
 
 
 def get_repository(repo_type: Type[BaseRepository]) -> Callable[[CosmosClient], BaseRepository]:
-    def _get_repo(client: CosmosClient = Depends(_get_db_client)) -> BaseRepository:
+    def _get_repo(client: CosmosClient = Depends(get_db_client_from_request)) -> BaseRepository:
         try:
             return repo_type(client)
         except UnableToAccessDatabase:

--- a/management_api_app/core/events.py
+++ b/management_api_app/core/events.py
@@ -2,13 +2,12 @@ from typing import Callable
 
 from fastapi import FastAPI
 
-from db.events import connect_to_db, bootstrap_database
+from db.events import bootstrap_database
 
 
 def create_start_app_handler(app: FastAPI) -> Callable:
     async def start_app() -> None:
         app.state.cosmos_client = None
-        await connect_to_db(app)
         await bootstrap_database(app)
 
     return start_app

--- a/management_api_app/tests/test_api/conftest.py
+++ b/management_api_app/tests/test_api/conftest.py
@@ -8,16 +8,12 @@ from asgi_lifespan import LifespanManager
 
 @pytest.fixture(autouse=True)
 def no_database():
-    """ overrides connecting to the database for all tests """
-    with patch('core.events.connect_to_db') as connect_db_mock:
-        connect_db_mock.return_value = None
-
-        with patch('db.repositories.base.BaseRepository._get_container') as container_mock:
-            container_mock.return_value = None
-
-            with patch('core.events.bootstrap_database') as bootstrap_mock:
-                bootstrap_mock.return_value = None
-                yield
+    """ overrides connecting to the database for all tests"""
+    with patch('api.dependencies.database.connect_to_db', return_value=None):
+        with patch('api.dependencies.database.get_db_client', return_value=None):
+            with patch('db.repositories.base.BaseRepository._get_container', return_value=None):
+                with patch('core.events.bootstrap_database', return_value=None):
+                    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
# PR for issue #212 

## What is being addressed

The API does not work after a deploy - due to the database not being available for service immediately

## How is this addressed

- Instead of relying on the startup-event to connect to the db, the API will connect as needed to the DB if a connection has not already been established
- Bootstrap rewritten to use the connect if not exists feature (connect_to_db)
- Tests rewritten to allow for this new behavior
