### PR TITLE
Refactor porter bundles to simplify dependencies.

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -5,7 +5,7 @@ on:
     # 1am each night https://crontab.guru/#0_1_*_*_*
     - cron: "0 1 * * *"
   push:
-    branches: [ develop, main ]
+    branches: [ develop, main, marrobi/issue350-5 ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -5,7 +5,7 @@ on:
     # 1am each night https://crontab.guru/#0_1_*_*_*
     - cron: "0 1 * * *"
   push:
-    branches: [ develop, main, marrobi/issue350-5 ]
+    branches: [ develop, main ]
   workflow_dispatch:
 
 jobs:

--- a/workspaces/azureml_devtestlabs/install_service_azureml.sh
+++ b/workspaces/azureml_devtestlabs/install_service_azureml.sh
@@ -4,7 +4,7 @@ set -e
 export AZUREML_WORKSPACE_NAME=$(porter installations output show azureml_workspace_name -i service-azureml_devtestlabs | tr -d '"')
 export AZUREML_ACR_ID=$(porter installations output show azureml_acr_id -i service-azureml_devtestlabs | tr -d '"')
 
-porter install --reference "${ACR_NAME}.azurecr.io/tre-service-innereye-deeplearning:v0.1.0" \
+porter install tre-service-azureml --reference "${ACR_NAME}.azurecr.io/tre-service-azureml:v0.1.2" \
     --cred ./azure.json \
-    --parameter-set ./parameters_service_innereye-deeplearning.json \
+    --parameter-set ./parameters_service_azureml.json \
     --debug

--- a/workspaces/azureml_devtestlabs/install_service_devtestlabs.sh
+++ b/workspaces/azureml_devtestlabs/install_service_devtestlabs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+porter install tre-service-innereye-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
+    --cred ./azure.json \
+    --parameter-set ./parameters_service_devtestlabs.json \
+    --debug

--- a/workspaces/azureml_devtestlabs/install_workspace_vanilla.sh
+++ b/workspaces/azureml_devtestlabs/install_workspace_vanilla.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+porter install tre-workspace-vanilla --reference "${ACR_NAME}.azurecr.io/tre-workspace-vanilla:v0.1.0" \
+    --cred ./azure.json \
+    --parameter-set ./parameters_workspace_vanilla.json \
+    --debug

--- a/workspaces/azureml_devtestlabs/porter.yaml
+++ b/workspaces/azureml_devtestlabs/porter.yaml
@@ -60,7 +60,6 @@ outputs:
 mixins:
   - exec
   - docker
-
 install:
   - exec:
       description: "docker login"
@@ -72,65 +71,14 @@ install:
         u: "{{ bundle.credentials.azure_client_id }}"
         p: "{{ bundle.credentials.azure_client_secret }}"
   - exec:
-      description: "Install vanilla workspace"
-      command: porter
-      arguments:
-        - install
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-workspace-vanilla:v0.1.0"
-        cred: ./azure.json
-        parameter-set: ./parameters_workspace_vanilla.json
-        debug:
+      description: "Install Vanilla Workspace service"
+      command: ./install_workspace_vanilla.sh
   - exec:
-      description: "Install Azure ML Service"
-      command: porter
-      arguments:
-        - install
-        - service-azureml
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-service-azureml:v0.1.2"
-        cred: ./azure.json
-        parameter-set: ./parameters_service_azureml.json
-        debug:
+      description: "Install DevTestLabs service"
+      command: ./install_service_devtestlabs.sh
   - exec:
-      description: "Get Azure ML Service Outputs"
-      command: porter
-      arguments:
-        - installations
-        - output
-        - show
-        - azureml_workspace_name
-      flags:
-        i: service-azureml
-      outputs:
-        - name: azureml_workspace_name
-          regex: (.*)
-  - exec:
-      description: "Get Azure ML Service Outputs"
-      command: porter
-      arguments:
-        - installations
-        - output
-        - show
-        - azureml_acr_id
-      flags:
-        i: service-azureml
-      outputs:
-        - name: azureml_acr_id
-          regex: (.*)
-  - exec:
-      description: "Install Dev Test Labs Virtual Desktop Service"
-      command: porter
-      arguments:
-        - install
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-service-devtestlabs:v0.1.0"
-        cred: ./azure.json
-        parameter-set: ./parameters_service_devtestlabs.json
-        debug:
+      description: "Install Azure ML service"
+      command: ./install_service_azureml.sh
 
 upgrade:
   - exec:
@@ -139,45 +87,9 @@ upgrade:
       arguments:
         - "This workspace does not implement upgrade action"
 
-# TODO: uninstall does not work at present, will need remote porter state
-uninstall:
-  - exec:
-      description: "docker login"
-      command: docker
+uninstall:  
+- exec:
+      description: "Uninstall workspace"
+      command: echo
       arguments:
-        - login
-        - "{{ bundle.parameters.acr_name }}.azurecr.io"
-      flags:
-        u: "{{ bundle.credentials.azure_client_id }}"
-        p: "{{ bundle.credentials.azure_client_secret }}"
-  - exec:
-      description: "Uninstall Dev Test Labs Virtual Desktop Service"
-      command: porter
-      arguments:
-        - uninstall
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-service-devtestlabs:v0.1.0"
-        cred: ./azure.json
-        parameter-set: ./parameters_service_devtestlabs.json
-  - exec:
-        description: "Uninstall Azure ML service"
-        command: porter
-        arguments:
-          - uninstall
-        flags:
-          d: "{{ bundle.parameters.porter_driver }}"
-          reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-service-azureml:v0.1.2"
-          cred: ./azure.json
-          parameter-set: ./parameters.json
-
-  - exec:
-      description: "Uninstall vanilla workspace"
-      command: porter
-      arguments:
-        - uninstall
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-workspace-vanilla:v0.1.0"
-        cred: ./azure.json
-        parameter-set: ./parameters_workspace_vanilla.json
+        - "This workspace does not implement uninstall action"

--- a/workspaces/azureml_devtestlabs/porter.yaml
+++ b/workspaces/azureml_devtestlabs/porter.yaml
@@ -51,12 +51,6 @@ parameters:
     type: string
     description: "The porter driver - azure or docker"
 
-outputs:
-  - name: azureml_workspace_name
-    type: string
-  - name: azureml_acr_id
-    type: string
-
 mixins:
   - exec
   - docker

--- a/workspaces/innereye_deeplearning/install_service_azureml.sh
+++ b/workspaces/innereye_deeplearning/install_service_azureml.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export AZUREML_WORKSPACE_NAME=$(porter installations output show azureml_workspace_name -i service-azureml_devtestlabs | tr -d '"')
+export AZUREML_ACR_ID=$(porter installations output show azureml_acr_id -i service-azureml_devtestlabs | tr -d '"')
+
+porter install tre-service-azureml --reference "${ACR_NAME}.azurecr.io/tre-service-azureml:v0.1.2" \
+    --cred ./azure.json \
+    --parameter-set ./parameters_service_azureml.json \
+    --debug

--- a/workspaces/innereye_deeplearning/install_service_devtestlabs.sh
+++ b/workspaces/innereye_deeplearning/install_service_devtestlabs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+porter install tre-service-innereye-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
+    --cred ./azure.json \
+    --parameter-set ./parameters_service_devtestlabs.json \
+    --debug

--- a/workspaces/innereye_deeplearning/install_service_innereye_deeplearning.sh
+++ b/workspaces/innereye_deeplearning/install_service_innereye_deeplearning.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export AZUREML_WORKSPACE_NAME=$(porter installations output show azureml_workspace_name -i tre-service-azureml | tr -d '"')
+export AZUREML_ACR_ID=$(porter installations output show azureml_acr_id -i tre-service-azureml | tr -d '"')
+
+porter install tre-service-innereye-deeplearning --reference "${ACR_NAME}.azurecr.io/tre-service-innereye-deeplearning:v0.1.0" \
+    --cred ./azure.json \
+    --parameter-set ./parameters_service_innereye-deeplearning.json \
+    --debug

--- a/workspaces/innereye_deeplearning/install_workspace_vanilla.sh
+++ b/workspaces/innereye_deeplearning/install_workspace_vanilla.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+porter install tre-workspace-vanilla --reference "${ACR_NAME}.azurecr.io/tre-workspace-vanilla:v0.1.0" \
+    --cred ./azure.json \
+    --parameter-set ./parameters_workspace_vanilla.json \
+    --debug

--- a/workspaces/innereye_deeplearning/parameters_service_azureml.json
+++ b/workspaces/innereye_deeplearning/parameters_service_azureml.json
@@ -1,27 +1,9 @@
 {
   "schemaVersion": "1.0.0-DRAFT+TODO",
-  "name": "workspace-azureml_devtestlabs",
+  "name": "service-azureml",
   "created": "2021-06-03T11:54:54.0225968Z",
   "modified": "2021-06-03T11:54:54.0225968Z",
   "parameters": [
-    {
-      "name": "address_space",
-      "source": {
-        "env": "ADDRESS_SPACE"
-      }
-    },
-    {
-      "name": "tre_id",
-      "source": {
-        "env": "TRE_ID"
-      }
-    },
-    {
-      "name": "azure_location",
-      "source": {
-        "env": "LOCATION"
-      }
-    },
     {
       "name": "workspace_id",
       "source": {
@@ -29,9 +11,9 @@
       }
     },
     {
-      "name": "acr_name",
+      "name": "tre_id",
       "source": {
-        "env": "ACR_NAME"
+        "env": "TRE_ID"
       }
     },
     {
@@ -50,12 +32,6 @@
       "name": "tfstate_storage_account_name",
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
-      }
-    },
-    {
-      "name": "porter_driver",
-      "source": {
-        "env": "PORTER_DRIVER"
       }
     }
   ]

--- a/workspaces/innereye_deeplearning/parameters_service_devtestlabs.json
+++ b/workspaces/innereye_deeplearning/parameters_service_devtestlabs.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0-DRAFT+TODO",
+  "name": "service-devtestlabs",
+  "created": "2021-06-03T11:54:54.0225968Z",
+  "modified": "2021-06-03T11:54:54.0225968Z",
+  "parameters": [
+    {
+      "name": "workspace_id",
+      "source": {
+        "env": "WORKSPACE_ID"
+      }
+    },
+    {
+      "name": "tre_id",
+      "source": {
+        "env": "TRE_ID"
+      }
+    },
+    {
+      "name": "tfstate_container_name",
+      "source": {
+        "env": "TERRAFORM_STATE_CONTAINER_NAME"
+      }
+    },
+    {
+      "name": "tfstate_resource_group_name",
+      "source": {
+        "env": "MGMT_RESOURCE_GROUP_NAME"
+      }
+    },
+    {
+      "name": "tfstate_storage_account_name",
+      "source": {
+        "env": "MGMT_STORAGE_ACCOUNT_NAME"
+      }
+    }
+  ]
+}

