### PR TITLE
Fixes App Insights configuration in the management API

### DIFF
--- a/management_api_app/.env.sample
+++ b/management_api_app/.env.sample
@@ -1,9 +1,9 @@
 # API configuration
 # -----------------
-# DEBUG=True                                    # when debug is set to True, debugging information for unhandled exceptions is shown in the swagger UI and logging is more verbose
+# DEBUG=True                                    # When debug is set to True, debugging information for unhandled exceptions is shown in the swagger UI and logging is more verbose
 
-# OAUTH Information - client ids etc. for the AAD Apps
-# ----------------
+# OAUTH information - client ids etc. for the AAD Apps
+# ----------------------------------------------------
 API_CLIENT_ID=__CHANGE_ME__                     # The AppId for the API service principal (TRE API)
 API_CLIENT_SECRET=__CHANGE_ME__                 # The Client secret fo the TRE API application
 SWAGGER_UI_CLIENT_ID=__CHANGE_ME__              # The AppId for the Swagger service principal (TRE Swagger UI)
@@ -21,16 +21,17 @@ STATE_STORE_KEY=__CHANGE_ME__                   # The Cosmos DB access key
 
 # Service bus configuration
 # -------------------------
-SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE=__CHANGE_ME__     # namespace format: <yournamespace>.servicebus.windows.net
+SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE=__CHANGE_ME__     # Namespace format: <yournamespace>.servicebus.windows.net
 SERVICE_BUS_RESOURCE_REQUEST_QUEUE=workspacequeue
 SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE=deploymentstatus
 
 # Logging and monitoring
 # ----------------------
-APPINSIGHTS_INSTRUMENTATIONKEY=                 # Application insight instrumentation key - can be left blank when debugging locally
+APPLICATIONINSIGHTS_CONNECTION_STRING=          # Application Insights connection string - can be left blank when debugging locally
+APPINSIGHTS_INSTRUMENTATIONKEY=                 # Application Insights instrumentation key - can be left blank when debugging locally
 
-# Service Principal for API process identity
-# ----------------------
+# Service principal for API process identity
+# ------------------------------------------
 AZURE_SUBSCRIPTION_ID=__CHANGE_ME__             # Azure subscription
 AZURE_TENANT_ID=__CHANGE_ME__                   # Azure tenant
 AZURE_CLIENT_ID=__CHANGE_ME__                   # The AppId of the Service Principal

--- a/management_api_app/main.py
+++ b/management_api_app/main.py
@@ -4,7 +4,6 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi_utils.tasks import repeat_every
-from opencensus.ext.azure.log_exporter import AzureLogHandler
 from starlette.exceptions import HTTPException
 from starlette.middleware.errors import ServerErrorMiddleware
 

--- a/management_api_app/main.py
+++ b/management_api_app/main.py
@@ -14,6 +14,7 @@ from api.errors.validation_error import http422_error_handler
 from api.errors.generic_error import generic_error_handler
 from core import config
 from core.events import create_start_app_handler, create_stop_app_handler
+from services.logging import disable_unwanted_loggers, initialize_logging
 from service_bus.deployment_status_update import receive_message_and_update_deployment
 
 
@@ -40,46 +41,6 @@ def get_application() -> FastAPI:
     return application
 
 
-def initialize_logging(logging_level: int):
-    """
-    Adds the Application Insights handler for the root logger and sets the given logging level.
-
-    :param logging_level: The logging level to set e.g., logging.WARNING.
-    """
-    logger = logging.getLogger()
-
-    logging.getLogger("azure.core.pipeline.policies.http_logging_policy").disabled = True
-
-    logging.getLogger("azure.eventhub._eventprocessor.event_processor").disabled = True
-
-    logging.getLogger("azure.identity.aio._credentials.managed_identity").disabled = True
-    logging.getLogger("azure.identity.aio._credentials.environment").disabled = True
-    logging.getLogger("azure.identity.aio._internal.get_token_mixin").disabled = True
-    logging.getLogger("azure.identity.aio._internal.decorators").disabled = True
-    logging.getLogger("azure.identity.aio._credentials.chained").disabled = True
-    logging.getLogger("azure.identity").disabled = True
-
-    logging.getLogger("msal.token_cache").disabled = True
-
-    logging.getLogger("uamqp").disabled = True
-    logging.getLogger("uamqp.authentication.cbs_auth_async").disabled = True
-    logging.getLogger("uamqp.async_ops.client_async").disabled = True
-    logging.getLogger("uamqp.async_ops.connection_async").disabled = True
-    logging.getLogger("uamqp.async_ops").disabled = True
-    logging.getLogger("uamqp.authentication").disabled = True
-    logging.getLogger("uamqp.c_uamqp").disabled = True
-    logging.getLogger("uamqp.connection").disabled = True
-    logging.getLogger("uamqp.receiver").disabled = True
-
-    try:
-        logger.addHandler(AzureLogHandler(connection_string=f"InstrumentationKey={config.APP_INSIGHTS_INSTRUMENTATION_KEY}"))
-    except ValueError:
-        logger.error("Application Insights instrumentation key missing or invalid")
-
-    logging.basicConfig(level=logging_level)
-    logger.setLevel(logging_level)
-
-
 app = get_application()
 
 
