### PR TITLE
Add make mgmt-deploy to deploy_mgmt_infra

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -54,6 +54,7 @@ jobs:
           export TF_VAR_acr_name=$ACR_NAME
           
           make bootstrap
+          make mgmt-deploy
 
   deploy_tre:
     name: Deploy TRE


### PR DESCRIPTION
# PR for issue #442

Closing #442 

## What is being addressed

Running workflow first time fails is publish_bundles step because of missing ACR.

## How is this addressed

Add step **make mgmt-deploy** to job **deploy_mgmt_infra**
