### PR TITLE
Python script to register application for a workspace.

### DIFF
--- a/scripts/workspace-app-reg.py
+++ b/scripts/workspace-app-reg.py
@@ -1,180 +1,191 @@
 #!/usr/local/bin/python3
 
-import sys, getopt, uuid
+import getopt
+import sys
+import uuid
 
 from azure.identity import AzureCliCredential
 from msgraph.core import GraphClient
 from requests.exceptions import HTTPError
-from requests.adapters import Response
+
 
 def usage():
-  print('workspace-app-reg.py -n <tre-name> -w <workspace-name>')
+    print('workspace-app-reg.py -n <tre-name> -w <workspace-name>')
 
 me: dict = None
 
+
 class Options:
-  tre_name: str = None
-  workspace_name: str = None
-  app_name: str = None
-  force: bool = False
+    tre_name: str = None
+    workspace_name: str = None
+    app_name: str = None
+    force: bool = False
+
 
 options = Options()
 
 class GraphError(Exception):
-  def __init__(self, error: dict):
-   self.code: str = error['error']['code']
-   self.message: str = error['error']['message']
-   self.innerError: dict = error['error']['innerError']
+    def __init__(self, error: dict):
+        self.code: str = error['error']['code']
+        self.message: str = error['error']['message']
+        self.innerError: dict = error['error']['innerError']
+
 
 class CliGraphClient(GraphClient):
-  def __init__(self):
-    super().__init__(credential=AzureCliCredential(), scopes=['https://graph.microsoft.com/.default'])
+    def __init__(self):
+        super().__init__(credential=AzureCliCredential(), scopes=['https://graph.microsoft.com/.default'])
 
-  def get(self, url: str, **kwargs):
-    resp = super().get(url, **kwargs)
+    def get(self, url: str, **kwargs):
+        resp = super().get(url, **kwargs)
 
-    try:
-      resp.raise_for_status()
-    except HTTPError:
-      raise GraphError(resp.json())
+        try:
+            resp.raise_for_status()
+        except HTTPError:
+            raise GraphError(resp.json())
 
-    json = resp.json()
+        json = resp.json()
 
-    if 'value' in json:
-      return json['value']
+        if 'value' in json:
+            return json['value']
 
-    return json
+        return json
+
 
 graph = CliGraphClient()
 
 def _get_commandline_options(argv):
-  global options
+    global options
 
-  try:
-    opts, _ = getopt.getopt(argv, "hn:w:f", ["tre-name=", "workspace-name=", "force"])
-  except getopt.GetoptError:
-    usage()
-    sys.exit(2)
+    try:
+        opts, _ = getopt.getopt(argv, "hn:w:f", ["tre-name=", "workspace-name=", "force"])
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
 
-  for opt, arg in opts:
-    if opt == '-h':
-      usage()
-      sys.exit()
-    elif opt == '-f':
-      options.force = True
-    elif opt in ("-n", "--tre-name"):
-      options.tre_name = arg
-    elif opt in ("-w", "--workspace-name"):
-      options.workspace_name = arg
+    for opt, arg in opts:
+        if opt == '-h':
+            usage()
+            sys.exit()
+        elif opt == '-f':
+            options.force = True
+        elif opt in ("-n", "--tre-name"):
+            options.tre_name = arg
+        elif opt in ("-w", "--workspace-name"):
+            options.workspace_name = arg
 
-  if options.tre_name == None or options.workspace_name == None:
-    usage()
-    sys.exit(2)
+    if options.tre_name == None or options.workspace_name == None:
+        usage()
+        sys.exit(2)
 
-  options.app_name = f"{options.tre_name} Workspace - {options.workspace_name}"
+    options.app_name = f"{options.tre_name} Workspace - {options.workspace_name}"
+
 
 def get_existing_app(name: str) -> dict:
-  apps = graph.get(f"/applications?$filter=displayName eq '{name}'")
+    apps = graph.get(f"/applications?$filter=displayName eq '{name}'")
 
-  if len(apps) > 1:
-    print(f"There are more than one applications with the name \"{name}\" already.")
-    sys.exit(1)
+    if len(apps) > 1:
+        print(f"There are more than one applications with the name \"{name}\" already.")
+        sys.exit(1)
 