@@ -89,6 +50,8 @@ async def initialize_logging_on_startup():
         initialize_logging(logging.DEBUG)
     else:
         initialize_logging(logging.INFO)
+
+    disable_unwanted_loggers()
 
 
 @app.on_event("startup")

--- a/management_api_app/services/logging.py
+++ b/management_api_app/services/logging.py
@@ -1,0 +1,72 @@
+import logging
+import os
+
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+from opencensus.trace import config_integration
+from opencensus.trace.samplers import AlwaysOnSampler
+from opencensus.trace.tracer import Tracer
+from typing import List
+
+
+UNWANTED_LOGGERS = [
+    "azure.core.pipeline.policies.http_logging_policy",
+    "azure.eventhub._eventprocessor.event_processor",
+    "azure.identity.aio._credentials.managed_identity",
+    "azure.identity.aio._credentials.environment",
+    "azure.identity.aio._internal.get_token_mixin",
+    "azure.identity.aio._internal.decorators",
+    "azure.identity.aio._credentials.chained",
+    "azure.identity",
+    "msal.token_cache",
+    "uamqp",
+    "uamqp.authentication.cbs_auth_async",
+    "uamqp.async_ops.client_async",
+    "uamqp.async_ops.connection_async",
+    "uamqp.async_ops",
+    "uamqp.authentication",
+    "uamqp.c_uamqp",
+    "uamqp.connection",
+    "uamqp.receiver"
+]
+
+
+def disable_unwanted_loggers():
+    """
+    Disables the unwanted loggers.
+    """
+    for logger_name in UNWANTED_LOGGERS:
+        logging.getLogger(logger_name).disabled = True
+
+
+def initialize_logging(logging_level: int, correlation_id: str) -> logging.LoggerAdapter:
+    """
+    Adds the Application Insights handler for the root logger and sets the given logging level.
+    Creates and returns a logger adapter that integrates the correlation ID, if given, to the log messages.
+
+    :param logging_level: The logging level to set e.g., logging.WARNING.
+    :param correlation_id: Optional. The correlation ID that is passed on to the operation_Id in App Insights.
+    :returns: A newly created logger adapter.
+    """
+    logger = logging.getLogger()
+    logger.addHandler(logging.StreamHandler())  # For logging into console
+    app_insights_connection_string = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
+
+    try:
+        logger.addHandler(AzureLogHandler(connection_string=app_insights_connection_string))
+    except ValueError as e:
+        logger.error(f"Failed to set Application Insights logger handler: {e}")
+
+    config_integration.trace_integrations(['logging'])
+    logging.basicConfig(level=logging_level, format='%(asctime)s traceId=%(traceId)s spanId=%(spanId)s %(message)s')
+    Tracer(sampler=AlwaysOnSampler())
+    logger.setLevel(logging_level)
+
+    extra = None
+
+    if correlation_id:
+        extra = {'traceId': correlation_id}
+
+    adapter = logging.LoggerAdapter(logger, extra)
+    adapter.debug(f"Logger adapter initialized with extra: {extra}")
+
+    return adapter

--- a/management_api_app/services/logging.py
+++ b/management_api_app/services/logging.py
@@ -5,7 +5,6 @@ from opencensus.ext.azure.log_exporter import AzureLogHandler
 from opencensus.trace import config_integration
 from opencensus.trace.samplers import AlwaysOnSampler
 from opencensus.trace.tracer import Tracer
