### PR TITLE
Add azurewebsites private dns zone

### DIFF
--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -98,22 +98,10 @@ resource "azurerm_private_endpoint" "management_api_private_endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.azurewebsites.net"
-    private_dns_zone_ids = [azurerm_private_dns_zone.azurewebsites.id]
+    private_dns_zone_ids = [var.azurewebsites_dns_zone_id]
   }
 }
 
-resource "azurerm_private_dns_zone" "azurewebsites" {
-  name                = "privatelink.azurewebsites.net"
-  resource_group_name = var.resource_group_name
-}
-
-resource "azurerm_private_dns_zone_virtual_network_link" "azurewebsites" {
-  resource_group_name   = var.resource_group_name
-  virtual_network_id    = var.core_vnet
-  private_dns_zone_name = azurerm_private_dns_zone.azurewebsites.name
-  name                  = "azurewebsites-link"
-  registration_enabled  = false
-}
 
 resource "azurerm_app_service_virtual_network_swift_connection" "api-integrated-vnet" {
   app_service_id = azurerm_app_service.management_api.id

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -17,6 +17,7 @@ variable "state_store_key" {}
 variable "service_bus_resource_request_queue" {}
 variable "service_bus_deployment_status_update_queue" {}
 variable "managed_identity" {}
+variable "azurewebsites_dns_zone_id" {}
 variable "swagger_ui_client_id" {}
 variable "aad_tenant_id" {}
 variable "api_client_id" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -86,6 +86,7 @@ module "api-webapp" {
   service_bus_resource_request_queue         = module.servicebus.workspacequeue
   service_bus_deployment_status_update_queue = module.servicebus.service_bus_deployment_status_update_queue
   managed_identity                           = module.identity.managed_identity
+  azurewebsites_dns_zone_id                  = module.network.azurewebsites_dns_zone_id
   swagger_ui_client_id                       = var.swagger_ui_client_id
   aad_tenant_id                              = var.aad_tenant_id
   api_client_id                              = var.api_client_id

--- a/templates/core/terraform/network/dns_zones.tf
+++ b/templates/core/terraform/network/dns_zones.tf
@@ -1,0 +1,13 @@
+
+resource "azurerm_private_dns_zone" "azurewebsites" {
+  name                = "privatelink.azurewebsites.net"
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "azurewebsites" {
+  resource_group_name   = var.resource_group_name
+  virtual_network_id    = azurerm_virtual_network.core.id
+  private_dns_zone_name = azurerm_private_dns_zone.azurewebsites.name
+  name                  = "azurewebsites-link"
+  registration_enabled  = false
+}

--- a/templates/core/terraform/network/output.tf
+++ b/templates/core/terraform/network/output.tf
@@ -25,3 +25,7 @@ output "shared" {
 output "aci" {
   value = azurerm_subnet.aci.id
 }
+
+output "azurewebsites_dns_zone_id" {
+  value = azurerm_private_dns_zone.azurewebsites.id
+}

--- a/workspaces/vanilla/terraform/.terraform.lock.hcl
+++ b/workspaces/vanilla/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.61.0"
   constraints = "2.61.0"
   hashes = [
+    "h1:HF/suXV0V9cQyW/bUGj00g/W59JWGpIk9L0FMsCE0u8=",
     "h1:oFTREfEpFnAsF/jJYy2alz7+fWX/AvdjxpCKEtCx2QU=",
     "zh:011075f7a9239e3f4e592f7ace8f40aa1af60e300b97a7d97d3834ecb3a2e27c",
     "zh:0f6bb1f5b742360b77125c7704d2890f1377db30f62188800a54000e3bc6c764",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:EPIax4Ftp2SNdB9pUfoSjxoueDoLc/Ck3EUoeX0Dvsg=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",

--- a/workspaces/vanilla/terraform/deploy.sh
+++ b/workspaces/vanilla/terraform/deploy.sh
@@ -1,14 +1,8 @@
-cat > workspace_backend.tf <<TRE_BACKEND
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "$TF_VAR_mgmt_resource_group_name"
-    storage_account_name = "$TF_VAR_mgmt_storage_account_name"
-    container_name       = "$TF_VAR_terraform_state_container_name"
-    key                  = "$TF_VAR_tre_id$TF_VAR_workspace_id"
-  }
-}
-TRE_BACKEND
-
-terraform init -input=false -backend=true -reconfigure -upgrade
+export TF_LOG=""
+terraform init -input=false -backend=true -reconfigure \
+    -backend-config="resource_group_name=$TF_VAR_mgmt_resource_group_name" \
+    -backend-config="storage_account_name=$TF_VAR_mgmt_storage_account_name" \
+    -backend-config="container_name=$TF_VAR_terraform_state_container_name" \
+    -backend-config="key=${TF_VAR_tre_id}${TF_VAR_workspace_id}"
 terraform plan
 terraform apply -auto-approve

--- a/workspaces/vanilla/terraform/network/locals.tf
+++ b/workspaces/vanilla/terraform/network/locals.tf
@@ -2,4 +2,5 @@ locals {
   ws_services_vnet_subnets       = cidrsubnets(var.address_space, 1, 1)
   services_subnet_address_prefix = local.ws_services_vnet_subnets[0]
   webapps_subnet_address_prefix  = local.ws_services_vnet_subnets[1]
+  workspace_resource_name_suffix = "${var.tre_id}-ws-${var.workspace_id}"
 }

--- a/workspaces/vanilla/terraform/network/network.tf
+++ b/workspaces/vanilla/terraform/network/network.tf
@@ -192,3 +192,11 @@ resource "azurerm_subnet_route_table_association" "rt_services_subnet_associatio
   route_table_id = data.azurerm_route_table.rt.id
   subnet_id      = azurerm_subnet.services.id
 }
+
+resource "azurerm_private_dns_zone_virtual_network_link" "azurewebsites" {
+  resource_group_name   = var.core_resource_group_name
+  virtual_network_id    = azurerm_virtual_network.ws.id
+  private_dns_zone_name = "privatelink.azurewebsites.net"
+  name                  = "link-azurewebsites-${local.workspace_resource_name_suffix}"
+  registration_enabled  = false
+}


### PR DESCRIPTION
# PR for issue #350

## What is being addressed

Services, such as InnerEye inference require a web app, with private endpoint. This needs a private DNS zone, as only one zone of each name can be attached for each VNet, and shared services also need a zone. For this reason the zone should live inthe "core" deployment, and attached to each workspace.

## How is this addressed

- Add private DNS zone to core
- Link DNS zone to vanilla workspace network
