### PR TITLE
API to use Managed Identity to authenticate against Cosmos DB

### DIFF
--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -8,7 +8,6 @@ jobs:
   build:
     name: "Lint and Test"
     runs-on: ubuntu-latest
-    environment: Dev
 
     steps:
       - name: Checkout code
@@ -16,11 +15,6 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
-      
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Lint code base
         uses: github/super-linter@v3

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: "Lint and Test"
     runs-on: ubuntu-latest
+    environment: Dev
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
+      
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Lint code base
         uses: github/super-linter@v3

--- a/devops/terraform/.terraform.lock.hcl
+++ b/devops/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.71.0"
   constraints = "2.71.0"
   hashes = [
+    "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
     "h1:ULax/q7p3Tl0l8DnXV9GNmdDRR1MHpimyLq8OP6E6I0=",
     "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
     "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",

--- a/management_api_app/.env.sample
+++ b/management_api_app/.env.sample
@@ -17,7 +17,9 @@ TRE_ID=mytre-dev-3142                           # The Azure TRE instance name - 
 # State store configuration
 # -------------------------
 STATE_STORE_ENDPOINT=https://localhost:8081     # The Cosmos DB endpoint - keep localhost if using an emulator. Otherwise https://<your_cosmos_db>.documents.azure.com:443/
-STATE_STORE_KEY=__CHANGE_ME__                   # The Cosmos DB access key
+COSMOSDB_ACCOUNT_NAME=__CHANGE_ME__            # The Cosmos DB account name
+SUBSCRIPTION_ID=__CHANGE_ME__                   # The subscription id where Cosmos DB is located
+RESOURCE_GROUP_NAME=__CHANGE_ME__               # The resource group name where Cosmos DB is located
 
 # Service bus configuration
 # -------------------------

--- a/management_api_app/.env.sample
+++ b/management_api_app/.env.sample
@@ -17,6 +17,7 @@ TRE_ID=mytre-dev-3142                           # The Azure TRE instance name - 
 # State store configuration
 # -------------------------
 STATE_STORE_ENDPOINT=https://localhost:8081     # The Cosmos DB endpoint - keep localhost if using an emulator. Otherwise https://<your_cosmos_db>.documents.azure.com:443/
+STATE_STORE_KEY=__CHANGE_ME__                   # The Cosmos DB key, use only with local emulator
 COSMOSDB_ACCOUNT_NAME=__CHANGE_ME__            # The Cosmos DB account name
 SUBSCRIPTION_ID=__CHANGE_ME__                   # The subscription id where Cosmos DB is located
 RESOURCE_GROUP_NAME=__CHANGE_ME__               # The resource group name where Cosmos DB is located

--- a/management_api_app/README.md
+++ b/management_api_app/README.md
@@ -123,7 +123,9 @@ See also: [Auth in code](#auth-in-code)
 | Environment variable name | Description |
 | ------------------------- | ----------- |
 | `STATE_STORE_ENDPOINT` | The Cosmos DB endpoint. Use `localhost` with an emulator. Example value: `https://localhost:8081` |
-| `STATE_STORE_KEY` | The Cosmos DB access key. |
+| `COSMOSDB_ACCOUNT_NAME` | The Cosmos DB account name. |
+| `SUBSCRIPTION_ID` | The Azure Subscription ID where Cosmos DB is lcoated. |
+| `RESOURCE_GROUP_NAME` | The Azure Resource Group name where Cosmos DB is lcoated. |
 
 ### Service Bus
 

--- a/management_api_app/README.md
+++ b/management_api_app/README.md
@@ -123,6 +123,7 @@ See also: [Auth in code](#auth-in-code)
 | Environment variable name | Description |
 | ------------------------- | ----------- |
 | `STATE_STORE_ENDPOINT` | The Cosmos DB endpoint. Use `localhost` with an emulator. Example value: `https://localhost:8081` |
+| `STATE_STORE_KEY` | The Cosmos DB key. Use only with localhost emulator. |
 | `COSMOSDB_ACCOUNT_NAME` | The Cosmos DB account name. |
 | `SUBSCRIPTION_ID` | The Azure Subscription ID where Cosmos DB is lcoated. |
 | `RESOURCE_GROUP_NAME` | The Azure Resource Group name where Cosmos DB is lcoated. |

--- a/management_api_app/api/dependencies/database.py
+++ b/management_api_app/api/dependencies/database.py
@@ -25,8 +25,7 @@ def connect_to_db() -> CosmosClient:
 
         if config.DEBUG:
             # ignore TLS(setup is pain) when on dev container and connecting to cosmosdb on windows host.
-            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key,
-                                             connection_verify=False)
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key,connection_verify=False)
         else:
             cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key)
         logging.debug("Connection established")