-from typing import List
 
 
 UNWANTED_LOGGERS = [

--- a/management_api_app/services/logging.py
+++ b/management_api_app/services/logging.py
@@ -38,7 +38,7 @@ def disable_unwanted_loggers():
         logging.getLogger(logger_name).disabled = True
 
 
-def initialize_logging(logging_level: int, correlation_id: str) -> logging.LoggerAdapter:
+def initialize_logging(logging_level: int, correlation_id: str = None) -> logging.LoggerAdapter:
     """
     Adds the Application Insights handler for the root logger and sets the given logging level.
     Creates and returns a logger adapter that integrates the correlation ID, if given, to the log messages.

--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -20,25 +20,27 @@ resource "azurerm_app_service" "management_api" {
   https_only          = true
 
   app_settings = {
-    "APPINSIGHTS_INSTRUMENTATIONKEY" = var.app_insights_instrumentation_key
-    "WEBSITES_PORT"                  = "8000"
-    "WEBSITE_VNET_ROUTE_ALL"         = 1
-
-    "DOCKER_REGISTRY_SERVER_USERNAME"       = var.docker_registry_username
-    "DOCKER_REGISTRY_SERVER_URL"            = "https://${var.docker_registry_server}"
-    "DOCKER_REGISTRY_SERVER_PASSWORD"       = var.docker_registry_password
-    "STATE_STORE_ENDPOINT"                  = var.state_store_endpoint
-    "STATE_STORE_KEY"                       = var.state_store_key
-    "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE" = "sb-${var.tre_id}.servicebus.windows.net"
-    "SERVICE_BUS_RESOURCE_REQUEST_QUEUE"    = var.service_bus_resource_request_queue
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"      = var.app_insights_connection_string
+    "APPINSIGHTS_INSTRUMENTATIONKEY"             = var.app_insights_instrumentation_key
+    "ApplicationInsightsAgent_EXTENSION_VERSION" = "~3"
+    "XDT_MicrosoftApplicationInsights_Mode"      = "default"
+    "WEBSITES_PORT"                              = "8000"
+    "WEBSITE_VNET_ROUTE_ALL"                     = 1
+    "DOCKER_REGISTRY_SERVER_USERNAME"            = var.docker_registry_username
+    "DOCKER_REGISTRY_SERVER_URL"                 = "https://${var.docker_registry_server}"
+    "DOCKER_REGISTRY_SERVER_PASSWORD"            = var.docker_registry_password
+    "STATE_STORE_ENDPOINT"                       = var.state_store_endpoint
+    "STATE_STORE_KEY"                            = var.state_store_key
+    "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE"      = "sb-${var.tre_id}.servicebus.windows.net"
+    "SERVICE_BUS_RESOURCE_REQUEST_QUEUE"         = var.service_bus_resource_request_queue
     "SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE" = var.service_bus_deployment_status_update_queue
-    "MANAGED_IDENTITY_CLIENT_ID"            = var.managed_identity.client_id
-    "TRE_ID"                                = var.tre_id
-    "RESOURCE_LOCATION"                     = var.location
-    "SWAGGER_UI_CLIENT_ID"                  = var.swagger_ui_client_id
-    "AAD_TENANT_ID"                         = var.aad_tenant_id
-    "API_CLIENT_ID"                         = var.api_client_id
-    "API_CLIENT_SECRET"                     = var.api_client_secret
+    "MANAGED_IDENTITY_CLIENT_ID"                 = var.managed_identity.client_id
+    "TRE_ID"                                     = var.tre_id
+    "RESOURCE_LOCATION"                          = var.location
+    "SWAGGER_UI_CLIENT_ID"                       = var.swagger_ui_client_id
+    "AAD_TENANT_ID"                              = var.aad_tenant_id
+    "API_CLIENT_ID"                              = var.api_client_id
+    "API_CLIENT_SECRET"                          = var.api_client_secret
   }
 
   identity {

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -5,6 +5,7 @@ variable "web_app_subnet" {}
 variable "core_vnet" {}
 variable "shared_subnet" {}
 variable "app_gw_subnet" {}
+variable "app_insights_connection_string" {}
 variable "app_insights_instrumentation_key" {}
 variable "log_analytics_workspace_id" {}
 variable "management_api_image_repository" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -74,6 +74,7 @@ module "api-webapp" {
   shared_subnet                              = module.network.shared
   app_gw_subnet                              = module.network.app_gw
   core_vnet                                  = module.network.core
+  app_insights_connection_string             = azurerm_application_insights.core.connection_string
   app_insights_instrumentation_key           = azurerm_application_insights.core.instrumentation_key
   log_analytics_workspace_id                 = azurerm_log_analytics_workspace.core.id
   management_api_image_repository            = var.management_api_image_repository


### PR DESCRIPTION
Fixes #389 

## How is this addressed

- Adds Application Insights connection string to API configuration
- Adds additional Application Insights configuration to API environment:
  - `"ApplicationInsightsAgent_EXTENSION_VERSION" = "~3"`
  - `"XDT_MicrosoftApplicationInsights_Mode" = "default"`

In addition, refactors logging code in API.
