### PR TITLE
Add Azure Function Core Tools (func) to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,6 +47,14 @@ RUN export PORTER_HOME=/home/vscode/.porter && curl -L https://cdn.porter.sh/lat
 
 ENV PATH /home/vscode/.porter/:$PATH
 
+# Install Azure Function Core Tools
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+    && sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
+    && sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/debian/$(lsb_release -rs | cut -d'.' -f 1)/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list' \
+    && sudo apt-get update \
+    && sudo apt-get update \
+    && sudo apt-get install azure-functions-core-tools-3
+
 # Install requirements
 COPY ["requirements.txt", "requirements-dev.txt", "/tmp/pip-tmp/" ]
 COPY ["management_api_app/requirements.txt", "/tmp/pip-tmp/management_api_app/" ]


### PR DESCRIPTION
# PR for issue #392 

## What is being addressed

[Azure Function Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Ccsharp%2Cbash) (`func`) added to devcontainer.

## How is this addressed

- Azure Func Core tools v3 for debian install added to .devcontainer/Dockerfile