--- a/management_api_app/api/dependencies/database.py
+++ b/management_api_app/api/dependencies/database.py
@@ -29,6 +29,7 @@ def connect_to_db() -> CosmosClient:
     except Exception as e:
         logging.debug(f"Connection to state store could not be established: {e}")
 
+
 def get_store_key() -> str:
     if config.STATE_STORE_KEY:
         primary_master_key = config.STATE_STORE_KEY
@@ -37,8 +38,9 @@ def get_store_key() -> str:
         cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
         database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
         primary_master_key = database_keys.primary_master_key
-    
+
     return primary_master_key
+
 
 def get_db_client(app: FastAPI) -> CosmosClient:
     if not app.state.cosmos_client:

--- a/management_api_app/api/dependencies/database.py
+++ b/management_api_app/api/dependencies/database.py
@@ -25,7 +25,7 @@ def connect_to_db() -> CosmosClient:
 
         if config.DEBUG:
             # ignore TLS(setup is pain) when on dev container and connecting to cosmosdb on windows host.
-            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key,connection_verify=False)
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key, connection_verify=False)
         else:
             cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key)
         logging.debug("Connection established")

--- a/management_api_app/api/dependencies/database.py
+++ b/management_api_app/api/dependencies/database.py
@@ -2,6 +2,8 @@ import logging
 from typing import Callable, Type
 
 from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.cosmosdb import CosmosDBManagementClient
 from fastapi import Depends, FastAPI, HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
@@ -16,12 +18,17 @@ def connect_to_db() -> CosmosClient:
     logging.debug(f"Connecting to {config.STATE_STORE_ENDPOINT}")
 
     try:
+        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID)
+        cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
+        database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
+        primary_master_key = database_keys.primary_master_key
+
         if config.DEBUG:
             # ignore TLS(setup is pain) when on dev container and connecting to cosmosdb on windows host.
-            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY,
-                                         connection_verify=False)
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key,
+                                             connection_verify=False)
         else:
-            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, config.STATE_STORE_KEY)
+            cosmos_client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key)
         logging.debug("Connection established")
         return cosmos_client
     except Exception as e:

--- a/management_api_app/api/dependencies/database.py
+++ b/management_api_app/api/dependencies/database.py
@@ -34,7 +34,7 @@ def get_store_key() -> str:
     if config.STATE_STORE_KEY:
         primary_master_key = config.STATE_STORE_KEY
     else:
-        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID)
+        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID, exclude_shared_token_cache_credential=True)
         cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
         database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
         primary_master_key = database_keys.primary_master_key

--- a/management_api_app/core/config.py
+++ b/management_api_app/core/config.py
@@ -15,10 +15,12 @@ TRE_ID: str = config("TRE_ID", default="")
 
 # State store configuration
 STATE_STORE_ENDPOINT: str = config("STATE_STORE_ENDPOINT", default="")      # Cosmos DB endpoint
-STATE_STORE_KEY: str = config("STATE_STORE_KEY", default="")                # Cosmos DB access key
+COSMOSDB_ACCOUNT_NAME: str = config("COSMOSDB_ACCOUNT_NAME", default="")                # Cosmos DB access key
 STATE_STORE_DATABASE = "AzureTRE"
 STATE_STORE_RESOURCES_CONTAINER = "Resources"
 STATE_STORE_RESOURCE_TEMPLATES_CONTAINER = "ResourceTemplates"
