### PR TITLE
Nexus without default repositories

### DIFF
--- a/templates/core/terraform/.terraform.lock.hcl
+++ b/templates/core/terraform/.terraform.lock.hcl
@@ -20,6 +20,24 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [

--- a/templates/shared_services/sonatype-nexus/nexus.properties
+++ b/templates/shared_services/sonatype-nexus/nexus.properties
@@ -1,0 +1,1 @@
+nexus.skipDefaultRepositories=true

--- a/templates/shared_services/sonatype-nexus/readme.md
+++ b/templates/shared_services/sonatype-nexus/readme.md
@@ -13,3 +13,4 @@ To deploy set `DEPLOY_NEXUS=true` in `templates/core/.env`.
 1. Retrieve the initial admin password from the "admin.password" file. You will find it by going to TRE management resource group -> storage account named "stg\<TRE-ID\>" -> "File Shares" -> "nexus-data".
 1. Use the password to login to Nexus and go through the initial setup wizard. You can allow anonymous access because the purpose of this service is to use publicly available software packages.
 1. On the admin screen, add **proxy** repositories as needed. Note that other types of repositories might be a way to move data in/out workspaces and you should not allow that.
+1. Finally, share the repositories addresses with your users.

--- a/templates/shared_services/sonatype-nexus/readme.md
+++ b/templates/shared_services/sonatype-nexus/readme.md
@@ -1,0 +1,15 @@
+# Nexus Shared Service
+
+This service allows users in workspaces to access external software packages in a secure manner by relying on Sonatype Nexus (RepoManager).
+Documentation on Nexus can be found here: [https://help.sonatype.com/repomanager3/](https://help.sonatype.com/repomanager3/).
+
+## Deploy
+
+To deploy set `DEPLOY_NEXUS=true` in `templates/core/.env`.
+
+## Configure
+
+1. Wait for the application to come online - it can take a few minutes... and then navigate to its homepage. You can find the url by looking at the management resource group and finding a web application whose name start with nexus.
+1. Retrieve the initial admin password from the "admin.password" file. You will find it by going to TRE management resource group -> storage account named "stg\<TRE-ID\>" -> "File Shares" -> "nexus-data".
+1. Use the password to login to Nexus and go through the initial setup wizard. You can allow anonymous access because the purpose of this service is to use publicly available software packages.
+1. On the admin screen, add **proxy** repositories as needed. Note that other types of repositories might be a way to move data in/out workspaces and you should not allow that.


### PR DESCRIPTION
# PR for issue #520, #519

## What is being addressed

Nexus is normally created with a default set of repositories but those might be a problem since they allow data to be shared across workspaces. This PR changes that to have our Nexus created empty.

## How is this addressed

- Include a nexus.properties file to skip the default repositories and upload it before Nexus starts up.
- Add a readme for the service
