### PR TITLE
Change TRE AAD role from TREResearcher to TREUser

### DIFF
--- a/docs/developer-quickstart.md
+++ b/docs/developer-quickstart.md
@@ -91,7 +91,7 @@ Execute the following steps to set up a development environment.
 
    Follow the [Microsoft Docs Quickstart](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) or run the [AAD App Reg script](../scripts/aad-app-reg.sh) to register two apps
 
-   - **TRE API:**  (with three roles `TREAdmin`, `TREWorkspaceOwner` and `TREResearcher`) This app is used to authenticate users to the API - add users to the admin, owner, and researcher roles.
+   - **TRE API:**  (with two roles `TREAdmin`, and `TREUser`) This app is used to authenticate users to the API - add users to the admin, and user roles.
    - **TRE Swagger UI**: This app is used to allow Swagger login
    - You will also want to create applications for workspaces (with the roles `WorkspaceResearcher` and `WorkspaceOwner`) that govern who can see what workspaces in the API
 

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -67,7 +67,7 @@ fi
 currentUserId=$(az ad signed-in-user show --query 'objectId' -o tsv)
 
 # Generate GUIDS
-declare researcherRoleId=$(cat /proc/sys/kernel/random/uuid)
+declare userRoleId=$(cat /proc/sys/kernel/random/uuid)
 declare adminRoleId=$(cat /proc/sys/kernel/random/uuid)
 declare workspaceReadId=$(cat /proc/sys/kernel/random/uuid)
 declare workspaceWriteId=$(cat /proc/sys/kernel/random/uuid)
@@ -96,12 +96,12 @@ declare existingApiApp=$(get_existing_app "${appName} API")
 if [[ -n ${existingApiApp} ]]; then
 	apiAppObjectId=$(echo ${existingApiApp} | jq -r '.objectId')
 	# Get existing ids of roles and scopes.
-	researcherRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREResearcher").id')
+	userRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREUser").id')
 	adminRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREAdmin").id')
 	workspaceReadId=$(echo "$existingApiApp" | jq -r '.oauth2Permissions[] | select(.value == "Workspace.Read").id')
 	workspaceWriteId=$(echo "$existingApiApp" | jq -r '.oauth2Permissions[] | select(.value == "Workspace.Write").id')
 
-	if [[ -z "${researcherRoleId}" ]]; then researcherRoleId=$(cat /proc/sys/kernel/random/uuid); fi
+	if [[ -z "${userRoleId}" ]]; then userRoleId=$(cat /proc/sys/kernel/random/uuid); fi
 	if [[ -z "${adminRoleId}" ]]; then adminRoleId=$(cat /proc/sys/kernel/random/uuid); fi
 	if [[ -z "${workspaceReadId}" ]]; then workspaceReadId=$(cat /proc/sys/kernel/random/uuid); fi
 	if [[ -z "${workspaceWriteId}" ]]; then workspaceWriteId=$(cat /proc/sys/kernel/random/uuid); fi
@@ -110,13 +110,13 @@ fi
 declare appRoles=$(jq -c . << JSON
 [
 	{
-		"id": "${researcherRoleId}",
+		"id": "${userRoleId}",
 		"allowedMemberTypes": [ "User" ],
 		"description": "Provides access to the ${appName} application.",
-		"displayName": "TRE Researchers",
+		"displayName": "TRE Userss",
 		"isEnabled": true,
 		"origin": "Application",
-		"value": "TREResearcher"
+		"value": "TREUser"
 	},
 	{
 		"id": "${adminRoleId}",


### PR DESCRIPTION
# PR for issue #385 

## What is being addressed

The role TREResearcher is confusing, as a Researcher will not create Workspaces - hence the role does not need to exist in the TRE application registration in Azure AD (only Workspace application registrations).