--- a/workspaces/innereye_deeplearning/parameters_workspace_vanilla.json
+++ b/workspaces/innereye_deeplearning/parameters_workspace_vanilla.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "1.0.0-DRAFT+TODO",
+  "name": "workspace-vanilla",
+  "created": "2021-06-04T13:37:29.5071039+03:00",
+  "modified": "2021-06-04T13:37:29.5071039+03:00",
+  "parameters": [
+    {
+      "name": "address_space",
+      "source": {
+        "env": "ADDRESS_SPACE"
+      }
+    },
+    {
+      "name": "azure_location",
+      "source": {
+        "env": "LOCATION"
+      }
+    },
+    {
+      "name": "tre_id",
+      "source": {
+        "env": "TRE_ID"
+      }
+    },
+    {
+      "name": "workspace_id",
+      "source": {
+        "env": "WORKSPACE_ID"
+      }
+    },
+    {
+      "name": "tfstate_container_name",
+      "source": {
+        "env": "TERRAFORM_STATE_CONTAINER_NAME"
+      }
+    },
+    {
+      "name": "tfstate_resource_group_name",
+      "source": {
+        "env": "MGMT_RESOURCE_GROUP_NAME"
+      }
+    },
+    {
+      "name": "tfstate_storage_account_name",
+      "source": {
+        "env": "MGMT_STORAGE_ACCOUNT_NAME"
+      }
+    }
+  ]
+}

