### PR TITLE
Add better api error messages

### DIFF
--- a/management_api_app/api/errors/generic_error.py
+++ b/management_api_app/api/errors/generic_error.py
@@ -1,0 +1,19 @@
+import logging
+
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+from core import config
+from resources import strings
+
+
+async def generic_error_handler(_: Request, exception: Exception) -> PlainTextResponse:
+    logging.debug("=====================================")
+    logging.debug("=====================================")
+    logging.exception(exception)
+    logging.debug("=====================================")
+    logging.debug("=====================================")
+    if config.DEBUG:
+        return PlainTextResponse(exception, status_code=500)
+    else:
+        return PlainTextResponse(strings.UNABLE_TO_PROCESS_REQUEST, status_code=500)

--- a/management_api_app/api/errors/generic_error.py
+++ b/management_api_app/api/errors/generic_error.py
@@ -9,11 +9,7 @@ from resources import strings
 
 async def generic_error_handler(_: Request, exception: Exception) -> PlainTextResponse:
     logging.debug("=====================================")
-    logging.debug("=====================================")
     logging.exception(exception)
     logging.debug("=====================================")
-    logging.debug("=====================================")
-    if config.DEBUG:
-        return PlainTextResponse(exception, status_code=500)
-    else:
-        return PlainTextResponse(strings.UNABLE_TO_PROCESS_REQUEST, status_code=500)
+    error_string = exception if config.DEBUG else strings.UNABLE_TO_PROCESS_REQUEST
+    return PlainTextResponse(error_string, status_code=500)

--- a/management_api_app/api/errors/http_error.py
+++ b/management_api_app/api/errors/http_error.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import PlainTextResponse
 
 
-async def http_error_handler(_: Request, exc: HTTPException) -> JSONResponse:
-    return JSONResponse({"errors": [exc.detail]}, status_code=exc.status_code)
+def http_error_handler(_: Request, exc: HTTPException) -> PlainTextResponse:
+    return PlainTextResponse(exc.detail, status_code=exc.status_code)

