### PR TITLE
Add a service file which combines required and properties from different schemas

### DIFF
--- a/management_api_app/schemas/azuread.json
+++ b/management_api_app/schemas/azuread.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/microsoft/AzureTRE/schema/azuread.json",
+  "type": "object",
+  "title": "Azure AD Authorisation Schema",
+  "default": {},
+  "required": [
+      "authConfig"
+  ],
+  "properties": {
+      "authConfig": {
+          "$id": "#/properties/authConfig",
+          "type": "object",
+          "title": "Authorisation configuration",
+          "required": [
+              "app_id"
+          ],
+          "properties": {
+              "app_id": {
+                  "$id": "#/properties/authConfig/properties/app_id",
+                  "type": "string",
+                  "title": "App Registration ID"
+              }
+          }
+      }
+  }
+}

--- a/management_api_app/schemas/workspace.json
+++ b/management_api_app/schemas/workspace.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/microsoft/AzureTRE/schema/workspace.json",
+  "type": "object",
+  "title": "Workspace Default Parameters",
+  "description": "These parameters are required for all workspaces",
+  "required": [
+      "display_name",
+      "description"
+  ],
+  "properties": {
+      "display_name": {
+          "$id": "#/properties/display_name",
+          "type": "string",
+          "title": "Name for the workspace",
+          "description": "The name of the workspace to be displayed to users"
+      },
+      "description": {
+          "$id": "#/properties/description",
+          "type": "string",
+          "title": "Description of the workspace",
+          "description": "Description of the workspace"
+      },
+      "address_space": {
+          "$id": "#/properties/address_space",
+          "type": "string",
+          "title": "Address space",
+          "description": "Network address space to be used by the workspace"
+      }
+  }
+}

--- a/management_api_app/services/concatjsonschema.py
+++ b/management_api_app/services/concatjsonschema.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+
+def merge_required(tuples):
+    required = [tup[0] for tup in tuples]
+    flattened = [val for sublist in required for val in sublist]
+    return flattened
+
+
+def merge_properties(tuples):
+    properties = {}
+    for tup in tuples:
+        properties.update(tup[1])
+    return properties
+
+
+def read_schema(schema_file):
+    workspace_schema_def = Path(__file__).parent / ".." / "schemas" / schema_file
+    with open(workspace_schema_def) as schema_f:
+        schema = json.load(schema_f)
+        return (schema["required"], schema["properties"])
+
+
+def load_workspace_schema_def():
+    return read_schema("workspace.json")
+
+
+def load_azuread_schema_def():
+    return read_schema("azuread.json")
+
+
+def print_formatted_json(required, properties):
+    for j in [required, properties]:
+        json_formatted_str = json.dumps(j, indent=4)
+        print(json_formatted_str)
+
+
+def concat_schema_defs(combine_with=None, print_result=None):
+    """Combines schema definitions of known blocks with optional schema
+
+    Args:
+        combine_with ([Tuple], optional): [Optional schema defs of a workspace]. Defaults to None.
+    Returns:
+        [Tuple]: [A tuple of merged required list and properties dictionary]
+    """
+    workspace_tuple = load_workspace_schema_def()
+    schema_tuple = load_azuread_schema_def()
+    basic_blocks = [workspace_tuple, schema_tuple]
+    _ = basic_blocks if not combine_with else basic_blocks.append(combine_with)
+    required = merge_required(basic_blocks)
+    properties = merge_properties(basic_blocks)
+    if print_result:
+        print_formatted_json(required, properties)
+    return (required, properties)
+
+
+if __name__ == "__main__":
+    concat_schema_defs(print_result=True)


### PR DESCRIPTION
# PR for issue #420 

A service which can combine fixed known schemas and an optional schema def as required by workspace.

Not used anywhere yet but the idea being that in GET workspace template this service can be used to send a combined response as a format suitable for json forms.