### PR TITLE
Remove contributor role from api identity

### DIFF
--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -216,6 +216,8 @@ resource "azurerm_monitor_diagnostic_setting" "webapp_management_api" {
   }
 }
 
-output "management_api_fqdn" {
-  value = azurerm_app_service.management_api.default_site_hostname
+resource "azurerm_role_assignment" "acrpull_role" {
+  scope                = var.acr_id
+  role_definition_name = "AcrPull"
+  principal_id         = var.managed_identity.principal_id
 }

--- a/templates/core/terraform/api-webapp/output.tf
+++ b/templates/core/terraform/api-webapp/output.tf
@@ -1,3 +1,7 @@
-output "app_service_plan_id" {
-  value = azurerm_app_service_plan.core.id
+# output "app_service_plan_id" {
+#   value = azurerm_app_service_plan.core.id
+# }
+
+output "management_api_fqdn" {
+  value = azurerm_app_service.management_api.default_site_hostname
 }

--- a/templates/core/terraform/api-webapp/output.tf
+++ b/templates/core/terraform/api-webapp/output.tf
@@ -1,7 +1,3 @@
-# output "app_service_plan_id" {
-#   value = azurerm_app_service_plan.core.id
-# }
-
 output "management_api_fqdn" {
   value = azurerm_app_service.management_api.default_site_hostname
 }

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -21,3 +21,4 @@ variable "swagger_ui_client_id" {}
 variable "aad_tenant_id" {}
 variable "api_client_id" {}
 variable "api_client_secret" {}
+variable "acr_id" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -105,6 +105,7 @@ module "api-webapp" {
   aad_tenant_id                              = var.aad_tenant_id
   api_client_id                              = var.api_client_id
   api_client_secret                          = var.api_client_secret
+  acr_id                                     = data.azurerm_container_registry.mgmt_acr.id
 }
 
 module "identity" {

--- a/templates/core/terraform/user-assigned-identity/identity.tf
+++ b/templates/core/terraform/user-assigned-identity/identity.tf
@@ -1,5 +1,3 @@
-data "azurerm_subscription" "current" {}
-
 resource "azurerm_user_assigned_identity" "id" {
   resource_group_name = var.resource_group_name
   location            = var.location
@@ -7,12 +5,6 @@ resource "azurerm_user_assigned_identity" "id" {
   name = "id-api-${var.tre_id}"
 
   lifecycle { ignore_changes = [tags] }
-}
-
-resource "azurerm_role_assignment" "contributor" {
-  scope                = data.azurerm_subscription.current.id
-  role_definition_name = "Contributor"
-  principal_id         = azurerm_user_assigned_identity.id.principal_id
 }
 
 resource "azurerm_role_assignment" "servicebus_sender" {

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -3,7 +3,6 @@ variable "tre_id" {
   description = "Unique TRE ID"
 }
 
-
 variable "location" {
   type        = string
   description = "Azure location (region) for deployment of core TRE services"


### PR DESCRIPTION
# PR for issue #671 

## What is being addressed

API identity doesn't need contributor role over the Azure subscription and is removed here.