### PR TITLE
Remove redundant variables from Guacamole and fetch image with managed identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: bootstrap-init mgmt-deploy mgmt-destroy build-api-image push-api-image deploy-tre destroy-tre letsencrypt
 
 SHELL:=/bin/bash
+ROOTPATH:=$(shell pwd)
 
 all: bootstrap mgmt-deploy build-api-image push-api-image build-resource-processor-vm-porter-image push-resource-processor-vm-porter-image build-gitea-image push-gitea-image tre-deploy
 
@@ -161,4 +162,4 @@ register-bundle:
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& cd ${DIR} \
-	&& ../../devops/scripts/publish_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type workspace --current --insecure
+	&& ${ROOTPATH}/devops/scripts/publish_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type workspace --current --insecure

--- a/workspaces/services/guacamole/parameters.json
+++ b/workspaces/services/guacamole/parameters.json
@@ -17,21 +17,9 @@
       }
     },
     {
-      "name": "acr_name",
-      "source": {
-        "env": "ACR_NAME"
-      }
-    },
-    {
       "name": "mgmt_resource_group_name",
       "source": {
         "env": "MGMT_RESOURCE_GROUP_NAME"
-      }
-    },
-    {
-      "name": "guacamole_image_tag",
-      "source": {
-        "env": "GUACAMOLE_IMAGE_TAG"
       }
     },
     {

--- a/workspaces/services/guacamole/porter.yaml
+++ b/workspaces/services/guacamole/porter.yaml
@@ -19,19 +19,10 @@ parameters:
     type: string
   - name: tre_id
     type: string
-  - name: acr_name
-    type: string
-    description: "Name of the azure container registry"
-    env: ACR_NAME
   - name: mgmt_resource_group_name
     type: string
     description: "Resource group containing the shared ACR"
     env: MGMT_RESOURCE_GROUP_NAME
-  - name: guacamole_image_tag
-    type: string
-    description: "Guacamole server image tag"
-    env: GUACAMOLE_IMAGE_TAG
-    default: "v0.0.1"
   - name: tfstate_resource_group_name
     type: string
     description: "Resource group containing the Terraform state storage account"
@@ -43,9 +34,6 @@ parameters:
     type: string
     default: "tfstate"
     description: "The name of the Terraform state storage container"
-  - name: arm_use_msi
-    env: ARM_USE_MSI
-    default: false
 
 outputs:
   - name: guacamole_workspace_name
@@ -65,10 +53,7 @@ install:
         arm_client_id: "{{ bundle.credentials.azure_client_id }}"
         arm_client_secret: "{{ bundle.credentials.azure_client_secret }}"
         arm_tenant_id: "{{ bundle.credentials.azure_tenant_id }}"
-        acr_name: "{{ bundle.parameters.acr_name }}"
         mgmt_resource_group_name: "{{ bundle.parameters.mgmt_resource_group_name }}"
-        guacamole_image_tag: "{{ bundle.parameters.guacamole_image_tag }}"
-        arm_use_msi: "{{ bundle.parameters.arm_use_msi }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"

--- a/workspaces/services/guacamole/porter.yaml
+++ b/workspaces/services/guacamole/porter.yaml
@@ -1,5 +1,5 @@
 name: tre-service-guacamole
-version: 0.1.2
+version: 0.1.8
 description: "An Azure TRE service for Guacamole"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -23,6 +23,8 @@ parameters:
     type: string
     description: "Resource group containing the shared ACR"
     env: MGMT_RESOURCE_GROUP_NAME
+
+  # the next 4 are automaticly sent by the resource processor call, so must be present.
   - name: tfstate_resource_group_name
     type: string
     description: "Resource group containing the Terraform state storage account"
@@ -34,6 +36,9 @@ parameters:
     type: string
     default: "tfstate"
     description: "The name of the Terraform state storage container"
+  - name: arm_use_msi
+    env: ARM_USE_MSI
+    default: false
 
 outputs:
   - name: guacamole_workspace_name
@@ -53,6 +58,7 @@ install:
         arm_client_id: "{{ bundle.credentials.azure_client_id }}"
         arm_client_secret: "{{ bundle.credentials.azure_client_secret }}"
         arm_tenant_id: "{{ bundle.credentials.azure_tenant_id }}"
+        arm_use_msi: "{{ bundle.parameters.arm_use_msi }}"
         mgmt_resource_group_name: "{{ bundle.parameters.mgmt_resource_group_name }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"

--- a/workspaces/services/guacamole/terraform/locals.tf
+++ b/workspaces/services/guacamole/terraform/locals.tf
@@ -7,11 +7,7 @@ resource "random_string" "unique_id" {
 locals {
   service_id                   = random_string.unique_id.result
   service_resource_name_suffix = "${var.tre_id}-ws-${var.workspace_id}-svc-${local.service_id}"
+  webapp_name                  = "guacamole-${local.service_resource_name_suffix}"
   core_vnet                    = "vnet-${var.tre_id}"
   core_resource_group_name     = "rg-${var.tre_id}"
-}
-
-data "azurerm_container_registry" "mgmt_acr" {
-  name                = var.acr_name
-  resource_group_name = var.mgmt_resource_group_name
 }

--- a/workspaces/services/guacamole/terraform/main.tf
+++ b/workspaces/services/guacamole/terraform/main.tf
@@ -41,3 +41,8 @@ data "azurerm_private_dns_zone" "azurewebsites" {
   name                = "privatelink.azurewebsites.net"
   resource_group_name = local.core_resource_group_name
 }
+
+data "azurerm_container_registry" "mgmt_acr" {
+  name                = "acr${var.tre_id}"
+  resource_group_name = var.mgmt_resource_group_name
+}

--- a/workspaces/services/guacamole/terraform/variables.tf
+++ b/workspaces/services/guacamole/terraform/variables.tf
@@ -4,6 +4,4 @@ variable "arm_client_id" {}
 variable "arm_client_secret" {}
 variable "arm_tenant_id" {}
 variable "arm_use_msi" {}
-variable "acr_name" {}
 variable "mgmt_resource_group_name" {}
-variable "guacamole_image_tag" {}

--- a/workspaces/services/guacamole/terraform/web_app.tf
+++ b/workspaces/services/guacamole/terraform/web_app.tf
@@ -1,5 +1,5 @@
 resource "azurerm_app_service_plan" "guacamole" {
-  name                = "plan-gua-${local.service_resource_name_suffix}"
+  name                = "plan-${local.webapp_name}"
   location            = data.azurerm_resource_group.ws.location
   resource_group_name = data.azurerm_resource_group.ws.name
   kind                = "Linux"
@@ -12,7 +12,7 @@ resource "azurerm_app_service_plan" "guacamole" {
 }
 
 resource "azurerm_app_service" "guacamole" {
-  name                = "guacamole-${local.service_resource_name_suffix}"
+  name                = local.webapp_name
   location            = data.azurerm_resource_group.ws.location
   resource_group_name = data.azurerm_resource_group.ws.name
   app_service_plan_id = azurerm_app_service_plan.guacamole.id
@@ -20,7 +20,6 @@ resource "azurerm_app_service" "guacamole" {
 
   site_config {
     linux_fx_version                     = "DOCKER|${data.azurerm_container_registry.mgmt_acr.name}.azurecr.io/guac-server:v0.1.0"
-    always_on                            = true
     http2_enabled                        = true
     acr_use_managed_identity_credentials = true
   }
@@ -54,14 +53,14 @@ resource "azurerm_app_service_virtual_network_swift_connection" "guacamole" {
 }
 
 resource "azurerm_private_endpoint" "guacamole" {
-  name                = "pe-guacamole-${local.service_resource_name_suffix}"
+  name                = "pe-${local.webapp_name}"
   location            = data.azurerm_resource_group.ws.location
   resource_group_name = data.azurerm_resource_group.ws.name
   subnet_id           = data.azurerm_subnet.services.id
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.guacamole.id
-    name                           = "psc-guacamole-${local.service_resource_name_suffix}"
+    name                           = "psc-${local.webapp_name}"
     subresource_names              = ["sites"]
     is_manual_connection           = false
   }

--- a/workspaces/services/guacamole/terraform/web_app.tf
+++ b/workspaces/services/guacamole/terraform/web_app.tf
@@ -19,7 +19,7 @@ resource "azurerm_app_service" "guacamole" {
   https_only          = true
 
   site_config {
-    linux_fx_version = "DOCKER|${var.acr_name}.azurecr.io/guac-server:${var.guacamole_image_tag}"
+    linux_fx_version = "DOCKER|${data.azurerm_container_registry.mgmt_acr.name}.azurecr.io/guac-server:v0.1.0"
     always_on        = true
     http2_enabled    = true
   }


### PR DESCRIPTION
# Resolves #617, Resolves #618, Resolves #619

## What is being addressed

- Instead of passing the ACR name, we get it from the mgmt acr object
- removed other irrelevant params
- Allow make register-bundle to work for any directory