### PR TITLE
Internally pass AAD params

### DIFF
--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -65,14 +65,6 @@ parameters:
     default: true
     env: GUAC_DISABLE_DOWNLOAD
     description:  "Guacamole disable download configuration"
-  - name: api_client_id
-    type: string
-    env: API_CLIENT_ID
-    description: "Azure API client id"
-  - name: aad_tenant_id
-    type: string
-    env: AAD_TENANT_ID
-    description: "AAD tenant id"
   - name: is_exposed_externally
     type: boolean
     default: false
@@ -129,8 +121,6 @@ install:
         guac_drive_name: "{{ bundle.parameters.guac_drive_name }}"
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
-        api_client_id: "{{ bundle.parameters.api_client_id }}"
-        aad_tenant_id: "{{ bundle.parameters.aad_tenant_id }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
         tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
@@ -168,8 +158,6 @@ uninstall:
         guac_drive_name: "{{ bundle.parameters.guac_drive_name }}"
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
-        api_client_id: "{{ bundle.parameters.api_client_id }}"
-        aad_tenant_id: "{{ bundle.parameters.aad_tenant_id }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"

--- a/templates/workspace_services/guacamole/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/terraform/locals.tf
@@ -11,7 +11,8 @@ locals {
   webapp_name                  = "guacamole-${local.service_resource_name_suffix}"
   core_vnet                    = "vnet-${var.tre_id}"
   core_resource_group_name     = "rg-${var.tre_id}"
-  issuer                       = "https://login.microsoftonline.com/${var.aad_tenant_id}/v2.0"
+  aad_tenant_id                = data.azurerm_app_service.management_api_core.app_settings["AAD_TENANT_ID"]
+  issuer                       = "https://login.microsoftonline.com/${local.aad_tenant_id}/v2.0"
   kv_url                       = "https://kv-guac-${var.tre_id}-${local.short_workspace_id}.vault.azure.net"
   api_url                      = "https://api-${var.tre_id}.azurewebsites.net"
 }

--- a/templates/workspace_services/guacamole/terraform/main.tf
+++ b/templates/workspace_services/guacamole/terraform/main.tf
@@ -73,6 +73,11 @@ data "azurerm_network_security_group" "ws" {
   resource_group_name = data.azurerm_virtual_network.ws.resource_group_name
 }
 
+data "azurerm_app_service" "management_api_core" {
+  name                = "api-${var.tre_id}"
+  resource_group_name = "rg-${var.tre_id}"
+}
+
 output "connection_uri" {
   value = azurerm_app_service.guacamole.default_site_hostname
 }

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -14,7 +14,5 @@ variable "guac_enable_drive" {}
 variable "guac_drive_name" {}
 variable "guac_drive_path" {}
 variable "guac_disable_download" {}
-variable "api_client_id" {}
-variable "aad_tenant_id" {}
 variable "is_exposed_externally" {}
 variable "tre_resource_id" {}

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -42,7 +42,7 @@ resource "azurerm_app_service" "guacamole" {
     GUAC_DRIVE_NAME       = "${var.guac_drive_name}"
     GUAC_DRIVE_PATH       = "${var.guac_drive_path}"
     GUAC_DISABLE_DOWNLOAD = "${var.guac_disable_download}"
-    AUDIENCE              = "${var.api_client_id}"
+    AUDIENCE              = data.azurerm_app_service.management_api_core.app_settings["API_CLIENT_ID"]
     ISSUER                = local.issuer
   }
 


### PR DESCRIPTION
# PR for issue #761 

## What is being addressed

Remove Azure AD app registration params (API_CLIENT_ID, AAD_TENANT_ID) from the api call and pass them internally through terraform variables.
