### PR TITLE
Fix issues with deployment status and template parameters

### DIFF
--- a/management_api_app/models/domain/resource.py
+++ b/management_api_app/models/domain/resource.py
@@ -25,8 +25,8 @@ class ResourceType(str, Enum):
 
 
 class Deployment(AzureTREModel):
-    status: Status
-    message: str
+    status: Status = Field(Status.NotDeployed, title="Deployment status")
+    message: str = Field("", title="Additional deployment status information")
 
 
 class Resource(AzureTREModel):
@@ -39,5 +39,5 @@ class Resource(AzureTREModel):
     resourceTemplateName: str = Field(title="Resource template name", description="The resource template (bundle) to deploy")
     resourceTemplateVersion: str = Field(title="Resource template version", description="The version of the resource template (bundle) to deploy")
     resourceTemplateParameters: dict = Field({}, title="Resource template parameters", description="Parameters for the deployment")
-    deployment: Deployment = Field("", title="Deployment", description="Fields related to deployment of this resource")
+    deployment: Deployment = Field(title="Deployment", description="Fields related to deployment of this resource")
     isDeleted: bool = Field(False, title="Is deleted", description="Marks the resource request as deleted (NOTE: this is not the deployment status)")

--- a/management_api_app/models/domain/resource_template.py
+++ b/management_api_app/models/domain/resource_template.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any
+from typing import List, Any
 
 from pydantic import Field
 
@@ -11,7 +11,7 @@ class Parameter(AzureTREModel):
     type: str = Field(title="Parameter type")
     default: Any = Field(title="Default value for the parameter")
     applyTo: str = Field("All Actions", title="The actions that the parameter applies to e.g. install, delete etc")
-    description: Optional[str] = Field(title="Parameter description")
+    description: str = Field("", title="Parameter description")
     required: bool = Field(False, title="Is the parameter required")
 
 
@@ -20,6 +20,6 @@ class ResourceTemplate(AzureTREModel):
     name: str = Field(title="Unique template name")
     description: str = Field(title="Template description")
     version: str = Field(title="Template version")
-    parameters: List[dict] = Field(title="Template parameters")
+    parameters: List[Parameter] = Field(title="Template parameters")
     resourceType: ResourceType = Field(title="Type of resource this template is for (workspace/service)")
     current: bool = Field(title="Is this the current version of this template")

--- a/management_api_app/models/schemas/workspace_template.py
+++ b/management_api_app/models/schemas/workspace_template.py
@@ -42,8 +42,7 @@ class WorkspaceTemplateInCreate(BaseModel):
     name: str = Field(title="Name of workspace template")
     version: str = Field(title="Version of workspace template")
     description: str = Field(title=" Description of workspace template")
-    parameters: List[dict] = Field([{}], title="Workspace template parameters",
-                                   description="Values for the parameters required by the workspace template")
+    parameters: List[Parameter] = Field([], title="Workspace template parameters", description="Values for the parameters required by the workspace template")
     resourceType: str = Field(title="Type of workspace template")
     current: bool = Field(title="Mark this version as current")
 

--- a/management_api_app/tests/test_api/test_routes/test_workspaces.py
+++ b/management_api_app/tests/test_api/test_routes/test_workspaces.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 from starlette import status
 
 from db.errors import EntityDoesNotExist
-from models.domain.resource import Status
+from models.domain.resource import Status, Deployment
 from models.domain.workspace import Workspace
 from models.schemas.workspace import get_sample_workspace
 from resources import strings
@@ -22,7 +22,7 @@ def create_sample_workspace_object(workspace_id):
         resourceTemplateName="tre-workspace-vanilla",
         resourceTemplateVersion="0.1.0",
         resourceTemplateParameters={},
-        status=Status.NotDeployed,
+        deployment=Deployment(status=Status.NotDeployed, message="")
     )
 
 

--- a/management_api_app/tests/test_db/test_repositories/test_workpaces_repository.py
+++ b/management_api_app/tests/test_db/test_repositories/test_workpaces_repository.py
@@ -5,7 +5,7 @@ import pytest
 
 import db.repositories.workspaces
 from db.errors import EntityDoesNotExist
-from models.domain.resource import Status, ResourceType
+from models.domain.resource import Deployment, Status, ResourceType
 from models.domain.workspace import Workspace
 from models.schemas.workspace import WorkspaceInCreate
 
@@ -88,7 +88,7 @@ def test_save_workspace_saves_the_items_to_the_database(cosmos_client_mock):
         resourceTemplateName="vanilla-tre",
         resourceTemplateVersion="0.1.0",
         resourceTemplateParameters={},
-        status=Status.NotDeployed,
+        deployment=Deployment(status=Status.NotDeployed, message="")
     )
 
     workspace_repo.save_workspace(workspace)


### PR DESCRIPTION
## What is being addressed

- Workspace.deployment was mistakenly given a default value of "" even though it is a class (status, message)
- ResourceTemplate.parameters were listed as List[dict] rather than List[Parameter]

## How is this addressed

- Fix the defaults and definitions
- Fix related tests