### PR TITLE
Fixing App Gateway Routes needed for authentication.

### DIFF
--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -146,7 +146,7 @@ resource "azurerm_application_gateway" "agw" {
 
     path_rule {
       name = "api"
-      paths = [ "/api/*", "/docs", "/openapi.json" ]
+      paths = [ "/api/*", "/docs", "/openapi.json", "/docs/oauth2-redirect" ]
       backend_address_pool_name = local.api_backend_pool_name
       backend_http_settings_name = local.api_http_setting_name
     }


### PR DESCRIPTION
# PR for issue #364 

## What is being addressed

When authenticating using the Swagger UI the OpenID Connect redirect path `/docs/oauth2-redirect` is used. This path needs to be specified in the Application Gateway routing rules.

_This part of the PR has been removed, pending a wider discussion on whether the storage account should have a private endpoint ..._
> Also, the storage account used for serving static web content needs to be open to the Internet, otherwise it can't server the static web content! This is currently used for Let's Encrypt domain verification so was preventing certificate issuance for the Application Gateway.
