### PR TITLE
Guacamole is accessible via public network

### DIFF
--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -73,6 +73,11 @@ parameters:
     type: string
     env: AAD_TENANT_ID
     description: "AAD tenant id"
+  - name: is_internal_network
+    type: boolean
+    default: true
+    env: IS_INTERNAL_NETWORK
+    description: "Determines if the web app will be available over public/internet or private networks"
   # the following are added automatically by the resource processor
   - name: id
     type: string

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -73,10 +73,10 @@ parameters:
     type: string
     env: AAD_TENANT_ID
     description: "AAD tenant id"
-  - name: is_internal_network
+  - name: is_exposed_externally
     type: boolean
-    default: true
-    env: IS_INTERNAL_NETWORK
+    default: false
+    env: IS_EXPOSED_EXTERNALLY
     description: "Determines if the web app will be available over public/internet or private networks"
   # the following are added automatically by the resource processor
   - name: id
@@ -131,6 +131,7 @@ install:
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         api_client_id: "{{ bundle.parameters.api_client_id }}"
         aad_tenant_id: "{{ bundle.parameters.aad_tenant_id }}"
+        is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
@@ -168,6 +169,7 @@ uninstall:
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         api_client_id: "{{ bundle.parameters.api_client_id }}"
         aad_tenant_id: "{{ bundle.parameters.aad_tenant_id }}"
+        is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -16,4 +16,4 @@ variable "guac_drive_path" {}
 variable "guac_disable_download" {}
 variable "api_client_id" {}
 variable "aad_tenant_id" {}
-variable "is_internal_network" {}
+variable "is_exposed_externally" {}

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -16,3 +16,4 @@ variable "guac_drive_path" {}
 variable "guac_disable_download" {}
 variable "api_client_id" {}
 variable "aad_tenant_id" {}
+variable "is_internal_network" {}

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -170,8 +170,8 @@ resource "azurerm_app_service_virtual_network_swift_connection" "guacamole" {
 }
 
 resource "azurerm_private_endpoint" "guacamole" {
-  # disabling this makes the webapp available on the public interet
-  count               = var.is_internal_network == true ? 1 : 0
+  # disabling this makes the webapp available on the public internet
+  count               = var.is_exposed_externally == false ? 1 : 0
   name                = "pe-${local.webapp_name}"
   location            = data.azurerm_resource_group.ws.location
   resource_group_name = data.azurerm_resource_group.ws.name

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -170,6 +170,8 @@ resource "azurerm_app_service_virtual_network_swift_connection" "guacamole" {
 }
 
 resource "azurerm_private_endpoint" "guacamole" {
+  # disabling this makes the webapp available on the public interet
+  count               = var.is_internal_network == true ? 1 : 0
   name                = "pe-${local.webapp_name}"
   location            = data.azurerm_resource_group.ws.location
   resource_group_name = data.azurerm_resource_group.ws.name


### PR DESCRIPTION
# PR for issue #705 

## What is being addressed

Guacamole is currently accessible via the private network which is not suitable for most use cases.

## How is this addressed

- Add a parameter that allows Guacamole to be provisioned with/out public network access by enable/disable its private endpoint.
