### PR TITLE
Fixed the devcontainer az cli mismatch

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,12 +16,7 @@ RUN apt-get update && apt-get install -y gnupg software-properties-common curl \
     && apt-get update && apt-get install -y terraform
 
 # Install Azure CLI
-RUN apt-get update \
-    && apt-get install ca-certificates curl apt-transport-https lsb-release gnupg \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null \
-    && AZ_REPO=$(lsb_release -cs) \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list \
-    && apt-get update && apt-get -y install azure-cli
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 # Make sure docker group id matches that on WSL.
 RUN groupadd --gid 1001 docker


### PR DESCRIPTION
Azure CLI now detects Debian version and install the matching version.