### PR TITLE
API always adds tre_id param to every resource

### DIFF
--- a/management_api_app/db/repositories/resources.py
+++ b/management_api_app/db/repositories/resources.py
@@ -35,6 +35,9 @@ class ResourceRepository(BaseRepository):
         template = template_repo.get_current_template(template_name, resource_type)
         return template_repo.enrich_template(template)
 
+    def get_resource_base_spec_params(self):
+        return {"tre_id": config.TRE_ID}
+
     def get_resource_dict_by_id(self, resource_id: UUID4) -> dict:
         query = self._active_resources_by_id_query(str(resource_id))
         resources = self.query(query=query)

--- a/management_api_app/db/repositories/user_resources.py
+++ b/management_api_app/db/repositories/user_resources.py
@@ -24,6 +24,9 @@ class UserResourceRepository(ResourceRepository):
 
         template_version = self.validate_input_against_template(user_resource_input.userResourceType, user_resource_input, ResourceType.UserResource)
 
+        # we don't want something in the input to overwrite the system parameters, so dict.update can't work.
+        resource_spec_parameters = {**user_resource_input.properties, **self.get_user_resource_spec_params()}
+
         user_resource = UserResource(
             id=full_user_resource_id,
             workspaceId=workspace_id,
@@ -31,7 +34,7 @@ class UserResourceRepository(ResourceRepository):
             parentWorkspaceServiceId=parent_workspace_service_id,
             resourceTemplateName=user_resource_input.userResourceType,
             resourceTemplateVersion=template_version,
-            resourceTemplateParameters=user_resource_input.properties,
+            resourceTemplateParameters=resource_spec_parameters,
             deployment=Deployment(status=Status.NotDeployed, message=strings.RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE)
         )
 
@@ -48,3 +51,6 @@ class UserResourceRepository(ResourceRepository):
     def get_user_resource_by_id(self, resource_id: str) -> UserResource:
         user_resource = self.get_resource_dict_by_type_and_id(resource_id, ResourceType.UserResource)
         return parse_obj_as(UserResource, user_resource)
+
+    def get_user_resource_spec_params(self):
+        return self.get_resource_base_spec_params()

--- a/management_api_app/db/repositories/workspace_services.py
+++ b/management_api_app/db/repositories/workspace_services.py
@@ -40,17 +40,23 @@ class WorkspaceServiceRepository(ResourceRepository):
         workspace_service = self.get_resource_dict_by_type_and_id(workspace_service_id, ResourceType.WorkspaceService)
         return parse_obj_as(WorkspaceService, workspace_service)
 
+    def get_workspace_service_spec_params(self):
+        return self.get_resource_base_spec_params()
+
     def create_workspace_service_item(self, workspace_service_input: WorkspaceServiceInCreate, workspace_id: str) -> WorkspaceService:
         full_workspace_service_id = str(uuid.uuid4())
 
         template_version = self.validate_input_against_template(workspace_service_input.workspaceServiceType, workspace_service_input, ResourceType.WorkspaceService)
+
+        # we don't want something in the input to overwrite the system parameters, so dict.update can't work.
+        resource_spec_parameters = {**workspace_service_input.properties, **self.get_workspace_service_spec_params()}
 
         workspace_service = WorkspaceService(
             id=full_workspace_service_id,
             workspaceId=workspace_id,
             resourceTemplateName=workspace_service_input.workspaceServiceType,
             resourceTemplateVersion=template_version,
-            resourceTemplateParameters=workspace_service_input.properties,
+            resourceTemplateParameters=resource_spec_parameters,
             deployment=Deployment(status=Status.NotDeployed, message=strings.RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE)
         )
 

--- a/management_api_app/tests_ma/test_db/test_repositories/test_user_resource_repository.py
+++ b/management_api_app/tests_ma/test_db/test_repositories/test_user_resource_repository.py
@@ -10,7 +10,7 @@ from models.schemas.user_resource import UserResourceInCreate
 
 @pytest.fixture
 def basic_user_resource_request():
-    return UserResourceInCreate(userResourceType="user-resource-type", properties={"display_name": "test", "description": "test"})
+    return UserResourceInCreate(userResourceType="user-resource-type", properties={"display_name": "test", "description": "test", "tre_id": "test"})
 
 
 @pytest.fixture
@@ -31,6 +31,7 @@ def user_resource():
 
 
 @patch('db.repositories.user_resources.UserResourceRepository.validate_input_against_template')
+@patch('core.config.TRE_ID', "9876")
 def test_create_user_resource_item_creates_a_user_resource_with_the_right_values(validate_input_mock, user_resource_repo, basic_user_resource_request):
     user_resource_to_create = basic_user_resource_request
     validate_input_mock.return_value = basic_user_resource_request.userResourceType
@@ -46,6 +47,9 @@ def test_create_user_resource_item_creates_a_user_resource_with_the_right_values
     assert user_resource.workspaceId == workspace_id
     assert user_resource.parentWorkspaceServiceId == parent_workspace_service_id
     assert user_resource.ownerId == user_id
+    assert len(user_resource.resourceTemplateParameters["tre_id"]) > 0
+    # need to make sure request doesn't override system param
+    assert user_resource.resourceTemplateParameters["tre_id"] != "test"
 
 
 @patch('db.repositories.user_resources.UserResourceRepository.validate_input_against_template')

--- a/management_api_app/tests_ma/test_db/test_repositories/test_workpaces_service_repository.py
+++ b/management_api_app/tests_ma/test_db/test_repositories/test_workpaces_service_repository.py
@@ -10,7 +10,7 @@ from models.schemas.workspace_service import WorkspaceServiceInCreate
 
 @pytest.fixture
 def basic_workspace_service_request():
-    return WorkspaceServiceInCreate(workspaceServiceType="workspace-service-type", properties={"display_name": "test", "description": "test"})
+    return WorkspaceServiceInCreate(workspaceServiceType="workspace-service-type", properties={"display_name": "test", "description": "test", "tre_id": "test"})
 
 
 @pytest.fixture
@@ -71,6 +71,7 @@ def test_get_workspace_service_by_id_queries_db(workspace_service_repo, workspac
 
 
 @patch('db.repositories.workspace_services.WorkspaceServiceRepository.validate_input_against_template')
+@patch('core.config.TRE_ID', "9876")
 def test_create_workspace_service_item_creates_a_workspace_with_the_right_values(validate_input_mock, workspace_service_repo, basic_workspace_service_request, basic_workspace_service_template):
     workspace_id = "000000d3-82da-4bfc-b6e9-9a7853ef753e"
     workspace_service_to_create = basic_workspace_service_request
@@ -86,6 +87,9 @@ def test_create_workspace_service_item_creates_a_workspace_with_the_right_values
     assert workspace_service.resourceType == ResourceType.WorkspaceService
     assert workspace_service.deployment.status == Status.NotDeployed
     assert workspace_service.workspaceId == workspace_id
+    assert len(workspace_service.resourceTemplateParameters["tre_id"]) > 0
+    # need to make sure request doesn't override system param
+    assert workspace_service.resourceTemplateParameters["tre_id"] != "test"
 
 
 @patch('db.repositories.workspace_services.WorkspaceServiceRepository.validate_input_against_template')


### PR DESCRIPTION
# PR for issue #717 

## What is being addressed

API sent tre_id when creating a workspace, but relied on the user/ui to provide that when creating a workspace-service/user-resource.

## How is this addressed

- Added system param for other resources types as well
- Additional tests to verify system params don't can be overridden by user input

