### PR TITLE
Configure Gitea registration preferences

### DIFF
--- a/templates/core/.env.sample
+++ b/templates/core/.env.sample
@@ -4,6 +4,10 @@ ADDRESS_SPACE="10.1.0.0/22" # /22 or larger
 MANAGEMENT_API_IMAGE_TAG=dev
 RESOURCE_PROCESSOR_VMSS_PORTER_IMAGE_TAG=dev
 DEPLOY_GITEA=true
+# Gitea usernames, TBD: https://github.com/microsoft/AzureTRE/issues/542
+GITEA_USERNAME=__CHANGE_ME__
+GITEA_PASSWD=__CHANGE_ME__
+GITEA_EMAIL=__CHANGE_ME__
 RESOURCE_PROCESSOR_TYPE="vmss_porter" # "function_cnab_driver"
 
 # Auth configuration

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -255,6 +255,9 @@ module "gitea" {
   source   = "../../shared_services/gitea/terraform"
   tre_id   = var.tre_id
   location = var.location
+  gitea_username   = var.gitea_username
+  gitea_passwd = var.gitea_passwd
+  gitea_email = var.gitea_email
   
   depends_on = [
     module.network

--- a/templates/core/terraform/variables.tf
+++ b/templates/core/terraform/variables.tf
@@ -124,6 +124,22 @@ variable "deploy_gitea" {
   description = "Deploy the Gitea shared service"
 }
 
+variable "gitea_username" {
+  type        = string
+  description = "An admin username for gitea service."
+}
+
+variable "gitea_passwd" {
+  type        = string
+  description = "An admin password for gitea service."
+  sensitive   = true
+}
+
+variable "gitea_email" {
+  type        = string
+  description = "An admin email for gitea service."
+}
+
 variable "deploy_nexus" {
   type        = bool
   default     = true

--- a/templates/shared_services/gitea/terraform/docker-compose.yml
+++ b/templates/shared_services/gitea/terraform/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  server:
+    image: gitea/gitea:latest
+    volumes:
+      - ${WEBAPP_STORAGE_HOME}:/home
+    ports:
+      - '3000:3000'
+    command:
+      - /bin/bash
+      - -c
+      - |
+        sleep 120 && gitea admin user create --admin --access-token --username=${GITEA_USERNAME} --password=${GITEA_PASSWD} --email=${GITEA_EMAIL} --must-change-password=false & /usr/bin/entrypoint

--- a/templates/shared_services/gitea/terraform/gitea-webapp.tf
+++ b/templates/shared_services/gitea/terraform/gitea-webapp.tf
@@ -9,6 +9,10 @@ resource "azurerm_app_service" "gitea" {
     "APPINSIGHTS_INSTRUMENTATIONKEY" = data.azurerm_application_insights.core.instrumentation_key
     "WEBSITES_PORT"                  = "3000"
     "WEBSITE_VNET_ROUTE_ALL"         = 1
+    
+    GITEA_USERNAME                 = var.gitea_username
+    GITEA_PASSWD                   = var.gitea_passwd
+    GITEA_EMAIL                    = var.gitea_email
 
     TRE_ID            = var.tre_id
     RESOURCE_LOCATION = var.location
@@ -29,10 +33,12 @@ resource "azurerm_app_service" "gitea" {
     GITEA__database__PASSWD=random_password.password.result
     
     GITEA__security__INSTALL_LOCK=true
+
+    GITEA__service__DISABLE_REGISTRATION=true
   }
 
   site_config {
-    linux_fx_version            = "DOCKER|gitea/gitea"
+    linux_fx_version            = "COMPOSE|${filebase64("docker-compose.yml")}"
     remote_debugging_enabled    = false
     scm_use_main_ip_restriction = true
 

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -8,3 +8,21 @@ variable "location" {
   type        = string
   description = "Azure location (region) for deployment of core TRE services"
 }
+
+
+variable "gitea_username" {
+  type        = string
+  description = "Admin username of gitea"
+}
+
+
+variable "gitea_passwd" {
+  type        = string
+  description = "Admin password of gitea"
+}
+
+
+variable "gitea_email" {
+  type        = string
+  description = "Admin email of gitea"
+}


### PR DESCRIPTION
# PR for issue #348 

## What is being addressed

Configure Gitea registration preferences

## How is this addressed
- Block normal users registrations by GITEA__service__DISABLE_REGISTRATION in the gitea config
- Add an admin user in order for the TRE admin to be able to push git repositories