### PR TITLE
fix update existing workspacetemplate - so that it doesn't throw errors

### DIFF
--- a/management_api_app/api/routes/workspace_templates.py
+++ b/management_api_app/api/routes/workspace_templates.py
@@ -23,14 +23,10 @@ async def get_workspace_templates(workspace_template_repo: WorkspaceTemplateRepo
     return WorkspaceTemplateNamesInList(templateNames=workspace_template_names)
 
 
-@router.post("/workspace-templates", status_code=status.HTTP_201_CREATED,
-             response_model=WorkspaceTemplateInResponse,
-             name=strings.API_CREATE_WORKSPACE_TEMPLATES)
-async def create_workspace_template(workspace_template_create: WorkspaceTemplateInCreate, workspace_template_repo: WorkspaceTemplateRepository =
-                                    Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateInResponse:
+@router.post("/workspace-templates", status_code=status.HTTP_201_CREATED, response_model=WorkspaceTemplateInResponse, name=strings.API_CREATE_WORKSPACE_TEMPLATES)
+async def create_workspace_template(workspace_template_create: WorkspaceTemplateInCreate, workspace_template_repo: WorkspaceTemplateRepository = Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateInResponse:
     try:
-        template = workspace_template_repo.get_workspace_template_by_name_and_version(workspace_template_create.name,
-                                                                                      workspace_template_create.version)
+        template = workspace_template_repo.get_workspace_template_by_name_and_version(workspace_template_create.name, workspace_template_create.version)
         if template:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=strings.WORKSPACE_TEMPLATE_VERSION_EXISTS)
     except EntityDoesNotExist:
@@ -38,7 +34,7 @@ async def create_workspace_template(workspace_template_create: WorkspaceTemplate
         if create_new_current:
             try:
                 template = workspace_template_repo.get_current_workspace_template_by_name(workspace_template_create.name)
-                template["current"] = "false"
+                template.current = False
                 workspace_template_repo.update_item(template)
             except EntityDoesNotExist:
                 # first registration

--- a/management_api_app/db/repositories/workspace_templates.py
+++ b/management_api_app/db/repositories/workspace_templates.py
@@ -62,4 +62,4 @@ class WorkspaceTemplateRepository(BaseRepository):
         return resource_template
 
     def update_item(self, resource_template: ResourceTemplate):
-        self.container.upsert_item(resource_template)
+        self.container.upsert_item(resource_template.dict())

--- a/management_api_app/models/domain/resource_template.py
+++ b/management_api_app/models/domain/resource_template.py
@@ -9,7 +9,7 @@ from models.domain.resource import ResourceType
 class Parameter(AzureTREModel):
     name: str = Field(title="Parameter name")
     type: str = Field(title="Parameter type")
-    default: Any = Field(title="Default value for the parameter")
+    default: Any = Field(None, title="Default value for the parameter")
     applyTo: str = Field("All Actions", title="The actions that the parameter applies to e.g. install, delete etc")
     description: str = Field("", title="Parameter description")
     required: bool = Field(False, title="Is the parameter required")


### PR DESCRIPTION
# PR for issue #316 

## What is being addressed

See bug #316

## How is this addressed

- UpdateItem converts the ResourceTemplate to a dict before posting to the DB
- Related tests are updated