--- a/workspaces/innereye_deeplearning/porter.yaml
+++ b/workspaces/innereye_deeplearning/porter.yaml
@@ -69,23 +69,17 @@ install:
         u: "{{ bundle.credentials.azure_client_id }}"
         p: "{{ bundle.credentials.azure_client_secret }}"
   - exec:
-      description: "Install azureml_devtestlabs workspace"
-      command: porter
-      arguments:
-        - install
-        - service-azureml_devtestlabs
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-workspace-azureml-devtestlabs:v0.1.4"
-        cred: ./azure.json
-        param: porter_driver={{ bundle.parameters.porter_driver }}
-        parameter-set: ./parameters_workspace_azureml-devtestlabs.json
-        debug:
-        # do not merge
-        allow-docker-host-access:
+      description: "Install Vanilla Workspace service"
+      command: ./install_workspace_vanilla.sh
   - exec:
-      description: "Install InnerEye deep learning service"
-      command: ./install_service_innereye_deep_learning.sh
+      description: "Install DevTestLabs service"
+      command: ./install_service_devtestlabs.sh
+  - exec:
+      description: "Install Azure ML service"
+      command: ./install_service_azureml.sh
+  - exec:
+      description: "Install InnerEye Deep Learning service"
+      command: ./install_service_innereye_deeplearning.sh
 
 upgrade:
   - exec:
