### PR TITLE
Fixes processor function App Insights configuration

### DIFF
--- a/processor_function/shared/logging.py
+++ b/processor_function/shared/logging.py
@@ -18,7 +18,7 @@ def initialize_logging(logging_level: int, correlation_id: str) -> logging.Logge
     """
     logger = logging.getLogger()
     logger.addHandler(logging.StreamHandler())  # For logging into console
-    app_insights_instrumentation_key = os.getenv("APP_INSIGHTS_INSTRUMENTATION_KEY")
+    app_insights_instrumentation_key = os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY")
 
     try:
         logger.addHandler(AzureLogHandler(connection_string=f"InstrumentationKey={app_insights_instrumentation_key}"))

--- a/processor_function/shared/logging.py
+++ b/processor_function/shared/logging.py
@@ -18,10 +18,10 @@ def initialize_logging(logging_level: int, correlation_id: str) -> logging.Logge
     """
     logger = logging.getLogger()
     logger.addHandler(logging.StreamHandler())  # For logging into console
-    app_insights_instrumentation_key = os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY")
+    app_insights_connection_string = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
 
     try:
-        logger.addHandler(AzureLogHandler(connection_string=f"InstrumentationKey={app_insights_instrumentation_key}"))
+        logger.addHandler(AzureLogHandler(connection_string=app_insights_connection_string))
     except ValueError as e:
         logger.error(f"Failed to set Application Insights logger handler: {e}")
 

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -106,6 +106,7 @@ module "processor_function" {
   tre_id                                     = var.tre_id
   location                                   = var.location
   resource_group_name                        = azurerm_resource_group.core.name
+  app_insights_connection_string             = azurerm_application_insights.core.connection_string
   app_insights_instrumentation_key           = azurerm_application_insights.core.instrumentation_key
   app_service_plan_id                        = module.api-webapp.app_service_plan_id
   storage_account_name                       = module.storage.storage_account_name

--- a/templates/core/terraform/processor_function/function.tf
+++ b/templates/core/terraform/processor_function/function.tf
@@ -21,7 +21,8 @@ resource "azurerm_function_app" "procesorfunction" {
     FUNCTION_APP_EDIT_MODE                = "readonly"
     FUNCTIONS_EXTENSION_VERSION           = "3"
     RESOURCE_GROUP_NAME                   = var.resource_group_name
-    APP_INSIGHTS_INSTRUMENTATION_KEY      = var.app_insights_instrumentation_key
+    APPLICATIONINSIGHTS_CONNECTION_STRING = var.app_insights_connection_string
+    APPINSIGHTS_INSTRUMENTATIONKEY        = var.app_insights_instrumentation_key
     VNET_NAME                             = var.core_vnet
     ACI_SUBNET                            = var.aci_subnet
     CNAB_AZURE_STATE_STORAGE_ACCOUNT_NAME = var.mgmt_storage_account_name

--- a/templates/core/terraform/processor_function/variables.tf
+++ b/templates/core/terraform/processor_function/variables.tf
@@ -1,6 +1,7 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
+variable "app_insights_connection_string" {}
 variable "app_insights_instrumentation_key" {}
 variable "app_service_plan_id" {}
 variable "storage_account_name" {}


### PR DESCRIPTION
Fixes #387 

## How is this addressed

- Adds the configuration implicitly expected by the Azure Function resource:
  - Application Insights connection string added
  - Application Insights instrumentation key environment variable name changed to match the expected one

In addition, the logging code changed to use the connection string instead of the instrumentation key now that the aforementioned is available as an environment variable.

## Receipts

From "from scratch" deployment:
![Function App Insights blade](https://user-images.githubusercontent.com/1629215/123939811-38276500-d9a1-11eb-8ed7-f51517ae721e.png)

Looking at Monitor blade of the function (compared to the one in bug report) after fresh deployment:
![Monitor blade](https://user-images.githubusercontent.com/1629215/123949465-437f8e00-d9ab-11eb-89ca-d5313f97e380.png)

