### PR TITLE
Adding step to deploy the processor function app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ deploy-processor-function:
 	echo -e "\n\e[34m»»» 🧩 \e[96mDeploying processor function\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
-	&& cd ./processor_function && func azure functionapp publish "processor-func-$${TRE_ID}"
+	&& cd ./processor_function && func azure functionapp publish "processor-func-$${TRE_ID}" --python
 
 letsencrypt:
 	echo -e "\n\e[34m»»» 🧩 \e[96mRequesting LetsEncrypt SSL certificate\e[0m..." \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -175,6 +175,12 @@ log_analytics_name = "log-<TRE_ID>"
 static_web_storage = "stwebaz<TRE_ID>"
 ```
 
+Deploy the processor function:
+
+```cmd
+make deploy-processor-function
+```
+
 The Azure TRE is initially deployed with an invalid self-signed SSL certificate. This certificate is stored in the deployed Key Vault. To update the certificate in Key Vault needs to be replaced with one valid for the configured domain name. To use a certificate from [Let's Encrypt][letsencrypt], simply run the command:
 
 ```cmd


### PR DESCRIPTION
# PR for issue 
Close #403 

## What is being addressed
Processor function is not deployed when following the quickstart deployment steps 
 
Describe the current behavior you are modifying
Quickstart is missing a tep of deploying the processor function.

## How is this addressed
- Updated quickstart.md to include the step to deploy the processor app.
- updated the function publish command to explicitly indicate it's a python function
