### PR TITLE
Adds creation of client secret for TRE API app registration

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -8,7 +8,7 @@ This document describes the authentication and authorization (A&A) of deployed A
 App registrations (represented by service principals) define the privileges enabling access to the TRE system (e.g., [Management API](../management_api_app/README.md)) as well as the workspaces.
 
 <!-- markdownlint-disable-next-line MD013 -->
-> **Note:** Run the [`/scripts/aad-app-reg.sh`](../scripts/aad-app-reg.sh) script to create the two main app registrations: "TRE API" and "TRE Swagger UI". You can also choose to create the app registrations manually via Azure Portal - see [Quickstart: Register an application with the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app) on how.
+> **Note:** Run the [`/scripts/aad-app-reg.sh`](../scripts/aad-app-reg.sh) script to create the two main app registrations: "TRE API" and "TRE Swagger UI". The script will create an app password (client secret) for the "TRE API" app; make sure to take note of it in the script ouput as it is only shown once. You can also choose to create the app registrations manually via Azure Portal - see [Quickstart: Register an application with the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-register-app) on how.
 
 Workspaces rely on app registrations as well, and those are documented under [Workspaces](#workspaces).
 

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 
 usage()
 {
-	echo "Usage: $(basename $BASH_SOURCE) -n <app-name> [-r <reply-url>] [-a]" 1>&2
-	echo 1>&2
-	echo 'For example:' 1>&2
-	echo "./$(basename $BASH_SOURCE) -n TRE -r https://mydre.region.cloudapp.azure.com/oidc-redirect" 1>&2
-	echo 1>&2
-	exit 1
+    echo "Usage: $(basename $BASH_SOURCE) -n <app-name> [-r <reply-url>] [-a]" 1>&2
+    echo 1>&2
+    echo 'For example:' 1>&2
+    echo "./$(basename $BASH_SOURCE) -n TRE -r https://mydre.region.cloudapp.azure.com/oidc-redirect" 1>&2
+    echo 1>&2
+    exit 1
 }
 
 # This function polls looking for an app registration with the given ID.
@@ -38,8 +38,8 @@ wait_for_new_app_registration()
 }
 
 if ! command -v az &> /dev/null; then
-	echo "This script requires Azure CLI" 1>&2
-	exit 1
+    echo "This script requires Azure CLI" 1>&2
+    exit 1
 fi
 
 declare grantAdminConsent=0
@@ -51,31 +51,31 @@ declare msGraphUri="https://graph.microsoft.com/v1.0"
 
 # Initialize parameters specified from command line
 while getopts ":n:r:a" arg; do
-	case "${arg}" in
-		n)
-			appName=${OPTARG}
-		;;
-		r)
-			replyUrl=${OPTARG}
-		;;
-		a)
-			grantAdminConsent=1
-		;;
-		?)
-			echo "Invalid option: -${OPTARG}."
-			exit 2
-		;;
-	esac
+    case "${arg}" in
+        n)
+            appName=${OPTARG}
+        ;;
+        r)
+            replyUrl=${OPTARG}
+        ;;
+        a)
+            grantAdminConsent=1
+        ;;
+        ?)
+            echo "Invalid option: -${OPTARG}."
+            exit 2
+        ;;
+    esac
 done
 
 if [[ -z "$appName" ]]; then
-	echo "Please specify the application name" 1>&2
-	usage
+    echo "Please specify the application name" 1>&2
+    usage
 fi
 
 if [[ $(az account list --only-show-errors -o json | jq 'length') -eq 0 ]]; then
