### PR TITLE
Persist outputs returned on deployment status

### DIFF
--- a/management_api_app/models/domain/resource.py
+++ b/management_api_app/models/domain/resource.py
@@ -57,3 +57,8 @@ class Resource(AzureTREModel):
             "version": self.resourceTemplateVersion,
             "parameters": self.resourceTemplateParameters
         }
+
+
+class Output(AzureTREModel):
+    Name: str = Field(title="", description="")
+    Value: str = Field(title="", description="")

--- a/management_api_app/models/domain/workspace.py
+++ b/management_api_app/models/domain/workspace.py
@@ -1,10 +1,11 @@
 from enum import Enum
+from typing import List
 
 from pydantic import Field
 from pydantic.types import UUID4
 
 from models.domain.azuretremodel import AzureTREModel
-from models.domain.resource import Resource, ResourceType, Status
+from models.domain.resource import Resource, ResourceType, Status, Output
 
 
 class WorkspaceRole(Enum):
@@ -17,6 +18,7 @@ class DeploymentStatusUpdateMessage(AzureTREModel):
     id: UUID4 = Field(title="", description="")
     status: Status = Field(title="", description="")
     message: str = Field(title="", description="")
+    outputs: List[Output] = Field(title="", description="", default=[])
 
 
 class Workspace(Resource):

--- a/management_api_app/requirements.txt
+++ b/management_api_app/requirements.txt
@@ -1,15 +1,15 @@
 # API
-fastapi[all]==0.65.2
+fastapi[all]==0.68.0
 fastapi-utils==0.2.1
 uvicorn[standard]==0.13.0
 gunicorn==20.1.0
 aiohttp==3.7.4.post0
-azure-core==1.15.0
+azure-core==1.17.0
 azure-cosmos==4.2.0
-azure-identity==1.6.0
+azure-identity==1.6.1
 azure-mgmt-cosmosdb==6.4.0
-azure-servicebus==7.2.0
+azure-servicebus==7.3.2
 opencensus-ext-azure==1.0.8
 opencensus-ext-logging==0.1.0
-msal==1.12.0
+msal==1.13.0
 jsonschema[format_nongpl]==3.2.0

--- a/management_api_app/service_bus/deployment_status_update.py
+++ b/management_api_app/service_bus/deployment_status_update.py
@@ -74,6 +74,12 @@ def create_updated_deployment_document(resource: dict, message: DeploymentStatus
     resource["deployment"]["status"] = message.status
     resource["deployment"]["message"] = message.message
 
+    # although outputs are likely to be relevant when resources are moving to "deployed" status,
+    # lets not limit when we update them and have the resource process make that decision.
+    output_dict = {output.Name: output.Value.strip("'").strip('"') for output in message.outputs}
+
+    resource["resourceTemplateParameters"].update(output_dict)
+
     return resource
 
 

--- a/management_api_app/tests_ma/test_service_bus/test_deployment_status_update.py
+++ b/management_api_app/tests_ma/test_service_bus/test_deployment_status_update.py
@@ -25,6 +25,16 @@ test_sb_message = {
     "message": "test message"
 }
 
+test_sb_message_with_outputs = {
+    "id": "59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
+    "status": Status.Deployed,
+    "message": "test message",
+    "outputs": [
+        {"Name": "name1", "Value": "value1", "Type": "type1"},
+        {"Name": "name2", "Value": "\"value2\"", "Type": "type2"}
+    ]
+}
+
 
 class ServiceBusReceivedMessageMock:
     def __init__(self, message: dict):
@@ -185,3 +195,54 @@ async def test_state_transitions_from_deployed_to_delete_failed(app, sb_client, 
     await receive_message_and_update_deployment(app)
 
     repo().update_item_dict.assert_called_once_with(expected_workspace.dict())
+
+
+@patch('service_bus.deployment_status_update.ResourceRepository')
+@patch('logging.error')
+@patch('service_bus.deployment_status_update.ServiceBusClient')
+@patch('fastapi.FastAPI')
+async def test_outputs_are_added_to_resource_item(app, sb_client, logging_mock, repo):
+    received_message = test_sb_message_with_outputs
+    received_message["status"] = Status.Deployed
+    service_bus_received_message_mock = ServiceBusReceivedMessageMock(received_message)
+
+    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[service_bus_received_message_mock])
+    sb_client().get_queue_receiver().complete_message = AsyncMock()
+
+    resource = create_sample_workspace_object(received_message["id"])
+    resource.resourceTemplateParameters = {"exitingName": "exitingValue"}
+    repo().get_resource_dict_by_id.return_value = resource.dict()
+
+    new_params = {"name1": "value1", "name2": "value2"}
+
+    expected_resource = resource
+    expected_resource.resourceTemplateParameters = {**resource.resourceTemplateParameters, **new_params}
+    expected_resource.deployment = Deployment(status=Status.Deployed, message=received_message["message"])
+
+    await receive_message_and_update_deployment(app)
+
+    repo().update_item_dict.assert_called_once_with(expected_resource.dict())
+
+
+@patch('service_bus.deployment_status_update.ResourceRepository')
+@patch('logging.error')
+@patch('service_bus.deployment_status_update.ServiceBusClient')
+@patch('fastapi.FastAPI')
+async def test_resourceTemplateParameters_dont_change_with_no_outputs(app, sb_client, logging_mock, repo):
+    received_message = test_sb_message
+    received_message["status"] = Status.Deployed
+    service_bus_received_message_mock = ServiceBusReceivedMessageMock(received_message)
+
+    sb_client().get_queue_receiver().receive_messages = AsyncMock(return_value=[service_bus_received_message_mock])
+    sb_client().get_queue_receiver().complete_message = AsyncMock()
+
+    resource = create_sample_workspace_object(received_message["id"])
+    resource.resourceTemplateParameters = {"exitingName": "exitingValue"}
+    repo().get_resource_dict_by_id.return_value = resource.dict()
+
+    expected_resource = resource
+    expected_resource.deployment = Deployment(status=Status.Deployed, message=received_message["message"])
+
+    await receive_message_and_update_deployment(app)
+
+    repo().update_item_dict.assert_called_once_with(expected_resource.dict())


### PR DESCRIPTION
# PR for issue #689 

## What is being addressed

Outputs should be persisted.

## How is this addressed

- API now reads the outputs returned in deployment status messages and saves to the resource on cosmos.
