### PR TITLE
Block public storage endpoints

### DIFF
--- a/templates/core/terraform/storage/storage.tf
+++ b/templates/core/terraform/storage/storage.tf
@@ -4,6 +4,12 @@ resource "azurerm_storage_account" "stg" {
   location                 = var.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  network_rules {
+      bypass         = ["AzureServices"]
+      default_action = "Deny"
+  }
+
 }
 
 resource "azurerm_storage_share" "storage_state_path" {

--- a/templates/services/storage_service/terraform/storage/storage.tf
+++ b/templates/services/storage_service/terraform/storage/storage.tf
@@ -4,6 +4,11 @@ resource "azurerm_storage_account" "storage" {
   location                 = var.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+
+  network_rules {
+      bypass         = ["AzureServices"]
+      default_action = "Deny"
+  }
 }
 
 resource "azurerm_private_dns_zone" "blobcore" {

--- a/workspaces/services/azureml/terraform/storage/main.tf
+++ b/workspaces/services/azureml/terraform/storage/main.tf
@@ -20,6 +20,11 @@ resource "azurerm_storage_account" "stg" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
+  network_rules {
+      bypass         = ["AzureServices"]
+      default_action = "Deny"
+  }
+
 }
 
 resource "azurerm_private_dns_zone" "filecore" {


### PR DESCRIPTION
# PR for issue 326

## What is being addressed

When storage accounts have private endpoints, public endpoint should be blocked.

Add:
```
  network_rules {
      bypass         = ["AzureServices"]
      default_action = "Deny"
  }
```