### PR TITLE
clean up resources on service bus failure

### DIFF
--- a/management_api_app/api/routes/workspaces.py
+++ b/management_api_app/api/routes/workspaces.py
@@ -50,7 +50,7 @@ async def create_workspace(workspace_create: WorkspaceInCreate, workspace_repo: 
     try:
         await send_resource_request_message(workspace, RequestAction.Install)
     except Exception as e:
-        # TODO: Rollback DB change, issue #154
+        workspace_repo.delete_resource(workspace.id)
         logging.error(f"Failed send workspace resource request message: {e}")
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=strings.SERVICE_BUS_GENERAL_ERROR_MESSAGE)
 
@@ -85,7 +85,7 @@ async def create_workspace_service(workspace_create: WorkspaceServiceInCreate,
     try:
         await send_resource_request_message(workspace_service, RequestAction.Install)
     except Exception as e:
-        # TODO: Rollback DB change, issue #154
+        workspace_service_repo.delete_resource(workspace_service.id)
         logging.error(f"Failed send workspace service resource request message: {e}")
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                             detail=strings.SERVICE_BUS_GENERAL_ERROR_MESSAGE)

--- a/management_api_app/db/repositories/resources.py
+++ b/management_api_app/db/repositories/resources.py
@@ -28,3 +28,6 @@ class ResourceRepository(BaseRepository):
 
     def update_resource_dict(self, resource_dict: dict):
         self.container.upsert_item(body=resource_dict)
+
+    def delete_resource(self, resource_id: str):
+        self.container.delete_item(item=resource_id, partition_key=resource_id)

--- a/management_api_app/tests_ma/test_api/test_routes/test_workspaces.py
+++ b/management_api_app/tests_ma/test_api/test_routes/test_workspaces.py
@@ -207,11 +207,12 @@ class TestWorkspaceRoutesThatRequireAdminRights:
         assert response.json()["workspaceServiceId"] == workspace_service_id
 
     # [POST] /workspaces/
+    @ patch("api.routes.workspaces.WorkspaceRepository.delete_resource")
     @ patch("api.routes.workspaces.send_resource_request_message")
     @ patch("api.routes.workspaces.WorkspaceRepository.save_workspace")
     @ patch("api.routes.workspaces.WorkspaceRepository.create_workspace_item")
     @ patch("api.routes.workspaces.WorkspaceRepository._validate_resource_parameters")
-    async def test_workspaces_post_returns_503_if_service_bus_call_fails(self, validate_workspace_parameters_mock, create_workspace_item_mock, save_workspace_mock, send_resource_request_message_mock,
+    async def test_workspaces_post_returns_503_if_service_bus_call_fails(self, validate_workspace_parameters_mock, create_workspace_item_mock, save_workspace_mock, send_resource_request_message_mock, delete_resource_mock,
                                                                          app: FastAPI, client: AsyncClient):
         workspace_id = "000000d3-82da-4bfc-b6e9-9a7853ef753e"
         validate_workspace_parameters_mock.return_value = None
@@ -223,6 +224,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE), json=input_data)
 
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        delete_resource_mock.assert_called_once_with(workspace_id)
 
     # [POST] /workspaces/
     @ patch("api.routes.workspaces.WorkspaceRepository._get_current_workspace_template")


### PR DESCRIPTION
# PR for issue #154 

## What is being addressed

If we make a workspace or workspace-service POST request - and the service bus is not accessible, the resource is cleaned up from the db so the db is reverted to its state before the POST

## How is this addressed

- delete the item on SB exception
- fix tests