-  if len(apps) == 1:
-    return apps[0]
+    if len(apps) == 1:
+        return apps[0]
 
-  return None
+    return None
+
 
 def _double_check():
-  domains = graph.get("/domains")
-  for d in domains:
-    if d['isDefault']:
-      domain = d['id']
-      break
+    domains = graph.get("/domains")
+    for d in domains:
+        if d['isDefault']:
+            domain = d['id']
+            break
 
-  cont = input(f"You are about to create app registrations in the Azure AD Tenant \"{domain}\", signed in as \"{me['displayName']}\"\nDo you want to continue? (y/N) ")
+    cont = input(f"You are about to create app registrations in the Azure AD Tenant \"{domain}\", signed in as \"{me['displayName']}\"\nDo you want to continue? (y/N) ")
 
-  if cont.lower() != "y" and cont.lower() != "yes":
-    sys.exit(0)
+    if cont.lower() != "y" and cont.lower() != "yes":
+        sys.exit(0)
+
 
 def ensure_sp(appId: str):
-  sps = graph.get(f"/servicePrincipals?$filter=appid eq '{appId}'")
-  if len(sps) == 0:
-    graph.post("/servicePrincipals", json={
-        "appId": appId,
-        "appRoleAssignmentRequired": True,
-        "tags": ['WindowsAzureActiveDirectoryIntegratedApp'],
-      }, headers={'Content-Type': 'application/json'})
- 
+    sps = graph.get(f"/servicePrincipals?$filter=appid eq '{appId}'")
+    if len(sps) == 0:
+        graph.post("/servicePrincipals", json = {
+            "appId": appId,
+            "appRoleAssignmentRequired": True,
+            "tags": ['WindowsAzureActiveDirectoryIntegratedApp'],
+        }, headers={'Content-Type': 'application/json'})
+
+
 def main():
-  global me
-  me = graph.get("/me")
+    global me
+    me = graph.get("/me")
 
-  if not options.force:
-    _double_check()
+    if not options.force:
+        _double_check()
 
-  existing_app = get_existing_app(options.app_name)
+    existing_app = get_existing_app(options.app_name)
 
-  # Generate new Guids if needed
-  ownerRoleId = str(uuid.uuid4())
-  researcherRoleId = str(uuid.uuid4())
+    # Generate new Guids if needed
+    ownerRoleId = str(uuid.uuid4())
+    researcherRoleId = str(uuid.uuid4())
 
-  # Get existing role and scope ids (in case we are updating the existing app)
-  if existing_app is not None:
-    ownerRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceOwner' ][0]
-    researcherRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceResearcher' ][0]
+    # Get existing role and scope ids (in case we are updating the existing app)
+    if existing_app is not None:
+        ownerRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceOwner' ][0]
+        researcherRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceResearcher' ][0]
 
