### PR TITLE
Fixes Management API unit test exceptions

### DIFF
--- a/management_api_app/resources/strings.py
+++ b/management_api_app/resources/strings.py
@@ -51,7 +51,7 @@ RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE = "This resource has not yet been deployed"
 
 # Service bus
 SERVICE_BUS_GENERAL_ERROR_MESSAGE = "Service bus failure"
-DEPLOYMENT_STATUS_MESSAGE_FORMAT_INCORRECT = "Service bus message is not formatted correctly."
+DEPLOYMENT_STATUS_MESSAGE_FORMAT_INCORRECT = "Service bus message is not formatted correctly"
 DEPLOYMENT_STATUS_ID_NOT_FOUND = "Service bus message refers to resource id = {} which does not exist"
 
 # Workspace creation validation

--- a/management_api_app/service_bus/deployment_status_update.py
+++ b/management_api_app/service_bus/deployment_status_update.py
@@ -48,8 +48,8 @@ async def receive_message():
                     try:
                         message = json.loads(str(msg))
                         result = (yield parse_obj_as(DeploymentStatusUpdateMessage, message))
-                    except (json.JSONDecodeError, ValidationError):
-                        logging.error(strings.DEPLOYMENT_STATUS_MESSAGE_FORMAT_INCORRECT)
+                    except (json.JSONDecodeError, ValidationError) as e:
+                        logging.error(f"{strings.DEPLOYMENT_STATUS_MESSAGE_FORMAT_INCORRECT}: {e}")
 
                     if result:
                         logging.info(f"Received deployment status update message with correlation ID {msg.correlation_id}: {message}")

--- a/management_api_app/tests/test_service_bus/test_deployment_status_update.py
+++ b/management_api_app/tests/test_service_bus/test_deployment_status_update.py
@@ -2,7 +2,6 @@ import json
 import pytest
 import uuid
 
-from azure.servicebus import ServiceBusMessage
 from mock import AsyncMock, patch
 
 from db.errors import EntityDoesNotExist
@@ -12,17 +11,28 @@ from models.domain.resource import Deployment
 from resources import strings
 from service_bus.deployment_status_update import receive_message_and_update_deployment
 
+
 pytestmark = pytest.mark.asyncio
 
-invalid_service_bus_message = ServiceBusMessage(body='{\'bad\': \'bad\'}', correlation_id="123")
+test_data = [
+    'bad',
+    '{"good": "json", "bad": "message"}'
+]
 
-valid_service_bus_message_body = {
+test_sb_message = {
     "id": "59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
     "status": Status.Deployed,
     "message": "test message"
 }
 
-valid_service_bus_message = ServiceBusMessage(body=json.dumps(valid_service_bus_message_body), correlation_id="456")
+
+class ServiceBusReceivedMessageMock:
+    def __init__(self, message: dict):
+        self.message = json.dumps(message)
+        self.correlation_id = "test_correlation_id"
+
+    def __str__(self):
+        return self.message
 
 
 def create_sample_workspace_object(workspace_id):
@@ -36,17 +46,21 @@ def create_sample_workspace_object(workspace_id):
     )
 
 
+@pytest.mark.parametrize("payload", test_data)
 @patch('logging.error')
 @patch('service_bus.deployment_status_update.ServiceBusClient')
 @patch('fastapi.FastAPI')
-async def test_receiving_bad_json_logs_error(app, sb_client, logging_mock):
-    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[invalid_service_bus_message])
+async def test_receiving_bad_json_logs_error(app, sb_client, logging_mock, payload):
+    service_bus_received_message_mock = ServiceBusReceivedMessageMock(payload)
+
+    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[service_bus_received_message_mock])
     sb_client().get_queue_receiver().complete_message = AsyncMock()
 
     await receive_message_and_update_deployment(app)
 
-    logging_mock.assert_called_once_with(strings.DEPLOYMENT_STATUS_MESSAGE_FORMAT_INCORRECT)
-    sb_client().get_queue_receiver().complete_message.assert_called_once_with(invalid_service_bus_message)
+    error_message = logging_mock.call_args.args[0]
+    assert error_message.startswith(strings.DEPLOYMENT_STATUS_MESSAGE_FORMAT_INCORRECT)
+    sb_client().get_queue_receiver().complete_message.assert_called_once_with(service_bus_received_message_mock)
 
 
 @patch('service_bus.deployment_status_update.WorkspaceRepository')
