### PR TITLE
Changes e2e get workspace template test to match new JSON from API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ sample.dat
 templates/core/terraform/scripts/index.html
 templates/core/terraform/scripts/validation.txt
 templates/core/terraform/plan
+e2e_tests/pytest_e2e.xml

--- a/e2e_tests/test_workspace_creation.py
+++ b/e2e_tests/test_workspace_creation.py
@@ -101,9 +101,8 @@ async def test_get_workspace_templates(template_name, token, verify) -> None:
             f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_WORKSPACE_TEMPLATES}",
             headers=headers)
 
-        all_templates = [value for item in response.json()["templates"]
-                         for value in item.values()]
-        assert (template_name in all_templates), f"No {template_name} template found"
+        template_names = [templates["name"] for templates in response.json()["templates"]]
+        assert (template_name in template_names), f"No {template_name} template found"
 
 
 @pytest.mark.smoke

--- a/e2e_tests/test_workspace_creation.py
+++ b/e2e_tests/test_workspace_creation.py
@@ -102,7 +102,7 @@ async def test_get_workspace_templates(template_name, token, verify) -> None:
             headers=headers)
 
         all_templates = [value for item in response.json()["templates"]
-                        for value in item.values()]
+                         for value in item.values()]
         assert (template_name in all_templates), f"No {template_name} template found"
 
 

--- a/e2e_tests/test_workspace_creation.py
+++ b/e2e_tests/test_workspace_creation.py
@@ -100,9 +100,9 @@ async def test_get_workspace_templates(template_name, token, verify) -> None:
         response = await client.get(
             f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_WORKSPACE_TEMPLATES}",
             headers=headers)
-        
+
         all_templates = [value for item in response.json()["templates"]
-                      for value in item.values()]
+                        for value in item.values()]
         assert (template_name in all_templates), f"No {template_name} template found"
 
 

--- a/e2e_tests/test_workspace_creation.py
+++ b/e2e_tests/test_workspace_creation.py
@@ -100,8 +100,10 @@ async def test_get_workspace_templates(template_name, token, verify) -> None:
         response = await client.get(
             f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_WORKSPACE_TEMPLATES}",
             headers=headers)
-
-        assert (template_name in response.json()["templateNames"]), f"No {template_name} template found"
+        
+        all_templates = [value for item in response.json()["templates"]
+                      for value in item.values()]
+        assert (template_name in all_templates), f"No {template_name} template found"
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
# PR for issue

## What is being addressed

Get Workspace template used to return templateNames json with a list of template names, when now it returns a name-description pair of templates.

## How is this addressed

- Switched JSON reading to match new JSON format
