### PR TITLE
Allow new TF domain in the firewall

### DIFF
--- a/templates/core/terraform/firewall/firewall.tf
+++ b/templates/core/terraform/firewall/firewall.tf
@@ -184,7 +184,8 @@ resource "azurerm_firewall_application_rule_collection" "resource_processor_subn
       "registry-1.docker.io",
       "auth.docker.io",
       "*.azurecr.io",
-      "registry.terraform.io"
+      "registry.terraform.io",
+      "releases.hashicorp.com"
     ]
     source_addresses = data.azurerm_subnet.resource_processor.address_prefixes
   }


### PR DESCRIPTION
# PR for issue #596 

## What is being addressed

Terraform isn't able to install provider components because a new domain they use is blocked in the firewall, and E2E are failing because of it.

## How is this addressed

- Add the newly used domain to the firewall allow list
