### PR TITLE
Add acr name and id as outputs

### DIFF
--- a/workspaces/azureml_devtestlabs/porter.yaml
+++ b/workspaces/azureml_devtestlabs/porter.yaml
@@ -54,6 +54,8 @@ parameters:
 outputs:
   - name: azureml_workspace_name
     type: string
+  - name: azureml_acr_id
+    type: string
 
 mixins:
   - exec
@@ -104,6 +106,19 @@ install:
         i: service-azureml
       outputs:
         - name: azureml_workspace_name
+          regex: (.*)
+  - exec:
+      description: "Get Azure ML Service Outputs"
+      command: porter
+      arguments:
+        - installations
+        - output
+        - show
+        - azureml_acr_id
+      flags:
+        i: service-azureml
+      outputs:
+        - name: azureml_acr_id
           regex: (.*)
   - exec:
       description: "Install Dev Test Labs Virtual Desktop Service"

--- a/workspaces/azureml_devtestlabs/readme.md
+++ b/workspaces/azureml_devtestlabs/readme.md
@@ -41,10 +41,10 @@ Service Tags:
     `make build-cnab-image`
 
 - A Azure ML DevTest Labs Workspace bundle built
-    `make porter-build DIR=./workspaces/azureml-devtestlabs`
+    `make porter-build DIR=./workspaces/azureml_devtestlabs`
 
 ## To deploy
 
 - Once prerequisites are installed, create a copy of `workspaces/azureml_devtestlabs/.env.sample` called `.env` in the  `workspaces/azureml_devtestlabs/` directory. Update the environment variable values to match your installation.
 
-- Run: `make porter-install DIR=./workspaces/azureml-devtestlabs`
+- Run: `make porter-install DIR=./workspaces/azureml_devtestlabs`

--- a/workspaces/services/azureml/porter.yaml
+++ b/workspaces/services/azureml/porter.yaml
@@ -34,6 +34,10 @@ parameters:
 outputs:
   - name: azureml_workspace_name
     type: string
+  - name: azureml_acr_id
+    type: string
+  - name: azureml_storage_account_id
+    type: string
 
 mixins:
   - exec
@@ -56,6 +60,8 @@ install:
         key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.workspace_id }}-svc-azureml"
       outputs:
       - name: azureml_workspace_name
+      - name: azureml_acr_id
+      - name: azureml_storage_account_id
 
 upgrade:
   - exec:

--- a/workspaces/services/azureml/terraform/acr/output.tf
+++ b/workspaces/services/azureml/terraform/acr/output.tf
@@ -1,0 +1,7 @@
+output "name" {
+    value = azurerm_container_registry.acr.name
+}
+
+output "id" {
+    value = azurerm_container_registry.acr.id
+}

--- a/workspaces/services/azureml/terraform/output.tf
+++ b/workspaces/services/azureml/terraform/output.tf
@@ -9,3 +9,11 @@ output "computeinstance_name" {
 output "computecluster_name" {
     value = "cl-${local.service_resource_name_suffix}"
 }
+
+output "azureml_acr_id" {
+    value = module.acr.id
+}
+
+output "azureml_storage_account_id" {
+    value = module.storage.storage_account_id
+}


### PR DESCRIPTION
# PR for issue #350

## What is being addressed

Other services - such as innereye deeplearning need the ACR ID as an output.

## How is this addressed

- Add acr_id as an output of Azure ML worksapce and service
