### PR TITLE
Removing docker registry username and pass from API config

### DIFF
--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -30,9 +30,7 @@ resource "azurerm_app_service" "management_api" {
     "XDT_MicrosoftApplicationInsights_Mode"      = "default"
     "WEBSITES_PORT"                              = "8000"
     "WEBSITE_VNET_ROUTE_ALL"                     = 1
-    "DOCKER_REGISTRY_SERVER_USERNAME"            = var.docker_registry_username
     "DOCKER_REGISTRY_SERVER_URL"                 = "https://${var.docker_registry_server}"
-    "DOCKER_REGISTRY_SERVER_PASSWORD"            = var.docker_registry_password
     "STATE_STORE_ENDPOINT"                       = var.state_store_endpoint
     "COSMOSDB_ACCOUNT_NAME"                      = var.cosmosdb_account_name
     "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE"      = "sb-${var.tre_id}.servicebus.windows.net"

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -11,8 +11,6 @@ variable "log_analytics_workspace_id" {}
 variable "management_api_image_repository" {}
 variable "management_api_image_tag" {}
 variable "docker_registry_server" {}
-variable "docker_registry_username" {}
-variable "docker_registry_password" {}
 variable "state_store_endpoint" {}
 variable "cosmosdb_account_name" {}
 variable "service_bus_resource_request_queue" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -95,8 +95,6 @@ module "api-webapp" {
   management_api_image_repository            = var.management_api_image_repository
   management_api_image_tag                   = var.management_api_image_tag
   docker_registry_server                     = var.docker_registry_server
-  docker_registry_username                   = var.docker_registry_username
-  docker_registry_password                   = var.docker_registry_password
   state_store_endpoint                       = module.state-store.endpoint
   cosmosdb_account_name                      = module.state-store.cosmosdb_account_name
   service_bus_resource_request_queue         = module.servicebus.workspacequeue

--- a/templates/core/terraform/variables.tf
+++ b/templates/core/terraform/variables.tf
@@ -83,17 +83,6 @@ variable "docker_registry_server" {
   description = "Docker registry server"
 }
 
-variable "docker_registry_username" {
-  type        = string
-  description = "Docker registry username"
-}
-
-variable "docker_registry_password" {
-  type        = string
-  description = "Docker registry password"
-  sensitive   = true
-}
-
 variable "swagger_ui_client_id" {
   type        = string
   description = "The client id (app id) of the registration in Azure AD for the Swagger UI"


### PR DESCRIPTION
# Removing docker registry username and pass from API config

## What is being addressed

Docker credentials are pushed to API, but have already been replaced by MSI downstream. Removing the credentials.

## How is this addressed

- Removed the credentials from TF so they are not pushed to API config

Closing #575 