@@ -94,36 +88,9 @@ upgrade:
       arguments:
         - "This workspace does not implement upgrade action"
 
-# TODO: uninstall does not work at present, will need remote porter state
-uninstall:
-  - exec:
-      description: "docker login"
-      command: docker
+uninstall:  
+- exec:
+      description: "Uninstall workspace"
+      command: echo
       arguments:
-        - login
-        - "{{ bundle.parameters.acr_name }}.azurecr.io"
-      flags:
-        u: "{{ bundle.credentials.azure_client_id }}"
-        p: "{{ bundle.credentials.azure_client_secret }}"
-  - exec:
-        description: "Uninstall InnerEye DeepLearning Service"
-        command: porter
-        arguments:
-          - uninstall
-        flags:
-          d: "{{ bundle.parameters.porter_driver }}"
-          reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-service-innereye-deeplearning:v0.1.0"
-          cred: ./azure.json
-          parameter-set: ./parameters_service_innereye-deeplearning.json
-          debug:
-  - exec:
-      description: "Install azureml_devtestlabs workspace"
-      command: porter
-      arguments:
-        - uninstall
-      flags:
-        d: "{{ bundle.parameters.porter_driver }}"
-        reference: "{{ bundle.parameters.acr_name }}.azurecr.io/tre-workspace-azureml-devtestlabs:v0.1.4"
-        cred: ./azure.json
-        parameter-set: ./parameters_workspace_azureml-devtestlabs.json
-        debug:
+        - "This workspace does not implement uninstall action"

--- a/workspaces/services/azureml/terraform/output.tf
+++ b/workspaces/services/azureml/terraform/output.tf
@@ -2,14 +2,6 @@ output "azureml_workspace_name" {
     value = azurerm_machine_learning_workspace.ml.name
 }
 
-output "computeinstance_name" {
-    value = "ci-${local.service_resource_name_suffix}"
-}
-
-output "computecluster_name" {
-    value = "cl-${local.service_resource_name_suffix}"
-}
-
 output "azureml_acr_id" {
     value = module.acr.id
 }


### PR DESCRIPTION
# PR for issue #350

## What is being addressed

Refactor porter bundles to simplify dependencies.

## How is this addressed

- Move to using scripts as proved out with the innereye inference bundle
- Remove workspace outputs no longer needed.