@@ -54,16 +68,18 @@ async def test_receiving_bad_json_logs_error(app, sb_client, logging_mock):
 @patch('service_bus.deployment_status_update.ServiceBusClient')
 @patch('fastapi.FastAPI')
 async def test_receiving_good_message(app, sb_client, logging_mock, repo):
-    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[valid_service_bus_message])
+    service_bus_received_message_mock = ServiceBusReceivedMessageMock(test_sb_message)
+
+    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[service_bus_received_message_mock])
     sb_client().get_queue_receiver().complete_message = AsyncMock()
-    expected_workspace = create_sample_workspace_object(valid_service_bus_message_body["id"])
+    expected_workspace = create_sample_workspace_object(test_sb_message["id"])
     repo().get_workspace_by_workspace_id.return_value = expected_workspace
 
     await receive_message_and_update_deployment(app)
-    repo().get_workspace_by_workspace_id.assert_called_once_with(uuid.UUID(valid_service_bus_message_body["id"]))
+    repo().get_workspace_by_workspace_id.assert_called_once_with(uuid.UUID(test_sb_message["id"]))
     repo().update_workspace.assert_called_once_with(expected_workspace)
     logging_mock.assert_not_called()
-    sb_client().get_queue_receiver().complete_message.assert_called_once_with(valid_service_bus_message)
+    sb_client().get_queue_receiver().complete_message.assert_called_once_with(service_bus_received_message_mock)
 
 
 @patch('service_bus.deployment_status_update.WorkspaceRepository')
@@ -71,14 +87,16 @@ async def test_receiving_good_message(app, sb_client, logging_mock, repo):
 @patch('service_bus.deployment_status_update.ServiceBusClient')
 @patch('fastapi.FastAPI')
 async def test_when_updating_non_existent_workspace_error_is_logged(app, sb_client, logging_mock, repo):
-    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[valid_service_bus_message])
+    service_bus_received_message_mock = ServiceBusReceivedMessageMock(test_sb_message)
+
+    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[service_bus_received_message_mock])
     sb_client().get_queue_receiver().complete_message = AsyncMock()
     repo().get_workspace_by_workspace_id.side_effect = EntityDoesNotExist
 
     await receive_message_and_update_deployment(app)
-    expected_error_message = strings.DEPLOYMENT_STATUS_ID_NOT_FOUND.format(valid_service_bus_message_body["id"])
+    expected_error_message = strings.DEPLOYMENT_STATUS_ID_NOT_FOUND.format(test_sb_message["id"])
     logging_mock.assert_called_once_with(expected_error_message)
-    sb_client().get_queue_receiver().complete_message.assert_called_once_with(valid_service_bus_message)
+    sb_client().get_queue_receiver().complete_message.assert_called_once_with(service_bus_received_message_mock)
 
 
 @patch('service_bus.deployment_status_update.WorkspaceRepository')
@@ -86,7 +104,9 @@ async def test_when_updating_non_existent_workspace_error_is_logged(app, sb_clie
 @patch('service_bus.deployment_status_update.ServiceBusClient')
 @patch('fastapi.FastAPI')
 async def test_when_updating_and_state_store_exception(app, sb_client, logging_mock, repo):
-    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[valid_service_bus_message])
+    service_bus_received_message_mock = ServiceBusReceivedMessageMock(test_sb_message)
+
+    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[service_bus_received_message_mock])
     sb_client().get_queue_receiver().complete_message = AsyncMock()
     repo().get_workspace_by_workspace_id.side_effect = Exception
 

--- a/templates/core/terraform/appgateway/certificate.tf
+++ b/templates/core/terraform/appgateway/certificate.tf
@@ -1,4 +1,4 @@
-resource "azurerm_key_vault_access_policy" "example" {
+resource "azurerm_key_vault_access_policy" "app_gw_managed_identity" {
   key_vault_id = var.keyvault_id
   tenant_id    = azurerm_user_assigned_identity.agw_id.tenant_id
   object_id    = azurerm_user_assigned_identity.agw_id.principal_id


### PR DESCRIPTION
Fixes #360 

## How is this addressed

Removes the use of actual ServiceBusMessage class in unit tests, which was causing logging related exceptions.
