### PR TITLE
Audience should just be the app id, not app identifier url.

### DIFF
--- a/management_api_app/core/config.py
+++ b/management_api_app/core/config.py
@@ -37,4 +37,4 @@ SWAGGER_UI_CLIENT_ID: str = config("SWAGGER_UI_CLIENT_ID", default="")
 AAD_TENANT_ID: str = config("AAD_TENANT_ID", default="")
 
 AAD_INSTANCE: str = config("AAD_INSTANCE", default="https://login.microsoftonline.com")
-API_AUDIENCE: str = config("API_AUDIENCE", default=f"api://{API_CLIENT_ID}")
+API_AUDIENCE: str = config("API_AUDIENCE", default=API_CLIENT_ID)


### PR DESCRIPTION
# PR for issue #361 

The audience claim is just the App Id GUID. Trying to use the App identifier URL to validate the access token fails with "Invalid Audience" error.