### PR TITLE
Set the partition key on the cosmos containers

### DIFF
--- a/management_api_app/db/repositories/base.py
+++ b/management_api_app/db/repositories/base.py
@@ -17,7 +17,10 @@ class BaseRepository:
     def _get_container(self, container_name) -> ContainerProxy:
         try:
             database = self._client.get_database_client(config.STATE_STORE_DATABASE)
-            return database.create_container_if_not_exists(id=container_name, partition_key=PartitionKey(path="/appId"))
+            container = database.create_container_if_not_exists(id=container_name, partition_key=PartitionKey(path="/id"))
+            properties = container.read()
+            print(properties['partitionKey'])
+            return container
         except Exception:
             raise UnableToAccessDatabase
 


### PR DESCRIPTION
# PR for bug #606 

## What is being addressed

Currently the partition key for the containers are set to /appId which is a value that doesn't exist in any of our documents and therefore the actual value of the partition key is NULL - given this - we can not do deletes or other operations that require partition keys with valid values.

Per https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview - in our scenario /id would be an appropriate partition key. 

## How is this addressed

- Set the partition key to /id when the containers are created.

**NOTE:** as this only happens on create - the database in the TRE environment needs to be purged after merging for this to take effect. 

@deniscep I know you had some related code - please verify if this change also needs to happen in your new code