### PR TITLE
Adding Keyvault for Guacamole service

### DIFF
--- a/workspaces/services/guacamole-azure-win10vm/terraform/main.tf
+++ b/workspaces/services/guacamole-azure-win10vm/terraform/main.tf
@@ -38,6 +38,6 @@ data "azurerm_subnet" "services" {
 }
 
 data "azurerm_key_vault" "kv" {
-  name                = "kv-${var.tre_id}-${var.workspace_id}"
+  name                = "kv-guacamole-${var.tre_id}-${var.workspace_id}"
   resource_group_name = data.azurerm_resource_group.ws.name
 }

--- a/workspaces/services/guacamole-azure-win10vm/terraform/main.tf
+++ b/workspaces/services/guacamole-azure-win10vm/terraform/main.tf
@@ -36,3 +36,8 @@ data "azurerm_subnet" "services" {
   virtual_network_name = data.azurerm_virtual_network.ws.name
   resource_group_name  = data.azurerm_resource_group.ws.name
 }
+
+data "azurerm_key_vault" "kv" {
+  name                = "kv-${var.tre_id}-${var.workspace_id}"
+  resource_group_name = data.azurerm_resource_group.ws.name
+}

--- a/workspaces/services/guacamole-azure-win10vm/terraform/win10vm.tf
+++ b/workspaces/services/guacamole-azure-win10vm/terraform/win10vm.tf
@@ -73,3 +73,9 @@ resource "azurerm_virtual_machine" "win10vm" {
     parent_service_id = var.parent_service_id
   }
 }
+
+resource "azurerm_key_vault_secret" "win10vm_password" {
+  name         = "${local.vm_name}-admin-credentials"
+  value        =  "${random_string.username.result}\n${random_password.password.result}"
+  key_vault_id =  data.azurerm_key_vault.kv.id
+}

--- a/workspaces/services/guacamole-azure-win10vm/terraform/win10vm.tf
+++ b/workspaces/services/guacamole-azure-win10vm/terraform/win10vm.tf
@@ -76,6 +76,6 @@ resource "azurerm_virtual_machine" "win10vm" {
 
 resource "azurerm_key_vault_secret" "win10vm_password" {
   name         = "${local.vm_name}-admin-credentials"
-  value        =  "${random_string.username.result}\n${random_password.password.result}"
-  key_vault_id =  data.azurerm_key_vault.kv.id
+  value        = "${random_string.username.result}\n${random_password.password.result}"
+  key_vault_id = data.azurerm_key_vault.kv.id
 }

--- a/workspaces/services/guacamole/terraform/keyvault.tf
+++ b/workspaces/services/guacamole/terraform/keyvault.tf
@@ -52,7 +52,7 @@ resource "azurerm_key_vault_access_policy" "current" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  secret_permissions = ["Get", "List", "Set", "Delete"]
 }
 
 resource "azurerm_key_vault_access_policy" "guacamole" {

--- a/workspaces/services/guacamole/terraform/keyvault.tf
+++ b/workspaces/services/guacamole/terraform/keyvault.tf
@@ -1,0 +1,64 @@
+resource "azurerm_key_vault" "kv" {
+  # One Keyvault across all Guacamole services
+  name                     = "kv-guacamole-${var.tre_id}-${var.workspace_id}"
+  location                 = data.azurerm_resource_group.ws.location
+  resource_group_name      = data.azurerm_resource_group.ws.name
+  sku_name                 = "standard"
+  purge_protection_enabled = true
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_private_dns_zone" "vaultcore" {
+  name                = "privatelink.vaultcore.azure.net"
+  resource_group_name = data.azurerm_resource_group.ws.name
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "vaultcorelink" {
+  name                  = "vaultcorelink-${local.service_resource_name_suffix}"
+  resource_group_name   = data.azurerm_resource_group.ws.name
+  private_dns_zone_name = azurerm_private_dns_zone.vaultcore.name
+  virtual_network_id    = data.azurerm_virtual_network.ws.id
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_private_endpoint" "kvpe" {
+  name                = "kvpe-${local.service_resource_name_suffix}"
+  location            = data.azurerm_resource_group.ws.location
+  resource_group_name = data.azurerm_resource_group.ws.name
+  subnet_id           = data.azurerm_subnet.services.id
+
+  lifecycle { ignore_changes = [tags] }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group"
+    private_dns_zone_ids = [azurerm_private_dns_zone.vaultcore.id]
+  }
+
+  private_service_connection {
+    name                           = "kvpescv-${local.service_resource_name_suffix}"
+    private_connection_resource_id = azurerm_key_vault.kv.id
+    is_manual_connection           = false
+    subresource_names              = ["Vault"]
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "current" {
+  key_vault_id = azurerm_key_vault.kv.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+}
+
+resource "azurerm_key_vault_access_policy" "guacamole" {
+  key_vault_id = azurerm_key_vault.kv.id
+  tenant_id    = azurerm_app_service.guacamole.identity.0.tenant_id
+  object_id    = azurerm_app_service.guacamole.identity.0.principal_id
+
+  secret_permissions = ["Get", "List", ]
+}


### PR DESCRIPTION
# PR for issue #630 #631

## What is being addressed

In order to implement credentials retrieval in Guacamole auth extension, we need a dedicated keyvault and for the credentials of VMs to be stored in the keyvault.

## How is this addressed

- Adding keyvault in terraform for the guacamole service
- Adding both access policies for the deploy processor and the guacamole managed identity
- Saving the vm username + password in the keyvault