--- a/management_api_app/api/errors/validation_error.py
+++ b/management_api_app/api/errors/validation_error.py
@@ -5,15 +5,12 @@ from fastapi.openapi.constants import REF_PREFIX
 from fastapi.openapi.utils import validation_error_response_definition
 from pydantic import ValidationError
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import PlainTextResponse
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 
-async def http422_error_handler(_: Request, exc: Union[RequestValidationError, ValidationError]) -> JSONResponse:
-    return JSONResponse(
-        {"errors": exc.errors()},
-        status_code=HTTP_422_UNPROCESSABLE_ENTITY,
-    )
+def http422_error_handler(_: Request, exception: Union[RequestValidationError, ValidationError]) -> PlainTextResponse:
+    return PlainTextResponse(str(exception), status_code=HTTP_422_UNPROCESSABLE_ENTITY)
 
 
 validation_error_response_definition["properties"] = {

--- a/management_api_app/api/routes/workspace_templates.py
+++ b/management_api_app/api/routes/workspace_templates.py
@@ -23,14 +23,10 @@ async def get_workspace_templates(workspace_template_repo: WorkspaceTemplateRepo
     return WorkspaceTemplateNamesInList(templateNames=workspace_template_names)
 
 
-@router.post("/workspace-templates", status_code=status.HTTP_201_CREATED,
-             response_model=WorkspaceTemplateInResponse,
-             name=strings.API_CREATE_WORKSPACE_TEMPLATES)
-async def create_workspace_template(workspace_template_create: WorkspaceTemplateInCreate, workspace_template_repo: WorkspaceTemplateRepository =
-                                    Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateInResponse:
+@router.post("/workspace-templates", status_code=status.HTTP_201_CREATED, response_model=WorkspaceTemplateInResponse, name=strings.API_CREATE_WORKSPACE_TEMPLATES)
+async def create_workspace_template(workspace_template_create: WorkspaceTemplateInCreate, workspace_template_repo: WorkspaceTemplateRepository = Depends(get_repository(WorkspaceTemplateRepository))) -> WorkspaceTemplateInResponse:
     try:
-        template = workspace_template_repo.get_workspace_template_by_name_and_version(workspace_template_create.name,
-                                                                                      workspace_template_create.version)
+        template = workspace_template_repo.get_workspace_template_by_name_and_version(workspace_template_create.name, workspace_template_create.version)
         if template:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=strings.WORKSPACE_TEMPLATE_VERSION_EXISTS)
     except EntityDoesNotExist:
@@ -38,7 +34,7 @@ async def create_workspace_template(workspace_template_create: WorkspaceTemplate
         if create_new_current:
             try:
                 template = workspace_template_repo.get_current_workspace_template_by_name(workspace_template_create.name)
-                template["current"] = "false"
+                template.current = False
                 workspace_template_repo.update_item(template)
             except EntityDoesNotExist:
                 # first registration

--- a/management_api_app/db/repositories/workspace_templates.py
+++ b/management_api_app/db/repositories/workspace_templates.py
@@ -62,4 +62,4 @@ class WorkspaceTemplateRepository(BaseRepository):
         return resource_template
 
     def update_item(self, resource_template: ResourceTemplate):
-        self.container.upsert_item(resource_template)
+        self.container.upsert_item(resource_template.dict())

--- a/management_api_app/main.py
+++ b/management_api_app/main.py
@@ -6,10 +6,12 @@ from fastapi.exceptions import RequestValidationError
 from fastapi_utils.tasks import repeat_every
 from opencensus.ext.azure.log_exporter import AzureLogHandler
 from starlette.exceptions import HTTPException
+from starlette.middleware.errors import ServerErrorMiddleware
 
 from api.routes.api import router as api_router
 from api.errors.http_error import http_error_handler
 from api.errors.validation_error import http422_error_handler
+from api.errors.generic_error import generic_error_handler
 from core import config
 from core.events import create_start_app_handler, create_stop_app_handler
 from service_bus.deployment_status_update import receive_message_and_update_deployment
@@ -21,6 +23,7 @@ def get_application() -> FastAPI:
     application.add_event_handler("startup", create_start_app_handler(application))
     application.add_event_handler("shutdown", create_stop_app_handler(application))
 
+    application.add_middleware(ServerErrorMiddleware, handler=generic_error_handler)
     application.add_exception_handler(HTTPException, http_error_handler)
     application.add_exception_handler(RequestValidationError, http422_error_handler)
 

--- a/management_api_app/models/domain/resource_template.py
+++ b/management_api_app/models/domain/resource_template.py
@@ -9,7 +9,7 @@ from models.domain.resource import ResourceType
 class Parameter(AzureTREModel):
     name: str = Field(title="Parameter name")
     type: str = Field(title="Parameter type")
-    default: Any = Field(title="Default value for the parameter")
+    default: Any = Field(None, title="Default value for the parameter")
     applyTo: str = Field("All Actions", title="The actions that the parameter applies to e.g. install, delete etc")
     description: str = Field("", title="Parameter description")
     required: bool = Field(False, title="Is the parameter required")

--- a/management_api_app/resources/strings.py
+++ b/management_api_app/resources/strings.py
@@ -21,8 +21,10 @@ STATE_STORE_ENDPOINT_NOT_RESPONDING = "State Store endpoint is not responding"
 UNSPECIFIED_ERROR = "Unspecified error"
 
 # Error strings
+UNABLE_TO_REPLACE_CURRENT_TEMPLATE = "Unable to replace the existing 'current' template with this name"
+UNABLE_TO_PROCESS_REQUEST = "Unable to process request"
 WORKSPACE_DOES_NOT_EXIST = "Workspace does not exist"
-WORKSPACE_TEMPLATE_DOES_NOT_EXIST = "Workspace template does not exist"
+WORKSPACE_TEMPLATE_DOES_NOT_EXIST = "Could not retrieve the 'current' template with this name"
 WORKSPACE_TEMPLATE_VERSION_EXISTS = "A template with this version already exists"
 
 # Resource Status

--- a/management_api_app/tests/test_api/test_errors/test_422_error.py
+++ b/management_api_app/tests/test_api/test_errors/test_422_error.py
@@ -17,4 +17,4 @@ async def test_frw_validation_error_format(app: FastAPI):
 
     assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
 
-    assert "errors" in response.json()
+    assert "error" in response.text

--- a/management_api_app/tests/test_api/test_errors/test_error.py
+++ b/management_api_app/tests/test_api/test_errors/test_error.py
@@ -12,4 +12,4 @@ async def test_frw_validation_error_format(app: FastAPI):
 
     assert response.status_code == HTTP_404_NOT_FOUND
 
-    assert "errors" in response.json()
+    assert "Not Found" in response.text

--- a/management_api_app/tests/test_db/test_repositories/test_workspace_templates_repository.py
+++ b/management_api_app/tests/test_db/test_repositories/test_workspace_templates_repository.py
@@ -154,7 +154,7 @@ def test_create_item(cosmos_mock, uuid_mock, create_mock):
         current=False
     )
     returned_template = template_repo.create_workspace_template_item(payload)
-    expected_resouce_template = ResourceTemplate(
+    expected_resource_template = ResourceTemplate(
         id="1234",
         name="name",
         description="some description",
@@ -163,8 +163,8 @@ def test_create_item(cosmos_mock, uuid_mock, create_mock):
         parameters=[],
         current=False
     )
-    create_mock.assert_called_once_with(expected_resouce_template)
-    assert expected_resouce_template == returned_template
+    create_mock.assert_called_once_with(expected_resource_template)
+    assert expected_resource_template == returned_template
 
 
 @patch('db.repositories.workspace_templates.WorkspaceTemplateRepository.container')


### PR DESCRIPTION
# PR for issue #213 

## What is being addressed

- Unhandled errors should not leak information
- Make it easier to debug errors without leaking info

## How is this addressed

- Add a generic error handler that logs information, but also displays in the browser if DEBUG=True
- Change the HTTP and ValidationError output so that it is more human readable
- Update related tests

NOTE: Because I built this on an existing branch - for some reason the changes that have already been merged still show up in this diff - but you can ignore any changes in resource_templates, workspace_templates and the tests for those files - they have already been merged