-	echo "Please run az login -t <tenant> --allow-no-subscriptions"
-	exit 1
+    echo "Please run az login -t <tenant> --allow-no-subscriptions"
+    exit 1
 fi
 
 declare tenant=$( az rest -m get -u https://graph.microsoft.com/v1.0/domains -o json | jq -r '.value[] | select(.isDefault == true) | .id')
@@ -99,84 +99,84 @@ declare workspaceWriteId=$(cat /proc/sys/kernel/random/uuid)
 declare apiAppObjectId=""
 
 function get_existing_app() {
-	local existingApiApps=$(az ad app list --display-name "$1" -o json)
+    local existingApiApps=$(az ad app list --display-name "$1" -o json)
 
-	if [[ $(echo ${existingApiApps} | jq 'length') -gt 1 ]]; then
-		echo "There are more than one applications with the name \"$1\" already."
-		exit 1
-	fi
+    if [[ $(echo ${existingApiApps} | jq 'length') -gt 1 ]]; then
+        echo "There are more than one applications with the name \"$1\" already."
+        exit 1
+    fi
 
-	if [[ $(echo ${existingApiApps} | jq 'length') -eq 1 ]]; then
-		echo "${existingApiApps}" | jq -c '.[0]'
-		return 0
-	fi
+    if [[ $(echo ${existingApiApps} | jq 'length') -eq 1 ]]; then
+        echo "${existingApiApps}" | jq -c '.[0]'
+        return 0
+    fi
 
-	return 1
+    return 1
 }
 
 # Is the API app already registered?
 declare existingApiApp=$(get_existing_app "${appName} API")
 
 if [[ -n ${existingApiApp} ]]; then
-	apiAppObjectId=$(echo ${existingApiApp} | jq -r '.objectId')
-	# Get existing ids of roles and scopes.
-	userRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREUser").id')
-	adminRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREAdmin").id')
-	workspaceReadId=$(echo "$existingApiApp" | jq -r '.oauth2Permissions[] | select(.value == "Workspace.Read").id')
-	workspaceWriteId=$(echo "$existingApiApp" | jq -r '.oauth2Permissions[] | select(.value == "Workspace.Write").id')
+    apiAppObjectId=$(echo ${existingApiApp} | jq -r '.objectId')
+    # Get existing ids of roles and scopes.
+    userRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREUser").id')
+    adminRoleId=$(echo "$existingApiApp" | jq -r '.appRoles[] | select(.value == "TREAdmin").id')
+    workspaceReadId=$(echo "$existingApiApp" | jq -r '.oauth2Permissions[] | select(.value == "Workspace.Read").id')
+    workspaceWriteId=$(echo "$existingApiApp" | jq -r '.oauth2Permissions[] | select(.value == "Workspace.Write").id')
 
-	if [[ -z "${userRoleId}" ]]; then userRoleId=$(cat /proc/sys/kernel/random/uuid); fi
-	if [[ -z "${adminRoleId}" ]]; then adminRoleId=$(cat /proc/sys/kernel/random/uuid); fi
-	if [[ -z "${workspaceReadId}" ]]; then workspaceReadId=$(cat /proc/sys/kernel/random/uuid); fi
-	if [[ -z "${workspaceWriteId}" ]]; then workspaceWriteId=$(cat /proc/sys/kernel/random/uuid); fi
+    if [[ -z "${userRoleId}" ]]; then userRoleId=$(cat /proc/sys/kernel/random/uuid); fi
+    if [[ -z "${adminRoleId}" ]]; then adminRoleId=$(cat /proc/sys/kernel/random/uuid); fi
+    if [[ -z "${workspaceReadId}" ]]; then workspaceReadId=$(cat /proc/sys/kernel/random/uuid); fi
+    if [[ -z "${workspaceWriteId}" ]]; then workspaceWriteId=$(cat /proc/sys/kernel/random/uuid); fi
 fi
 
 declare appRoles=$(jq -c . << JSON
 [
-	{
-		"id": "${userRoleId}",
-		"allowedMemberTypes": [ "User" ],
-		"description": "Provides access to the ${appName} application.",
-		"displayName": "TRE Users",
-		"isEnabled": true,
-		"origin": "Application",
-		"value": "TREUser"
-	},
-	{
-		"id": "${adminRoleId}",
-		"allowedMemberTypes": [ "User" ],
-		"description": "Provides resource administrator access to the ${appName}.",
-		"displayName": "TRE Administrators",
-		"isEnabled": true,
-		"origin": "Application",
-		"value": "TREAdmin"
-	}
+    {
+        "id": "${userRoleId}",
+        "allowedMemberTypes": [ "User" ],
+        "description": "Provides access to the ${appName} application.",
+        "displayName": "TRE Users",
+        "isEnabled": true,
+        "origin": "Application",
+        "value": "TREUser"
+    },
+    {
+        "id": "${adminRoleId}",
+        "allowedMemberTypes": [ "User" ],
+        "description": "Provides resource administrator access to the ${appName}.",
+        "displayName": "TRE Administrators",
+        "isEnabled": true,
+        "origin": "Application",
+        "value": "TREAdmin"
+    }
 ]
 JSON
 )
 
 declare oauth2PermissionScopes=$(jq -c . << JSON
 [
-	{
-		"adminConsentDescription": "Allow the app to get information about the ${appName} workspaces on behalf of the signed-in user.",
-		"adminConsentDisplayName": "List and Get ${appName} Workspaces",
-		"id": "${workspaceReadId}",
-		"isEnabled": true,
-		"type": "User",
-		"userConsentDescription": "Allow the app to get information about the ${appName} workspaces on your behalf.",
-		"userConsentDisplayName": "Get the ${appName} Workspaces you have access to",
-		"value": "Workspace.Read"
-	},
-	{
-		"adminConsentDescription": "Allow the app to create, update or delete ${appName} workspaces on behalf of the signed-in user.",
-		"adminConsentDisplayName": "Modify ${appName} Workspaces",
-		"id": "${workspaceWriteId}",
-		"isEnabled": true,
-		"type": "User",
-		"userConsentDescription": "Allow the app to create, update or delete ${appName} workspaces on your behalf.",
-		"userConsentDisplayName": "Modify ${appName} Workspaces for you",
-		"value": "Workspace.Write"
-	}
+    {
+        "adminConsentDescription": "Allow the app to get information about the ${appName} workspaces on behalf of the signed-in user.",
+        "adminConsentDisplayName": "List and Get ${appName} Workspaces",
+        "id": "${workspaceReadId}",
+        "isEnabled": true,
+        "type": "User",
+        "userConsentDescription": "Allow the app to get information about the ${appName} workspaces on your behalf.",
+        "userConsentDisplayName": "Get the ${appName} Workspaces you have access to",
+        "value": "Workspace.Read"
+    },
+    {
+        "adminConsentDescription": "Allow the app to create, update or delete ${appName} workspaces on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Modify ${appName} Workspaces",
+        "id": "${workspaceWriteId}",
+        "isEnabled": true,
+        "type": "User",
+        "userConsentDescription": "Allow the app to create, update or delete ${appName} workspaces on your behalf.",
+        "userConsentDisplayName": "Modify ${appName} Workspaces for you",
+        "value": "Workspace.Write"
+    }
 ]
 JSON
 )
@@ -209,45 +209,45 @@ declare roleDirectoryReadAll=$(get_msgraph_role "Directory.Read.All" )
 
 declare apiRequiredResourceAccess=$(jq -c . << JSON
 [
-	{
-		"resourceAppId": "${msGraphAppId}",
-		"resourceAccess": [
-			${roleUserReadAll},
-			${roleDirectoryReadAll}
-		]
-	}
+    {
+        "resourceAppId": "${msGraphAppId}",
+        "resourceAccess": [
+            ${roleUserReadAll},
+            ${roleDirectoryReadAll}
+        ]
+    }
 ]
 JSON
 )
 
 declare apiApp=$(jq -c . << JSON
 {
-	"displayName": "${appName} API",
-	"api": {
-		"requestedAccessTokenVersion": 2,
-		"oauth2PermissionScopes": ${oauth2PermissionScopes}
-	},
-	"appRoles": ${appRoles},
-	"signInAudience": "AzureADMyOrg",
-	"requiredResourceAccess": ${apiRequiredResourceAccess}
+    "displayName": "${appName} API",
+    "api": {
+        "requestedAccessTokenVersion": 2,
+        "oauth2PermissionScopes": ${oauth2PermissionScopes}
+    },
+    "appRoles": ${appRoles},
+    "signInAudience": "AzureADMyOrg",
+    "requiredResourceAccess": ${apiRequiredResourceAccess}
 }
 JSON
 )
 
 if [[ -n ${apiAppObjectId} ]]; then
-	echo "Updating app ${apiAppObjectId}"
-	az rest --method PATCH --uri "${msGraphUri}/applications/${apiAppObjectId}" --headers Content-Type=application/json --body "${apiApp}"
-	apiAppId=$(az ad app show --id ${apiAppObjectId} --query "appId" -o tsv)
-	echo "Updated App Registration updated with ID ${apiAppId}"
+    echo "Updating app ${apiAppObjectId}"
+    az rest --method PATCH --uri "${msGraphUri}/applications/${apiAppObjectId}" --headers Content-Type=application/json --body "${apiApp}"
+    apiAppId=$(az ad app show --id ${apiAppObjectId} --query "appId" -o tsv)
+    echo "Updated App Registration updated with ID ${apiAppId}"
 else
-	apiAppId=$(az rest --method POST --uri "${msGraphUri}/applications" --headers Content-Type=application/json --body "${apiApp}" -o tsv --query "appId")
-	echo "Creating a new App Registration with ID ${apiAppId}"
+    apiAppId=$(az rest --method POST --uri "${msGraphUri}/applications" --headers Content-Type=application/json --body "${apiApp}" -o tsv --query "appId")
+    echo "Creating a new App Registration with ID ${apiAppId}"
 
     # Poll until the app registration is found in the listing.
     wait_for_new_app_registration $apiAppId
 
-	# Update to set the identifier URI.
-	az ad app update --id ${apiAppId} --identifier-uris "api://${apiAppId}"
+    # Update to set the identifier URI.
+    az ad app update --id ${apiAppId} --identifier-uris "api://${apiAppId}"
 fi
 
 # Make the current user an owner of the application.
@@ -260,8 +260,8 @@ resetPassword=0
 
 # If not, create a new service principal
 if [[ -z "$spId" ]]; then
-	spId=$(az ad sp create --id ${apiAppId} --query 'objectId' --output tsv)
-	echo "New Service Principal created with ID $spId"
+    spId=$(az ad sp create --id ${apiAppId} --query 'objectId' --output tsv)
+    echo "New Service Principal created with ID $spId"
     resetPassword=1
 else
     echo "Service Principal for the app already exists."
@@ -285,8 +285,8 @@ az ad sp update --id $spId --set tags="['WindowsAzureActiveDirectoryIntegratedAp
 
 # Grant admin consent on the required resource accesses (Graph API)
 if [[ $grantAdminConsent -eq 1 ]]; then
-	echo "Granting Admin Consent for ${apiAppId}"
-	az ad app permission admin-consent --id ${apiAppId}
+    echo "Granting Admin Consent for ${apiAppId}"
+    az ad app permission admin-consent --id ${apiAppId}
 fi
 
 # Now create the app for the Swagger UI
@@ -296,40 +296,40 @@ declare scope_offline_access=$(get_msgraph_scope "offline_access")
 
 declare swaggerRequiredResourceAccess=$(jq -c . << JSON
 [
-	{
-		"resourceAppId": "00000003-0000-0000-c000-000000000000",
-		"resourceAccess": [
-			${scope_openid},
-			${scope_offline_access}
-		]
-	},
-	{
-		"resourceAppId": "${apiAppId}",
-		"resourceAccess": [
-			{
-				"id": "${workspaceReadId}",
-				"type": "Scope"
-			},
-			{
-				"id": "${workspaceWriteId}",
-				"type": "Scope"
-			}
-		]
-	}
+    {
+        "resourceAppId": "00000003-0000-0000-c000-000000000000",
+        "resourceAccess": [
+            ${scope_openid},
+            ${scope_offline_access}
+        ]
+    },
+    {
+        "resourceAppId": "${apiAppId}",
+        "resourceAccess": [
+            {
+                "id": "${workspaceReadId}",
+                "type": "Scope"
+            },
+            {
+                "id": "${workspaceWriteId}",
+                "type": "Scope"
+            }
+        ]
+    }
 ]
 JSON
 )
 
 declare swaggerUIApp=$(jq -c . << JSON
 {
-	"displayName": "${appName} Swagger UI",
-	"signInAudience": "AzureADMyOrg",
-	"requiredResourceAccess": ${swaggerRequiredResourceAccess},
-	"spa": {
-		"redirectUris": [
-			"http://localhost:8000/docs/oauth2-redirect"
-		]
-	}
+    "displayName": "${appName} Swagger UI",
+    "signInAudience": "AzureADMyOrg",
+    "requiredResourceAccess": ${swaggerRequiredResourceAccess},
+    "spa": {
+        "redirectUris": [
+            "http://localhost:8000/docs/oauth2-redirect"
+        ]
+    }
 }
 JSON
 )
@@ -339,14 +339,14 @@ echo "Register the \"${appName}Swagger UI\" application"
 # Is the API app already registered?
 declare existingSwaggerUIApp=$(get_existing_app "${appName} Swagger UI")
 if [[ -n ${existingSwaggerUIApp} ]]; then
-	swaggerUIAppObjectId=$(echo "${existingSwaggerUIApp}" | jq -r '.objectId')
-	echo "Updating app ${swaggerUIAppObjectId}"
-	az rest --method PATCH --uri "${msGraphUri}/applications/${swaggerUIAppObjectId}" --headers Content-Type=application/json --body "${swaggerUIApp}"
-	swaggerAppId=$(az ad app show --id ${swaggerUIAppObjectId} --query "appId" -o tsv)
-	echo "Updated App Registration with ID ${swaggerAppId}"
+    swaggerUIAppObjectId=$(echo "${existingSwaggerUIApp}" | jq -r '.objectId')
+    echo "Updating app ${swaggerUIAppObjectId}"
+    az rest --method PATCH --uri "${msGraphUri}/applications/${swaggerUIAppObjectId}" --headers Content-Type=application/json --body "${swaggerUIApp}"
+    swaggerAppId=$(az ad app show --id ${swaggerUIAppObjectId} --query "appId" -o tsv)
+    echo "Updated App Registration with ID ${swaggerAppId}"
 else
-	swaggerAppId=$(az rest --method POST --uri "${msGraphUri}/applications" --headers Content-Type=application/json --body "${swaggerUIApp}" -o tsv --query "appId")
-	echo "Creating a new App Registration with ID ${swaggerAppId}"
+    swaggerAppId=$(az rest --method POST --uri "${msGraphUri}/applications" --headers Content-Type=application/json --body "${swaggerUIApp}" -o tsv --query "appId")
+    echo "Creating a new App Registration with ID ${swaggerAppId}"
 
     # Poll until the app registration is found in the listing.
     wait_for_new_app_registration $swaggerAppId
@@ -360,13 +360,13 @@ swaggerSpId=$(az ad sp list --filter "appId eq '${swaggerAppId}'" --query '[0].o
 
 # If not, create a new service principal
 if [[ -z "$swaggerSpId" ]]; then
-	swaggerSpId=$(az ad sp create --id ${swaggerAppId} --query 'objectId' --output tsv)
-	echo "New Service Principal created with ID $swaggerSpId"
+    swaggerSpId=$(az ad sp create --id ${swaggerAppId} --query 'objectId' --output tsv)
+    echo "New Service Principal created with ID $swaggerSpId"
 fi
 
 # Grant admin consent on the required resources
 if [[ $grantAdminConsent -eq 1 ]]; then
-	az ad app permission admin-consent --id ${swaggerAppId}
+    az ad app permission admin-consent --id ${swaggerAppId}
 fi
 
 echo "Done"

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -361,7 +361,7 @@ swaggerSpId=$(az ad sp list --filter "appId eq '${swaggerAppId}'" --query '[0].o
 # If not, create a new service principal
 if [[ -z "$swaggerSpId" ]]; then
 	swaggerSpId=$(az ad sp create --id ${swaggerAppId} --query 'objectId' --output tsv)
-	echo "New Service Principal created with id $swaggerSpId"
+	echo "New Service Principal created with ID $swaggerSpId"
 fi
 
 # Grant admin consent on the required resources

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -17,16 +17,16 @@ usage()
 # If after the number of retries no app registration is found, the function exits.
 wait_for_new_app_registration()
 {
-    apiAppId=$1
+    appId=$1
     retries=10
     counter=0
-    objectId=$(az ad app list --filter "appId eq '${apiAppId}'" --query '[0].objectId' --output tsv)
+    objectId=$(az ad app list --filter "appId eq '${appId}'" --query '[0].objectId' --output tsv)
 
     while [[ -z $objectId && $counter -lt $retries ]]; do
         counter=$((counter+1))
-        echo "Waiting for App Registration with ID ${apiAppId} to show up (${counter}/${retries})..."
+        echo "Waiting for App Registration with ID ${appId} to show up (${counter}/${retries})..."
         sleep 5
-        objectId=$(az ad app list --filter "appId eq '${apiAppId}'" --query '[0].objectId' --output tsv)
+        objectId=$(az ad app list --filter "appId eq '${appId}'" --query '[0].objectId' --output tsv)
     done
 
     if [[ -z $objectId ]]; then
@@ -34,7 +34,7 @@ wait_for_new_app_registration()
         exit 1
     fi
 
-    echo "App Registration with ID ${apiAppId} found"
+    echo "App Registration with ID ${appId} found"
 }
 
 if ! command -v az &> /dev/null; then

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -369,4 +369,4 @@ if [[ $grantAdminConsent -eq 1 ]]; then
 	az ad app permission admin-consent --id ${swaggerAppId}
 fi
 
-echo "done"
+echo "Done"


### PR DESCRIPTION
# PR for issue #603 

## What is being addressed and how

* Adds creation of a client secret for the "TRE API" app registration in `aad-app-reg.sh` script
* Fixes the async bug in the script by adding a polling loop - when creating a new app registration, it can take a moment to happen and if it's not ready, the script will fail
* Updates documentation to note that the client secret needs to be retrieved from the script output
* Tabs to spaces!!!

## Sample output

Fresh run:

```plaintext
$ ./aad-app-reg.sh -n MyTestApp123 -r https://not.real/redirect
You are about to create App Registrations in the Azure AD Tenant ***.
Do you want to continue? (y/N) y
Creating a new App Registration with ID 55c67e11-ed08-45b8-a429-b2c4d90d23ed
Waiting for App Registration with ID 55c67e11-ed08-45b8-a429-b2c4d90d23ed to show up (1/10)...
Waiting for App Registration with ID 55c67e11-ed08-45b8-a429-b2c4d90d23ed to show up (2/10)...
Waiting for App Registration with ID 55c67e11-ed08-45b8-a429-b2c4d90d23ed to show up (3/10)...
App Registration with ID 55c67e11-ed08-45b8-a429-b2c4d90d23ed found
New Service Principal created with ID e7ac6014-8470-4257-9d1b-e92fc3c92eb1
WARNING: The output includes credentials that you must protect. Be sure that you do not include these credentials in your code or check the credentials into your source control. For more information, see https://aka.ms/azadsp-cli
MyTestApp123 API app password (client secret): ***
Register the "MyTestApp123Swagger UI" application
Creating a new App Registration with ID b3076491-def0-4457-a7a9-eec78256b041
Waiting for App Registration with ID b3076491-def0-4457-a7a9-eec78256b041 to show up (1/10)...
App Registration with ID b3076491-def0-4457-a7a9-eec78256b041 found
New Service Principal created with id 854ce73d-d523-4cac-934f-78098eeceb79
Done
```

Second run:

```plaintext
$ ./aad-app-reg.sh -n MyTestApp123 -r https://not.real/redirect
You are about to create App Registrations in the Azure AD Tenant ***.
Do you want to continue? (y/N) y
Updating app c557798a-0720-4c1f-9d66-0af7f79fe4eb
Updated App Registration updated with ID 55c67e11-ed08-45b8-a429-b2c4d90d23ed
Service Principal for the app already exists.
Existing passwords (client secrets) cannot be queried. To view the password it needs to be reset.
Do you wish to reset the MyTestApp123 API app password (y/N)? y
WARNING: The output includes credentials that you must protect. Be sure that you do not include these credentials in your code or check the credentials into your source control. For more information, see https://aka.ms/azadsp-cli
MyTestApp123 API app password (client secret): ***
Register the "MyTestApp123Swagger UI" application
Updating app 63995759-215e-4bb6-88b1-576fa28a1c44
Updated App Registration with ID b3076491-def0-4457-a7a9-eec78256b041
Done
```