### PR TITLE
Fix resource processor version to buster

### DIFF
--- a/resource_processor/vmss_porter/Dockerfile
+++ b/resource_processor/vmss_porter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:buster
+FROM python:3.8-buster
 
 # Azure CLI
 RUN apt-get update \

--- a/resource_processor/vmss_porter/Dockerfile
+++ b/resource_processor/vmss_porter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.10
+FROM python:buster
 
 # Azure CLI
 RUN apt-get update \

--- a/resource_processor/vmss_porter/Dockerfile
+++ b/resource_processor/vmss_porter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8.10
 
 # Azure CLI
 RUN apt-get update \

--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -59,6 +59,7 @@ resource "azurerm_app_service" "management_api" {
     remote_debugging_enabled             = false
     scm_use_main_ip_restriction          = true
     acr_use_managed_identity_credentials = true
+    acr_user_managed_identity_client_id  = var.managed_identity.client_id
 
     cors {
       allowed_origins     = []


### PR DESCRIPTION
# PR for issue

## What is being addressed

Building resource processor fails for python 3.8 image; switch to buster
Added also the acr_user_managed_identity_client_id to api_web_app

