### PR TITLE
Switching Debian:latest to debian:buster

### DIFF
--- a/workspaces/innereye_deeplearning/Dockerfile.tmpl
+++ b/workspaces/innereye_deeplearning/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \

--- a/workspaces/innereye_deeplearning_inference/Dockerfile.tmpl
+++ b/workspaces/innereye_deeplearning_inference/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \

--- a/workspaces/services/azureml/Dockerfile.tmpl
+++ b/workspaces/services/azureml/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 # Install Azure CLI
 RUN apt-get update \

--- a/workspaces/services/guacamole-azure-win10vm/Dockerfile.tmpl
+++ b/workspaces/services/guacamole-azure-win10vm/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 # Install Azure CLI
 RUN apt-get update \

--- a/workspaces/services/guacamole/Dockerfile.tmpl
+++ b/workspaces/services/guacamole/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 # Install Azure CLI
 RUN apt-get update \

--- a/workspaces/services/innereye_deeplearning/Dockerfile.tmpl
+++ b/workspaces/services/innereye_deeplearning/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 # Install Azure CLI
 RUN apt-get update \

--- a/workspaces/services/innereye_inference/Dockerfile.tmpl
+++ b/workspaces/services/innereye_inference/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 
 # Install Azure CLI
 RUN apt-get update \


### PR DESCRIPTION
# PR for issue

## What is being addressed

Debian:bullseye fails on getting Azure CLI packages -> replace with debian:buster

## How is this addressed

Switching Debian:latest to debian:buster

Closes #659 