+SUBSCRIPTION_ID: str = config("SUBSCRIPTION_ID", default="")
+RESOURCE_GROUP_NAME: str = config("RESOURCE_GROUP_NAME", default="")
 
 # Service bus configuration
 SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE: str = config("SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE", default="")

--- a/management_api_app/core/config.py
+++ b/management_api_app/core/config.py
@@ -15,7 +15,7 @@ TRE_ID: str = config("TRE_ID", default="")
 
 # State store configuration
 STATE_STORE_ENDPOINT: str = config("STATE_STORE_ENDPOINT", default="")      # Cosmos DB endpoint
-STATE_STORE_KEY : str = config("STATE_STORE_KEY", default="")                # Cosmos DB access key
+STATE_STORE_KEY: str = config("STATE_STORE_KEY", default="")                # Cosmos DB access key
 COSMOSDB_ACCOUNT_NAME: str = config("COSMOSDB_ACCOUNT_NAME", default="")                # Cosmos DB account name
 STATE_STORE_DATABASE = "AzureTRE"
 STATE_STORE_RESOURCES_CONTAINER = "Resources"

--- a/management_api_app/core/config.py
+++ b/management_api_app/core/config.py
@@ -15,12 +15,14 @@ TRE_ID: str = config("TRE_ID", default="")
 
 # State store configuration
 STATE_STORE_ENDPOINT: str = config("STATE_STORE_ENDPOINT", default="")      # Cosmos DB endpoint
-COSMOSDB_ACCOUNT_NAME: str = config("COSMOSDB_ACCOUNT_NAME", default="")                # Cosmos DB access key
+STATE_STORE_KEY : str = config("STATE_STORE_KEY", default="")                # Cosmos DB access key
+COSMOSDB_ACCOUNT_NAME: str = config("COSMOSDB_ACCOUNT_NAME", default="")                # Cosmos DB account name
 STATE_STORE_DATABASE = "AzureTRE"
 STATE_STORE_RESOURCES_CONTAINER = "Resources"
 STATE_STORE_RESOURCE_TEMPLATES_CONTAINER = "ResourceTemplates"
 SUBSCRIPTION_ID: str = config("SUBSCRIPTION_ID", default="")
 RESOURCE_GROUP_NAME: str = config("RESOURCE_GROUP_NAME", default="")
+
 
 # Service bus configuration
 SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE: str = config("SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE", default="")

--- a/management_api_app/requirements.txt
+++ b/management_api_app/requirements.txt
@@ -7,6 +7,7 @@ aiohttp==3.7.4.post0
 azure-core==1.15.0
 azure-cosmos==4.2.0
 azure-identity==1.6.0
+azure-mgmt-cosmosdb==6.4.0
 azure-servicebus==7.2.0
 opencensus-ext-azure==1.0.8
 opencensus-ext-logging==0.1.0

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -1,7 +1,5 @@
 from azure.core import exceptions
 from azure.cosmos import CosmosClient
-from azure.identity import DefaultAzureCredential
-from azure.mgmt.cosmosdb import CosmosDBManagementClient
 
 from api.dependencies.database import get_store_key
 from core import config

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -13,6 +13,7 @@ def create_state_store_status() -> (StatusEnum, str):
     message = ""
     try:
         primary_master_key = get_store_key()
+        #primary_master_key=""
         client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key)    # noqa: F841 - flake 8 client is not used
     except exceptions.ServiceRequestError:
         status = StatusEnum.not_ok

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -27,7 +27,7 @@ def get_store_key() -> str:
     if config.STATE_STORE_KEY:
         primary_master_key = config.STATE_STORE_KEY
     else:
-        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID)
+        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID, exclude_shared_token_cache_credential=True)
         cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
         database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
         primary_master_key = database_keys.primary_master_key

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -1,7 +1,9 @@
 from azure.core import exceptions
 from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.cosmosdb import CosmosDBManagementClient
 
-from core.config import STATE_STORE_ENDPOINT, STATE_STORE_KEY
+from core import config
 from models.schemas.status import StatusEnum
 from resources import strings
 
@@ -10,7 +12,11 @@ def create_state_store_status() -> (StatusEnum, str):
     status = StatusEnum.ok
     message = ""
     try:
