### PR TITLE
Fix blank log message error, fix errors in scripts and tf for complex bundles

### DIFF
--- a/processor_function/vm_porter/runner.py
+++ b/processor_function/vm_porter/runner.py
@@ -116,7 +116,8 @@ async def run_porter(command, env_vars):
         result_stderr = stderr.decode()
         logger_adapter.info('[stderr]')
         for string in result_stderr.split('\n'):
-            logger_adapter.info(str(string))
+            if len(string) != 0:
+                logger_adapter.info(str(string))
 
     return (proc.returncode, result_stdout, result_stderr)
 

--- a/workspaces/azureml_devtestlabs/install_service_azureml.sh
+++ b/workspaces/azureml_devtestlabs/install_service_azureml.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-export AZUREML_WORKSPACE_NAME=$(porter installations output show azureml_workspace_name -i service-azureml_devtestlabs | tr -d '"')
-export AZUREML_ACR_ID=$(porter installations output show azureml_acr_id -i service-azureml_devtestlabs | tr -d '"')
-
 porter install tre-service-azureml --reference "${ACR_NAME}.azurecr.io/tre-service-azureml:v0.1.4" \
     --cred ./azure.json \
     --parameter-set ./parameters_service_azureml.json \

--- a/workspaces/azureml_devtestlabs/install_service_devtestlabs.sh
+++ b/workspaces/azureml_devtestlabs/install_service_devtestlabs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-porter install tre-service-innereye-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
+porter install tre-service-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
     --cred ./azure.json \
     --parameter-set ./parameters_service_devtestlabs.json \
     --debug

--- a/workspaces/innereye_deeplearning/install_service_azureml.sh
+++ b/workspaces/innereye_deeplearning/install_service_azureml.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-export AZUREML_WORKSPACE_NAME=$(porter installations output show azureml_workspace_name -i service-azureml_devtestlabs | tr -d '"')
-export AZUREML_ACR_ID=$(porter installations output show azureml_acr_id -i service-azureml_devtestlabs | tr -d '"')
-
 porter install tre-service-azureml --reference "${ACR_NAME}.azurecr.io/tre-service-azureml:v0.1.4" \
     --cred ./azure.json \
     --parameter-set ./parameters_service_azureml.json \

--- a/workspaces/innereye_deeplearning/install_service_devtestlabs.sh
+++ b/workspaces/innereye_deeplearning/install_service_devtestlabs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-porter install tre-service-innereye-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
+porter install tre-service-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
     --cred ./azure.json \
     --parameter-set ./parameters_service_devtestlabs.json \
     --debug

--- a/workspaces/innereye_deeplearning_inference/install_service_azureml.sh
+++ b/workspaces/innereye_deeplearning_inference/install_service_azureml.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-export AZUREML_WORKSPACE_NAME=$(porter installations output show azureml_workspace_name -i service-azureml_devtestlabs | tr -d '"')
-export AZUREML_ACR_ID=$(porter installations output show azureml_acr_id -i service-azureml_devtestlabs | tr -d '"')
-
 porter install tre-service-azureml --reference "${ACR_NAME}.azurecr.io/tre-service-azureml:v0.1.4" \
     --cred ./azure.json \
     --parameter-set ./parameters_service_azureml.json \

--- a/workspaces/innereye_deeplearning_inference/install_service_devtestlabs.sh
+++ b/workspaces/innereye_deeplearning_inference/install_service_devtestlabs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-porter install tre-service-innereye-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
+porter install tre-service-devtestlabs --reference "${ACR_NAME}.azurecr.io/tre-service-devtestlabs:v0.1.0" \
     --cred ./azure.json \
     --parameter-set ./parameters_service_devtestlabs.json \
     --debug

--- a/workspaces/services/azureml/terraform/firewall.tf
+++ b/workspaces/services/azureml/terraform/firewall.tf
@@ -9,7 +9,7 @@ data "azurerm_firewall" "fw" {
 
 resource "null_resource" "az_login" {
   provisioner "local-exec" {
-    command = "az login --identity -u '${data.azurerm_client_config.client_id}'"
+    command = "az login --identity -u '${data.azurerm_client_config.current.client_id}'"
   }
   triggers = {
     timestamp = timestamp()

--- a/workspaces/services/innereye_deeplearning/terraform/firewall.tf
+++ b/workspaces/services/innereye_deeplearning/terraform/firewall.tf
@@ -12,7 +12,7 @@ data "azurerm_client_config" "current" {}
 
 resource "null_resource" "az_login" {
   provisioner "local-exec" {
-    command = "az login --identity -u '${data.azurerm_client_config.client_id}'"
+    command = "az login --identity -u '${data.azurerm_client_config.current.client_id}'"
   }
 
   triggers = {


### PR DESCRIPTION
# PR for issue #496 
## What is being addressed

Fixing a number of bugs with the complex templates scripts since service principal has been removed.

## How is this addressed

- Fix installation naming - previous copy/paste error
- Fix incorrect resource name in terraform
- When output line is blank prevent it being logged