-  appRoles = [
-    {
-      "id": researcherRoleId,
-      "allowedMemberTypes": [ "User" ],
-      "description": f"Provides access to the {options.tre_name} workspace {options.workspace_name}.",
-      "displayName": "Researchers",
-      "isEnabled": True,
-      "origin": "Application",
-      "value": "WorkspaceResearcher"
-    },
-    {
-      "id": ownerRoleId,
-      "allowedMemberTypes": [ "User" ],
-      "description": f"Provides ownership access to the {options.tre_name} workspace {options.workspace_name}.",
-      "displayName": "Owners",
-      "isEnabled": True,
-      "origin": "Application",
-      "value": "WorkspaceOwner"
+    appRoles = [
+        {
+            "id": researcherRoleId,
+            "allowedMemberTypes": [ "User" ],
+            "description": f"Provides access to the {options.tre_name} workspace {options.workspace_name}.",
+            "displayName": "Researchers",
+            "isEnabled": True,
+            "origin": "Application",
+            "value": "WorkspaceResearcher"
+        },
+        {
+            "id": ownerRoleId,
+            "allowedMemberTypes": [ "User" ],
+            "description": f"Provides ownership access to the {options.tre_name} workspace {options.workspace_name}.",
+            "displayName": "Owners",
+            "isEnabled": True,
+            "origin": "Application",
+            "value": "WorkspaceOwner"
+        }
+    ]
+
+    # Define the API application
+    apiApp = {
+        "displayName": options.app_name,
+        "appRoles": appRoles,
+        "signInAudience": "AzureADMyOrg"
     }
-  ]
 
-  # Define the API application
-  apiApp = {
-    "displayName": options.app_name,
-    "appRoles": appRoles,
-    "signInAudience": "AzureADMyOrg"
-  }
-
-  if existing_app is not None:
-    apiAppId = existing_app['appId']
-    # Update
-    resp = graph.patch(f"/applications/{existing_app['id']}", json=apiApp, headers={'Content-Type': 'application/json'})
-    if resp.ok:
-      print(f"Updated application \"{existing_app['displayName']}\" (appid={apiAppId})")
+    if existing_app is not None:
+        apiAppId = existing_app['appId']
+        # Update
+        resp = graph.patch(f"/applications/{existing_app['id']}", json=apiApp, headers={'Content-Type': 'application/json'})
+        if resp.ok:
+            print(f"Updated application \"{existing_app['displayName']}\" (appid={apiAppId})")
+        else:
+            content = resp.json()
+            print(content)
     else:
-      content = resp.json()
-      print(content)
-  else:
-    # Create
-    resp = graph.post(f"/applications", json=apiApp, headers={'Content-Type': 'application/json'})
-    content = resp.json()
-    if resp.ok:
-      apiAppId = content['appId']
-      print(f"Created application \"{content['displayName']}\" (appid={apiAppId})")
-      graph.post(f"/applications/{content['id']}/owners/$ref")
-    else:
-      print(content)
+        # Create
+        resp = graph.post(f"/applications", json=apiApp, headers={'Content-Type': 'application/json'})
+        content = resp.json()
+        if resp.ok:
+            apiAppId = content['appId']
+            print(f"Created application \"{content['displayName']}\" (appid={apiAppId})")
+            graph.post(f"/applications/{content['id']}/owners/$ref")
+        else:
+            print(content)
 
-  if apiAppId is not None and len(apiAppId) != 0:
-    ensure_sp(apiAppId)
+    if apiAppId is not None and len(apiAppId) != 0:
+        ensure_sp(apiAppId)
+
 
 if __name__ == "__main__":
-  _get_commandline_options(sys.argv[1:])
-  main()
+    _get_commandline_options(sys.argv[1:])
+    main()

--- a/scripts/workspace-app-reg.py
+++ b/scripts/workspace-app-reg.py
@@ -12,6 +12,7 @@ from requests.exceptions import HTTPError
 def usage():
     print('workspace-app-reg.py -n <tre-name> -w <workspace-name>')
 
+
 me: dict = None
 
 
@@ -23,6 +24,7 @@ class Options:
 
 
 options = Options()
+
 
 class GraphError(Exception):
     def __init__(self, error: dict):
@@ -53,6 +55,7 @@ class CliGraphClient(GraphClient):
 
 graph = CliGraphClient()
 
+
 def _get_commandline_options(argv):
     global options
 
@@ -73,7 +76,7 @@ def _get_commandline_options(argv):
         elif opt in ("-w", "--workspace-name"):
             options.workspace_name = arg
 
-    if options.tre_name == None or options.workspace_name == None:
+    if options.tre_name is None or options.workspace_name is None:
         usage()
         sys.exit(2)
 
@@ -109,7 +112,7 @@ def _double_check():
 def ensure_sp(appId: str):
     sps = graph.get(f"/servicePrincipals?$filter=appid eq '{appId}'")
     if len(sps) == 0:
-        graph.post("/servicePrincipals", json = {
+        graph.post("/servicePrincipals", json={
             "appId": appId,
             "appRoleAssignmentRequired": True,
             "tags": ['WindowsAzureActiveDirectoryIntegratedApp'],
@@ -131,13 +134,13 @@ def main():
 
     # Get existing role and scope ids (in case we are updating the existing app)
     if existing_app is not None:
-        ownerRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceOwner' ][0]
-        researcherRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceResearcher' ][0]
+        ownerRoleId = [r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceOwner'][0]
+        researcherRoleId = [r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceResearcher'][0]
 
     appRoles = [
         {
             "id": researcherRoleId,
-            "allowedMemberTypes": [ "User" ],
+            "allowedMemberTypes": ["User"],
             "description": f"Provides access to the {options.tre_name} workspace {options.workspace_name}.",
             "displayName": "Researchers",
             "isEnabled": True,
@@ -146,7 +149,7 @@ def main():
         },
         {
             "id": ownerRoleId,
-            "allowedMemberTypes": [ "User" ],
+            "allowedMemberTypes": ["User"],
             "description": f"Provides ownership access to the {options.tre_name} workspace {options.workspace_name}.",
             "displayName": "Owners",
             "isEnabled": True,

--- a/scripts/workspace-app-reg.py
+++ b/scripts/workspace-app-reg.py
@@ -1,0 +1,180 @@
+#!/usr/local/bin/python3
+
+import sys, getopt, uuid
+
+from azure.identity import AzureCliCredential
+from msgraph.core import GraphClient
+from requests.exceptions import HTTPError
+from requests.adapters import Response
+
+def usage():
+  print('workspace-app-reg.py -n <tre-name> -w <workspace-name>')
+
+me: dict = None
+
+class Options:
+  tre_name: str = None
+  workspace_name: str = None
+  app_name: str = None
+  force: bool = False
+
+options = Options()
+
+class GraphError(Exception):
+  def __init__(self, error: dict):
+   self.code: str = error['error']['code']
+   self.message: str = error['error']['message']
+   self.innerError: dict = error['error']['innerError']
+
+class CliGraphClient(GraphClient):
+  def __init__(self):
+    super().__init__(credential=AzureCliCredential(), scopes=['https://graph.microsoft.com/.default'])
+
+  def get(self, url: str, **kwargs):
+    resp = super().get(url, **kwargs)
+
+    try:
+      resp.raise_for_status()
+    except HTTPError:
+      raise GraphError(resp.json())
+
+    json = resp.json()
+
+    if 'value' in json:
+      return json['value']
+
+    return json
+
+graph = CliGraphClient()
+
+def _get_commandline_options(argv):
+  global options
+
+  try:
+    opts, _ = getopt.getopt(argv, "hn:w:f", ["tre-name=", "workspace-name=", "force"])
+  except getopt.GetoptError:
+    usage()
+    sys.exit(2)
+
+  for opt, arg in opts:
+    if opt == '-h':
+      usage()
+      sys.exit()
+    elif opt == '-f':
+      options.force = True
+    elif opt in ("-n", "--tre-name"):
+      options.tre_name = arg
+    elif opt in ("-w", "--workspace-name"):
+      options.workspace_name = arg
+
+  if options.tre_name == None or options.workspace_name == None:
+    usage()
+    sys.exit(2)
+
+  options.app_name = f"{options.tre_name} Workspace - {options.workspace_name}"
+
+def get_existing_app(name: str) -> dict:
+  apps = graph.get(f"/applications?$filter=displayName eq '{name}'")
+
+  if len(apps) > 1:
+    print(f"There are more than one applications with the name \"{name}\" already.")
+    sys.exit(1)
+
+  if len(apps) == 1:
+    return apps[0]
+
+  return None
+
+def _double_check():
+  domains = graph.get("/domains")
+  for d in domains:
+    if d['isDefault']:
+      domain = d['id']
+      break
+
+  cont = input(f"You are about to create app registrations in the Azure AD Tenant \"{domain}\", signed in as \"{me['displayName']}\"\nDo you want to continue? (y/N) ")
+
+  if cont.lower() != "y" and cont.lower() != "yes":
+    sys.exit(0)
+
+def ensure_sp(appId: str):
+  sps = graph.get(f"/servicePrincipals?$filter=appid eq '{appId}'")
+  if len(sps) == 0:
+    graph.post("/servicePrincipals", json={
+        "appId": appId,
+        "appRoleAssignmentRequired": True,
+        "tags": ['WindowsAzureActiveDirectoryIntegratedApp'],
+      }, headers={'Content-Type': 'application/json'})
+ 
+def main():
+  global me
+  me = graph.get("/me")
+
+  if not options.force:
+    _double_check()
+
+  existing_app = get_existing_app(options.app_name)
+
+  # Generate new Guids if needed
+  ownerRoleId = str(uuid.uuid4())
+  researcherRoleId = str(uuid.uuid4())
+
+  # Get existing role and scope ids (in case we are updating the existing app)
+  if existing_app is not None:
+    ownerRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceOwner' ][0]
+    researcherRoleId = [ r['id'] for r in existing_app['appRoles'] if r['value'] == 'WorkspaceResearcher' ][0]
+
+  appRoles = [
+    {
+      "id": researcherRoleId,
+      "allowedMemberTypes": [ "User" ],
+      "description": f"Provides access to the {options.tre_name} workspace {options.workspace_name}.",
+      "displayName": "Researchers",
+      "isEnabled": True,
+      "origin": "Application",
+      "value": "WorkspaceResearcher"
+    },
+    {
+      "id": ownerRoleId,
+      "allowedMemberTypes": [ "User" ],
+      "description": f"Provides ownership access to the {options.tre_name} workspace {options.workspace_name}.",
+      "displayName": "Owners",
+      "isEnabled": True,
+      "origin": "Application",
+      "value": "WorkspaceOwner"
+    }
+  ]
+
+  # Define the API application
+  apiApp = {
+    "displayName": options.app_name,
+    "appRoles": appRoles,
+    "signInAudience": "AzureADMyOrg"
+  }
+
+  if existing_app is not None:
+    apiAppId = existing_app['appId']
+    # Update
+    resp = graph.patch(f"/applications/{existing_app['id']}", json=apiApp, headers={'Content-Type': 'application/json'})
+    if resp.ok:
+      print(f"Updated application \"{existing_app['displayName']}\" (appid={apiAppId})")
+    else:
+      content = resp.json()
+      print(content)
+  else:
+    # Create
+    resp = graph.post(f"/applications", json=apiApp, headers={'Content-Type': 'application/json'})
+    content = resp.json()
+    if resp.ok:
+      apiAppId = content['appId']
+      print(f"Created application \"{content['displayName']}\" (appid={apiAppId})")
+      graph.post(f"/applications/{content['id']}/owners/$ref")
+    else:
+      print(content)
+
+  if apiAppId is not None and len(apiAppId) != 0:
+    ensure_sp(apiAppId)
+
+if __name__ == "__main__":
+  _get_commandline_options(sys.argv[1:])
+  main()

--- a/scripts/workspace-app-reg.py
+++ b/scripts/workspace-app-reg.py
@@ -176,7 +176,7 @@ def main():
             print(content)
     else:
         # Create
-        resp = graph.post(f"/applications", json=apiApp, headers={'Content-Type': 'application/json'})
+        resp = graph.post("/applications", json=apiApp, headers={'Content-Type': 'application/json'})
         content = resp.json()
         if resp.ok:
             apiAppId = content['appId']


### PR DESCRIPTION
# PR for issue #211

The app registration in Azure AD required for authenticating a workspace will be created manually and then the app id passed to the create workspace API.

This PR has a Python script that can be used to create the app registration in Azure AD.

`workspace-app-reg.py -n <tre-name> -w <workspace-name>`

The option `--tre-name` or `-n` should be the name of the TRE, i.e. `"TRE"`
The option `--workspace-name` or `-w` should be the name of the workspace.

Both TRE name and workspace name are required.

The script uses the current Azure CLI credentials to call into Microsoft Graph. It will display the name of the tenant and the name of the signed in user and ask for confirmation. For example:
```
vscode ➜ /workspaces/tre (askew/task-211 ✗) $ ./scripts/workspace-app-reg.py -n TRE -w "Test Workspace"
You are about to create app registrations in the Azure AD Tenant "researchenv.onmicrosoft.com", signed in as "Stephen Askew"
Do you want to continue? (y/N) 
```

This prompt can be skipped using the option `--force` or  `-f`.