-        client = CosmosClient(STATE_STORE_ENDPOINT, STATE_STORE_KEY)    # noqa: F841 - flake 8 client is not used
+        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID)
+        cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
+        database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
+        primary_master_key = database_keys.primary_master_key
+        client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key)    # noqa: F841 - flake 8 client is not used
     except exceptions.ServiceRequestError:
         status = StatusEnum.not_ok
         message = strings.STATE_STORE_ENDPOINT_NOT_RESPONDING

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -13,7 +13,6 @@ def create_state_store_status() -> (StatusEnum, str):
     message = ""
     try:
         primary_master_key = get_store_key()
-        #primary_master_key=""
         client = CosmosClient(config.STATE_STORE_ENDPOINT, primary_master_key)    # noqa: F841 - flake 8 client is not used
     except exceptions.ServiceRequestError:
         status = StatusEnum.not_ok

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -3,6 +3,7 @@ from azure.cosmos import CosmosClient
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.cosmosdb import CosmosDBManagementClient
 
+from api.dependencies.database import get_store_key
 from core import config
 from models.schemas.status import StatusEnum
 from resources import strings
@@ -21,15 +22,3 @@ def create_state_store_status() -> (StatusEnum, str):
         status = StatusEnum.not_ok
         message = strings.UNSPECIFIED_ERROR
     return status, message
-
-
-def get_store_key() -> str:
-    if config.STATE_STORE_KEY:
-        primary_master_key = config.STATE_STORE_KEY
-    else:
-        credential = DefaultAzureCredential(managed_identity_client_id=config.MANAGED_IDENTITY_CLIENT_ID, exclude_shared_token_cache_credential=True)
-        cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
-        database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
-        primary_master_key = database_keys.primary_master_key
-
-    return primary_master_key

--- a/management_api_app/services/health_checker.py
+++ b/management_api_app/services/health_checker.py
@@ -22,6 +22,7 @@ def create_state_store_status() -> (StatusEnum, str):
         message = strings.UNSPECIFIED_ERROR
     return status, message
 
+
 def get_store_key() -> str:
     if config.STATE_STORE_KEY:
         primary_master_key = config.STATE_STORE_KEY
@@ -30,5 +31,5 @@ def get_store_key() -> str:
         cosmosdb_client = CosmosDBManagementClient(credential, subscription_id=config.SUBSCRIPTION_ID)
         database_keys = cosmosdb_client.database_accounts.list_keys(resource_group_name=config.RESOURCE_GROUP_NAME, account_name=config.COSMOSDB_ACCOUNT_NAME)
         primary_master_key = database_keys.primary_master_key
-    
+
     return primary_master_key

--- a/management_api_app/tests_ma/test_services/test_health_checker.py
+++ b/management_api_app/tests_ma/test_services/test_health_checker.py
@@ -7,7 +7,9 @@ from services import health_checker
 
 
 @patch("services.health_checker.CosmosClient")
-def test_get_state_store_status_responding(cosmos_client_mock) -> None:
+@patch("services.health_checker.get_store_key")
+def test_get_state_store_status_responding(cosmos_client_mock, get_store_key_mock) -> None:
+    get_store_key_mock.return_value = None
     cosmos_client_mock.return_value = None
 
     status, message = health_checker.create_state_store_status()
@@ -17,7 +19,9 @@ def test_get_state_store_status_responding(cosmos_client_mock) -> None:
 
 
 @patch("services.health_checker.CosmosClient")
-def test_get_state_store_status_not_responding(cosmos_client_mock) -> None:
+@patch("services.health_checker.get_store_key")
+def test_get_state_store_status_not_responding(cosmos_client_mock, get_store_key_mock) -> None:
+    get_store_key_mock.return_value = None
     cosmos_client_mock.return_value = None
     cosmos_client_mock.side_effect = ServiceRequestError(message="some message")
 
@@ -28,7 +32,9 @@ def test_get_state_store_status_not_responding(cosmos_client_mock) -> None:
 
 
 @patch("services.health_checker.CosmosClient")
