### PR TITLE
API doesn't use MSI for ACR image pull

### DIFF
--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -58,6 +58,7 @@ resource "azurerm_app_service" "management_api" {
     linux_fx_version            = "DOCKER|${var.docker_registry_server}/${var.management_api_image_repository}:${var.management_api_image_tag}"
     remote_debugging_enabled    = false
     scm_use_main_ip_restriction = true
+    acr_use_managed_identity_credentials = true
 
     cors {
       allowed_origins     = []

--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -55,9 +55,9 @@ resource "azurerm_app_service" "management_api" {
   lifecycle { ignore_changes = [tags] }
 
   site_config {
-    linux_fx_version            = "DOCKER|${var.docker_registry_server}/${var.management_api_image_repository}:${var.management_api_image_tag}"
-    remote_debugging_enabled    = false
-    scm_use_main_ip_restriction = true
+    linux_fx_version                     = "DOCKER|${var.docker_registry_server}/${var.management_api_image_repository}:${var.management_api_image_tag}"
+    remote_debugging_enabled             = false
+    scm_use_main_ip_restriction          = true
     acr_use_managed_identity_credentials = true
 
     cors {


### PR DESCRIPTION
# PR for issue

## What is being addressed

API doesn't use MSI for ACR image pull

## How is this addressed

- Set API acr_use_managed_identity_credentials=true

Closes #647 