### PR TITLE
Deployment returns outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-api-image:
 	&& docker build -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/management-api:$${IMAGE_TAG}" ./management_api_app/
 
 build-resource-processor-vm-porter-image:
-	echo -e "\n\e[34m»»» 🧩 \e[96mBuilding Image\e[0m..." \
+	echo -e "\n\e[34m»»» 🧩 \e[96mBuilding Resource Processor Image\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
@@ -47,7 +47,7 @@ build-gitea-image:
 	&& docker build -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/gitea:$${IMAGE_TAG}" -f ./templates/shared_services/gitea/Dockerfile .
 
 push-resource-processor-vm-porter-image:
-	echo -e "\n\e[34m»»» 🧩 \e[96mPushing Images\e[0m..." \
+	echo -e "\n\e[34m»»» 🧩 \e[96mPushing Resource Processor Image\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
@@ -55,7 +55,7 @@ push-resource-processor-vm-porter-image:
 	&& docker push "$${ACR_NAME}.azurecr.io/microsoft/azuretre/resource-processor-vm-porter:$${IMAGE_TAG}"
 
 push-api-image:
-	echo -e "\n\e[34m»»» 🧩 \e[96mPushing Images\e[0m..." \
+	echo -e "\n\e[34m»»» 🧩 \e[96mPushing API Image\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \

--- a/resource_processor/shared/logging.py
+++ b/resource_processor/shared/logging.py
@@ -95,7 +95,7 @@ def shell_output_logger(console_output: str, prefix_item: str, logger: logging.L
     Logs the shell output (stdout/err) a line at a time with an option to remove ANSI control chars.
     """
     logger.log(logging_level, prefix_item)
-    
+
     if console_output is None:
         return
 
@@ -115,6 +115,6 @@ def shell_output_logger(console_output: str, prefix_item: str, logger: logging.L
     for string in console_output.split('\n'):
         if os.environ.get('DEBUG', False) is False:
             string = ansi_escape.sub('', string)  # removes all ANSI formatting
-        
+
         if len(string) != 0:
-            logger.log(logging_level, string)        
+            logger.log(logging_level, string)

--- a/resource_processor/shared/logging.py
+++ b/resource_processor/shared/logging.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 from opencensus.ext.azure.log_exporter import AzureLogHandler
 from opencensus.trace import config_integration
@@ -87,3 +88,33 @@ def get_message_id_logger(correlation_id: str) -> logging.LoggerAdapter:
     adapter.debug(f"Logger adapter now includes extra: {extra}")
 
     return adapter
+
+
+def shell_output_logger(console_output: str, prefix_item: str, logger: logging.LoggerAdapter, logging_level: int):
+    """
+    Logs the shell output (stdout/err) a line at a time with an option to remove ANSI control chars.
+    """
+    logger.log(logging_level, prefix_item)
+    
+    if console_output is None:
+        return
+
+    # 7-bit C1 ANSI sequences
+    ansi_escape = re.compile(r'''
+        \x1B  # ESC
+        (?:   # 7-bit C1 Fe (except CSI)
+            [@-Z\\-_]
+        |     # or [ for CSI, followed by a control sequence
+            \[
+            [0-?]*  # Parameter bytes
+            [ -/]*  # Intermediate bytes
+            [@-~]   # Final byte
+        )
+    ''', re.VERBOSE)
+
+    for string in console_output.split('\n'):
+        if os.environ.get('DEBUG', False) is False:
+            string = ansi_escape.sub('', string)  # removes all ANSI formatting
+        
+        if len(string) != 0:
+            logger.log(logging_level, string)        

--- a/resource_processor/vmss_porter/Dockerfile
+++ b/resource_processor/vmss_porter/Dockerfile
@@ -17,13 +17,15 @@ RUN apt-get update && apt-get install -y gnupg software-properties-common curl \
 # Install Porter
 RUN export PORTER_HOME=/root/.porter && curl -L https://cdn.porter.sh/latest/install-linux.sh | bash
 
-
 # Install Docker
-RUN apt-get update &&  apt-get install -y  apt-transport-https ca-certificates curl gnupg  lsb-release \
+RUN apt-get update &&  apt-get install -y apt-transport-https ca-certificates curl gnupg  lsb-release \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install jq
+RUN apt-get install -y jq
 
 ENV PATH /root/.porter/:$PATH
 

--- a/resource_processor/vmss_porter/readme.md
+++ b/resource_processor/vmss_porter/readme.md
@@ -28,17 +28,19 @@ If you use visual studio code you can set up your launch.json to include the fol
         "AZURE_CLIENT_SECRET": "",
         "AZURE_TENANT_ID": "",
         "REGISTRY_SERVER": "",
-        "ARM_SUBSCRIPTION_ID": "",
         "TERRAFORM_STATE_CONTAINER_NAME": "",
         "MGMT_RESOURCE_GROUP_NAME": "",
         "MGMT_STORAGE_ACCOUNT_NAME": "",
-        "SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE": "deploy",
-        "SERVICE_BUS_RESOURCE_REQUEST_QUEUE": "",
+        "SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE": "deploymentstatus",
+        "SERVICE_BUS_RESOURCE_REQUEST_QUEUE": "workspacequeue",
         "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE": "",
         "ARM_CLIENT_ID": "",
         "ARM_CLIENT_SECRET": "",
-        "ARM_TENANT_ID": ""
+        "ARM_TENANT_ID": "",
+        "ARM_SUBSCRIPTION_ID": "",
+        "ARM_USE_MSI": "false"
       }
+}
 ```
 
 When working locally we use a service principal (SP). This SP needs enough permissions to be able to talk to service bus and to deploy resources into the subscription. That means the service principal needs Owner access to subscription(ARM_SUBSCRIPTION_ID) and also needs **Azure Service Bus Data Sender** and **Azure Service Bus Data Receiver** on the service bus namespace defined above(SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE).

--- a/resource_processor/vmss_porter/runner.py
+++ b/resource_processor/vmss_porter/runner.py
@@ -118,7 +118,7 @@ async def build_porter_command(msg_body, env_vars):
         # if still not found, might be a special case
         if parameter_value is None:
             if parameter_name == "mgmt_acr_name":
-                parameter_value = env_vars['registry_server'].replace('.azurecr.io','')
+                parameter_value = env_vars['registry_server'].replace('.azurecr.io', '')
             elif parameter_name == "mgmt_resource_group_name":
                 parameter_value = env_vars['tfstate_resource_group_name']
 
@@ -233,7 +233,7 @@ async def get_porter_outputs(msg_body, env_vars, message_logger_adapter):
             logger_adapter.info(f"Got outputs as json: {outputs_json}")
         except ValueError:
             logger_adapter.info(f"Got outputs invalid json: {stdout}")
-        
+
         return True, outputs_json
 
 

--- a/resource_processor/vmss_porter/runner.py
+++ b/resource_processor/vmss_porter/runner.py
@@ -105,12 +105,14 @@ async def build_porter_command(msg_body, env_vars):
         logger_adapter.warning("Unknown proter parameters - explain probably failed.")
     else:
         for parameter_name in porter_parameter_keys:
-            # try to find the param in order of priorities: 
+            # try to find the param in order of priorities:
             # 1. msg parameters collection
             # 2. env_vars (e.g. terraform state ones)
             # 3. msg body root (e.g. id of the resource)
-            parameter_value = msg_body['parameters'].get(parameter_name,
-                env_vars.get(parameter_name,
+            parameter_value = msg_body['parameters'].get(
+                parameter_name,
+                env_vars.get(
+                    parameter_name,
                     msg_body.get(parameter_name)))
 
             # if still not found, might be a special case
@@ -191,7 +193,7 @@ def service_bus_message_generator(sb_message, status, deployment_message, output
         "id": sb_message["id"],
         "status": status,
         "message": f"{installation_id}: {deployment_message}"}
-    
+
     if outputs is not None:
         message_dict["outputs"] = outputs
 

--- a/workspaces/services/guacamole-azure-win10vm/porter.yaml
+++ b/workspaces/services/guacamole-azure-win10vm/porter.yaml
@@ -23,6 +23,12 @@ parameters:
     type: string
     description: "Resource group containing the shared ACR"
     env: PARENT_SERVICE_ID
+
+  # the following are added automatically by the resource processor
+  - name: id
+    type: string
+    description: "An Id for this installation"
+    env: id
   - name: tfstate_resource_group_name
     type: string
     description: "Resource group containing the Terraform state storage account"
@@ -68,7 +74,7 @@ install:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
         container_name: "{{ bundle.parameters.tfstate_container_name }}"
-        key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.workspace_id }}-svc-guacamole-winwin10vm"
+        key: "{{ bundle.parameters.id }}"
       outputs:
       - name: ip
       - name: hostname
@@ -95,4 +101,4 @@ uninstall:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
         container_name: "{{ bundle.parameters.tfstate_container_name }}"
-        key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.workspace_id }}-svc-guacamole-winwin10vm"
+        key: "{{ bundle.parameters.id }}"

--- a/workspaces/services/guacamole-azure-win10vm/terraform/locals.tf
+++ b/workspaces/services/guacamole-azure-win10vm/terraform/locals.tf
@@ -6,7 +6,8 @@ resource "random_string" "unique_id" {
 
 locals {
   service_id                   = random_string.unique_id.result
-  service_resource_name_suffix = "${var.tre_id}-ws-${var.workspace_id}-svc-${local.service_id}"
+  short_workspace_id           = substr(var.workspace_id, -4, -1)
+  service_resource_name_suffix = "${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.service_id}"
   core_vnet                    = "vnet-${var.tre_id}"
   core_resource_group_name     = "rg-${var.tre_id}"
   vm_name                      = "win10vm${local.service_id}"

--- a/workspaces/services/guacamole-azure-win10vm/terraform/main.tf
+++ b/workspaces/services/guacamole-azure-win10vm/terraform/main.tf
@@ -18,11 +18,11 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 data "azurerm_resource_group" "ws" {
-  name = "rg-${var.tre_id}-ws-${var.workspace_id}"
+  name = "rg-${var.tre_id}-ws-${local.short_workspace_id}"
 }
 
 data "azurerm_virtual_network" "ws" {
-  name                = "vnet-${var.tre_id}-ws-${var.workspace_id}"
+  name                = "vnet-${var.tre_id}-ws-${local.short_workspace_id}"
   resource_group_name = data.azurerm_resource_group.ws.name
 }
 
@@ -38,7 +38,7 @@ data "azurerm_subnet" "services" {
 }
 
 data "azurerm_key_vault" "kv" {
-  name                = "kv-guacamole-${var.tre_id}-${var.workspace_id}"
+  name                = "kv-guac-${var.tre_id}-${local.short_workspace_id}"
   resource_group_name = data.azurerm_resource_group.ws.name
 }
 

--- a/workspaces/services/guacamole/porter.yaml
+++ b/workspaces/services/guacamole/porter.yaml
@@ -35,7 +35,12 @@ parameters:
     type: string
     description: "Resource group containing the devops ACR"
     env: MGMT_RESOURCE_GROUP_NAME
-  # the next 4 are automaticly sent by the resource processor call, so must be present.
+  
+  # the following are added automatically by the resource processor
+  - name: id
+    type: string
+    description: "An Id for this installation"
+    env: id
   - name: tfstate_resource_group_name
     type: string
     description: "Resource group containing the Terraform state storage account"
@@ -80,7 +85,7 @@ install:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
         container_name: "{{ bundle.parameters.tfstate_container_name }}"
-        key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.workspace_id }}-svc-guacamole"
+        key: "{{ bundle.parameters.id }}"
       outputs:
       - name: connection_uri
 

--- a/workspaces/services/guacamole/porter.yaml
+++ b/workspaces/services/guacamole/porter.yaml
@@ -27,9 +27,9 @@ parameters:
     type: string
     default: "v0.1.0"
     description: "The tag of the guacamole image"
-  - name: acr_name
+  - name: mgmt_acr_name
     type: string
-    env: acr_name
+    env: mgmt_acr_name
     description: "The devops ACR name"
   - name: mgmt_resource_group_name
     type: string
@@ -75,7 +75,7 @@ install:
         tre_id: "{{ bundle.parameters.tre_id }}"
         image_name: "{{ bundle.parameters.image_name }}"
         image_tag: "{{ bundle.parameters.image_tag }}"
-        mgmt_acr_name: "{{ bundle.parameters.acr_name }}"
+        mgmt_acr_name: "{{ bundle.parameters.mgmt_acr_name }}"
         mgmt_resource_group_name: "{{ bundle.parameters.mgmt_resource_group_name }}"
         arm_client_id: "{{ bundle.credentials.azure_client_id }}"
         arm_client_secret: "{{ bundle.credentials.azure_client_secret }}"
@@ -104,7 +104,7 @@ uninstall:
         tre_id: "{{ bundle.parameters.tre_id }}"
         image_name: "{{ bundle.parameters.image_name }}"
         image_tag: "{{ bundle.parameters.image_tag }}"
-        mgmt_acr_name: "{{ bundle.parameters.acr_name }}"
+        mgmt_acr_name: "{{ bundle.parameters.mgmt_acr_name }}"
         mgmt_resource_group_name: "{{ bundle.parameters.mgmt_resource_group_name }}"
         arm_client_id: "{{ bundle.credentials.azure_client_id }}"
         arm_client_secret: "{{ bundle.credentials.azure_client_secret }}"

--- a/workspaces/services/guacamole/terraform/keyvault.tf
+++ b/workspaces/services/guacamole/terraform/keyvault.tf
@@ -1,6 +1,6 @@
 resource "azurerm_key_vault" "kv" {
   # One Keyvault across all Guacamole services
-  name                     = "kv-guacamole-${var.tre_id}-${var.workspace_id}"
+  name                     = "kv-guac-${var.tre_id}-${local.short_workspace_id}"
   location                 = data.azurerm_resource_group.ws.location
   resource_group_name      = data.azurerm_resource_group.ws.name
   sku_name                 = "standard"

--- a/workspaces/services/guacamole/terraform/locals.tf
+++ b/workspaces/services/guacamole/terraform/locals.tf
@@ -6,7 +6,8 @@ resource "random_string" "unique_id" {
 
 locals {
   service_id                   = random_string.unique_id.result
-  service_resource_name_suffix = "${var.tre_id}-ws-${var.workspace_id}-svc-${local.service_id}"
+  short_workspace_id           = substr(var.workspace_id, -4, -1)
+  service_resource_name_suffix = "${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.service_id}"
   webapp_name                  = "guacamole-${local.service_resource_name_suffix}"
   core_vnet                    = "vnet-${var.tre_id}"
   core_resource_group_name     = "rg-${var.tre_id}"

--- a/workspaces/services/guacamole/terraform/main.tf
+++ b/workspaces/services/guacamole/terraform/main.tf
@@ -22,12 +22,12 @@ data "azurerm_user_assigned_identity" "vmss_id" {
 }
 
 data "azurerm_resource_group" "ws" {
-  name = "rg-${var.tre_id}-ws-${var.workspace_id}"
+  name = "rg-${var.tre_id}-ws-${local.short_workspace_id}"
 }
 
 data "azurerm_virtual_network" "ws" {
-  name                = "vnet-${var.tre_id}-ws-${var.workspace_id}"
-  resource_group_name = "rg-${var.tre_id}-ws-${var.workspace_id}"
+  name                = "vnet-${var.tre_id}-ws-${local.short_workspace_id}"
+  resource_group_name = "rg-${var.tre_id}-ws-${local.short_workspace_id}"
 }
 
 data "azurerm_subnet" "web_apps" {

--- a/workspaces/vanilla/porter.yaml
+++ b/workspaces/vanilla/porter.yaml
@@ -46,7 +46,7 @@ parameters:
 mixins:
   - exec
   - terraform:
-      clientVersion: 0.15.4
+      clientVersion: 1.0.4
 
 install:
   - terraform:


### PR DESCRIPTION
# PR for issue #629 

## What is being addressed

Deployment via porter expose outputs we need to persist 

## How is this addressed

- Extract porter outputs and return in the deployment status message
- Change the way we prepare parameters for porter to allow for bundles without Terraform and also prioritize how the value sources
- Bundle meant to be deployed into workspaces (e.g. guacamole/vm) should be using the resource id as the Terraform store key
- Change guacamole/vm templates to make use special params (like workspace_id) automatically

### Additional
- Remove ANSI control chars from the shell outputs - will make it easier to read on app insights.