-def test_get_state_store_status_other_exception(cosmos_client_mock) -> None:
+@patch("services.health_checker.get_store_key")
+def test_get_state_store_status_other_exception(cosmos_client_mock, get_store_key_mock) -> None:
+    get_store_key_mock.return_value = None
     cosmos_client_mock.return_value = None
     cosmos_client_mock.side_effect = Exception()
 

--- a/templates/core/terraform/.terraform.lock.hcl
+++ b/templates/core/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.71.0"
   constraints = "2.71.0"
   hashes = [
+    "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
     "h1:ULax/q7p3Tl0l8DnXV9GNmdDRR1MHpimyLq8OP6E6I0=",
     "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
     "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.0"
   hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
     "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
     "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
@@ -41,6 +43,7 @@ provider "registry.terraform.io/hashicorp/null" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
@@ -60,6 +63,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",

--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -1,3 +1,5 @@
+data "azurerm_subscription" "current" {}
+
 resource "azurerm_app_service_plan" "core" {
   name                = "plan-${var.tre_id}"
   resource_group_name = var.resource_group_name
@@ -32,7 +34,7 @@ resource "azurerm_app_service" "management_api" {
     "DOCKER_REGISTRY_SERVER_URL"                 = "https://${var.docker_registry_server}"
     "DOCKER_REGISTRY_SERVER_PASSWORD"            = var.docker_registry_password
     "STATE_STORE_ENDPOINT"                       = var.state_store_endpoint
-    "STATE_STORE_KEY"                            = var.state_store_key
+    "COSMOSDB_ACCOUNT_NAME"                      = var.cosmosdb_account_name
     "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE"      = "sb-${var.tre_id}.servicebus.windows.net"
     "SERVICE_BUS_RESOURCE_REQUEST_QUEUE"         = var.service_bus_resource_request_queue
     "SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE" = var.service_bus_deployment_status_update_queue
@@ -43,6 +45,8 @@ resource "azurerm_app_service" "management_api" {
     "AAD_TENANT_ID"                              = var.aad_tenant_id
     "API_CLIENT_ID"                              = var.api_client_id
     "API_CLIENT_SECRET"                          = var.api_client_secret
+    "RESOURCE_GROUP_NAME"                        = var.resource_group_name
+    "SUBSCRIPTION_ID"                            = data.azurerm_subscription.current.subscription_id
   }
 
   identity {

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -14,7 +14,7 @@ variable "docker_registry_server" {}
 variable "docker_registry_username" {}
 variable "docker_registry_password" {}
 variable "state_store_endpoint" {}
-variable "state_store_key" {}
+variable "cosmosdb_account_name" {}
 variable "service_bus_resource_request_queue" {}
 variable "service_bus_deployment_status_update_queue" {}
 variable "managed_identity" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -98,7 +98,7 @@ module "api-webapp" {
   docker_registry_username                   = var.docker_registry_username
   docker_registry_password                   = var.docker_registry_password
   state_store_endpoint                       = module.state-store.endpoint
-  state_store_key                            = module.state-store.primary_key
+  cosmosdb_account_name                      = module.state-store.cosmosdb_account_name
   service_bus_resource_request_queue         = module.servicebus.workspacequeue
   service_bus_deployment_status_update_queue = module.servicebus.service_bus_deployment_status_update_queue
   managed_identity                           = module.identity.managed_identity

--- a/templates/core/terraform/state-store/output.tf
+++ b/templates/core/terraform/state-store/output.tf
@@ -2,6 +2,6 @@ output "endpoint" {
   value = azurerm_cosmosdb_account.tre-db-account.endpoint
 }
 
-output "primary_key" {
-  value = azurerm_cosmosdb_account.tre-db-account.primary_key
+output "cosmosdb_account_name" {
+  value = azurerm_cosmosdb_account.tre-db-account.name
 }


### PR DESCRIPTION
# API to use Managed Identity to authenticate against Cosmos DB

## What is being addressed

Switched API authentication to CosmosDB from using key stored in config to actively pulling key via mgmt API with MSI credentials.

## How is this addressed

- Added DefaultCredenital auth to database.py
- Added needed variables to TF (subscription_id, resource_group_name, cosmosdb_account_name)
- Removed key passing from TF to app config
- Modified docs where needed.

Closes #345 