### PR TITLE
API calculates address_space automatically

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -17,6 +17,8 @@ jobs:
     name: Deploy Management Infrastructure
     runs-on: ubuntu-latest
     environment: Dev
+    env:
+      TF_INPUT: 0 # interactive is off
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -73,6 +75,7 @@ jobs:
     environment: Dev
     env:
       DOCKER_BUILDKIT: 1
+      TF_INPUT: 0 # interactive is off
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -97,6 +100,7 @@ jobs:
           LOCATION: ${{ secrets.LOCATION }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
           ADDRESS_SPACE: ${{ secrets.ADDRESS_SPACE }}
+          TF_VAR_tre_address_space: ${{ secrets.TRE_ADDRESS_SPACE }}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           TF_VAR_swagger_ui_client_id: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
           TF_VAR_aad_tenant_id: "${{ secrets.AAD_TENANT_ID }}"
@@ -181,11 +185,11 @@ jobs:
           # ************************
           export RESPONSE=$(curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&resource=${RESOURCE}&client_id=${CLIENT_ID}&username=${USERNAME}&password=${PASSWORD}&scope=default)" https://login.microsoftonline.com/${AUTH_TENANT_ID}/oauth2/token)
           export TOKEN=$(jq -r '.access_token' <<< "$RESPONSE")
-          
+
           # Check if base template is already registered
           # ********************************************
           export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-base" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
-          
+
           if [[ ${STATUS_CODE} == 404 ]]
           then
             make register-bundle DIR=./templates/workspaces/base
@@ -194,7 +198,7 @@ jobs:
           # Check if azureml_devtestlabs template is already registered
           # ***********************************************************
           export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-azureml-devtestlabs" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
-          
+
           if [[ ${STATUS_CODE} == 404 ]]
           then
             make register-bundle DIR=./templates/workspaces/azureml_devtestlabs
@@ -203,7 +207,7 @@ jobs:
           # Check if innereye_deeplearning template is already registered
           # *************************************************************
           export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-innereye-deeplearning" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
-          
+
           if [[ ${STATUS_CODE} == 404 ]]
           then
             make register-bundle DIR=./templates/workspaces/innereye_deeplearning
@@ -212,7 +216,7 @@ jobs:
           # Check if innereye_deeplearning_inference template is already registered
           # ***********************************************************************
           export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-innereye-deeplearning-inference" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
-          
+
           if [[ ${STATUS_CODE} == 404 ]]
           then
             make register-bundle DIR=./templates/workspaces/innereye_deeplearning_inference
@@ -254,11 +258,11 @@ jobs:
           # ************************
           export RESPONSE=$(curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&resource=${RESOURCE}&client_id=${CLIENT_ID}&username=${USERNAME}&password=${PASSWORD}&scope=default)" https://login.microsoftonline.com/${AUTH_TENANT_ID}/oauth2/token)
           export TOKEN=$(jq -r '.access_token' <<< "$RESPONSE")
-          
+
           # Check if guacamole service template is already registered
           # *********************************************************
           export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-service-templates/tre-service-guacamole" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
-          
+
           if [[ ${STATUS_CODE} == 404 ]]
           then
             make register-bundle DIR=./templates/workspace_services/guacamole

--- a/api_app/core/config.py
+++ b/api_app/core/config.py
@@ -12,6 +12,8 @@ VERSION = "0.0.0"
 # Resource Info
 RESOURCE_LOCATION: str = config("RESOURCE_LOCATION", default="")
 TRE_ID: str = config("TRE_ID", default="")
+CORE_ADDRESS_SPACE: str = config("ADDRESS_SPACE", default="")
+TRE_ADDRESS_SPACE: str = config("TRE_ADDRESS_SPACE", default="")
 
 # State store configuration
 STATE_STORE_ENDPOINT: str = config("STATE_STORE_ENDPOINT", default="")      # Cosmos DB endpoint

--- a/api_app/services/cidr_service.py
+++ b/api_app/services/cidr_service.py
@@ -1,0 +1,46 @@
+from typing import List
+from ipaddress import IPv4Network, NetmaskValueError, collapse_addresses
+
+from core import config
+
+
+def generate_new_cidr(allocated_subnets: List[str], required_cidr_block_type: int) -> str:
+    if required_cidr_block_type >= 32 or required_cidr_block_type < 8:
+        raise NetmaskValueError("Invalid netmask for this operation.")
+
+    core_network = IPv4Network(config.CORE_ADDRESS_SPACE)
+    allocation_network = IPv4Network(config.TRE_ADDRESS_SPACE)
+
+    free_subnets = remove_subnet([allocation_network], core_network)
+
+    for subnet_string in allocated_subnets:
+        free_subnets = remove_subnet(free_subnets, IPv4Network(subnet_string))
+
+    # compare to the required subnet size and work with what is large enough
+    free_subnets = [x for x in free_subnets if x.prefixlen <= required_cidr_block_type]
+
+    if len(free_subnets) == 0:
+        raise Exception("Not enough space in network.")
+
+    # allocate in smaller subnets before larger ones
+    free_subnets.sort(key=lambda x: x.prefixlen, reverse=True)
+    allocation_subnet = free_subnets[0]
+    new_subnet = list(allocation_subnet.subnets(new_prefix=required_cidr_block_type))
+    return str(new_subnet[0])
+
+
+def remove_subnet(subnets: List[IPv4Network], exclude: IPv4Network) -> List[IPv4Network]:
+    result = []
+    # Find which subnet the exclusion is part of
+    for sub in subnets:
+        # If found, exclude & add the result
+        if exclude.subnet_of(sub):
+            result.extend(list(sub.address_exclude(exclude)))
+        else:
+            # Other subnets can be added directly
+            result.append(sub)
+
+    # Collapse in case of overlaps
+    new_result = list(collapse_addresses(result))
+    new_result.sort()
+    return new_result

--- a/api_app/tests_ma/test_services/test_cidr_service.py
+++ b/api_app/tests_ma/test_services/test_cidr_service.py
@@ -1,0 +1,35 @@
+import ipaddress
+import pytest
+from mock import patch
+
+import services.cidr_service
+
+generate_new_cidr_test_data = [
+    (["10.2.4.0/24", "10.1.0.0/16", "10.2.1.0/24", "10.2.3.0/24", "10.2.0.0/24", "10.2.2.0/24"], 24, "10.2.5.0/24"),
+    (["10.2.4.0/24", "10.1.0.0/16", "10.2.1.0/24", "10.2.3.0/24", "10.2.0.0/24", "10.2.2.0/24"], 16, "10.3.0.0/16"),
+    (["10.1.0.0/16"], 24, "10.2.0.0/24"),
+    (["10.1.0.0/16"], 16, "10.2.0.0/16"),
+    (["10.1.0.0/16", "10.2.1.0/24"], 24, "10.2.0.0/24"),
+    (["10.2.1.0/24", "10.1.0.0/16"], 16, "10.3.0.0/16"),
+    (["10.1.0.0/16", "10.5.1.0/24"], 16, "10.4.0.0/16"),
+    (["10.2.1.0/24", "10.1.0.0/16"], 20, "10.2.16.0/20"),
+]
+
+
+@pytest.mark.parametrize("input_addresses, input_network_size, expected_cidr", generate_new_cidr_test_data)
+@patch('core.config.CORE_ADDRESS_SPACE', "10.0.0.0/16")
+@patch('core.config.TRE_ADDRESS_SPACE', "10.0.0.0/12")
+def test_generate_new_cidr__returns_currect_block(input_addresses, input_network_size, expected_cidr):
+    assert expected_cidr == services.cidr_service.generate_new_cidr(input_addresses, input_network_size)
+
+
+@patch('core.config.CORE_ADDRESS_SPACE', "10.5.0.0/16")
+def test_generate_new_cidr__invalid_netmask_raises_exception():
+    with pytest.raises(ipaddress.NetmaskValueError):
+        services.cidr_service.generate_new_cidr(["10.2.1.0/24", "10.1.0.0/16"], 50)
+
+
+@patch('core.config.CORE_ADDRESS_SPACE', "10.5.0.0/16")
+def test_generate_new_cidr__invalid_network_raises_exception():
+    with pytest.raises(ipaddress.AddressValueError):
+        services.cidr_service.generate_new_cidr(["10.1.0.300/16"], 24)

--- a/docs/deployment-quickstart.md
+++ b/docs/deployment-quickstart.md
@@ -123,6 +123,7 @@ All other variables can have their default values for now. You should now have a
 #  Used for TRE deployment
 TRE_ID=aztreqs
 ADDRESS_SPACE="10.1.0.0/22"
+TRE_ADDRESS_SPACE="10.0.0.0/12"
 API_IMAGE_TAG=dev
 RESOURCE_PROCESSOR_VMSS_PORTER_IMAGE_TAG=dev
 GITEA_IMAGE_TAG=dev

--- a/docs/manual-deployment.md
+++ b/docs/manual-deployment.md
@@ -38,7 +38,6 @@ cp devops/.env.sample devops/.env
 | `PORTER_OUTPUT_CONTAINER_NAME` | The name of the storage container where to store the workspace/workspace service deployment output. Workspaces and workspace templates are implemented using [Porter](https://porter.sh) bundles - hence the name of the variable. The storage account used is the one defined in `STATE_STORAGE_ACCOUNT_NAME`. |
 | `DEBUG` | If set to "true" disables purge protection of keyvault. |
 
-
 Copy [/templates/core/.env.sample](../templates/core/.env.sample) to `/templates/core/.env` and set values for all variables described in the table below:
 
 ```cmd
@@ -49,6 +48,7 @@ cp templates/core/.env.sample templates/core/.env
 | ------------------------- | ----------- |
 | `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `mytre-dev-3142` will result in a resource group name for Azure TRE instance of `rg-mytre-dev-3142`. This must be less than 12 characters. Allowed characters: Alphanumeric, underscores, and hyphens. |
 | `ADDRESS_SPACE` | The address space for the Azure TRE core virtual network. `/22` or larger. |
+| `TRE_ADDRESS_SPACE` | The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). E.g. `10.0.0.0/12`|
 | `API_IMAGE_TAG` | The tag of the API image. Make it the same as `IMAGE_TAG` above.|
 | `RESOURCE_PROCESSOR_VMSS_PORTER_IMAGE_TAG` | The tag of the resource processor image. Make it the same as `IMAGE_TAG` above.|
 | `GITEA_IMAGE_TAG` | The tag of the Gitea image. Make it the same as `IMAGE_TAG` above.|

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -20,6 +20,7 @@ These are onetime configuration steps required to set up the GitHub Actions work
 | `PORTER_OUTPUT_CONTAINER_NAME` | The name of the storage container where to store the workspace/workspace service deployment output. Workspaces and workspace templates are implemented using [Porter](https://porter.sh) bundles - hence the name of the secret. The storage account used is the same as defined by `STATE_STORAGE_ACCOUNT_NAME`. |
 | `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: Alphanumeric, underscores, and hyphens. |
 | `ADDRESS_SPACE` |  The address space for the Azure TRE core virtual network. E.g. `10.1.0.0/22`. Recommended `/22` or larger.  |
+| `TRE_ADDRESS_SPACE` | The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). E.g. `10.0.0.0/12`|
 | `SWAGGER_UI_CLIENT_ID` | The application (client) ID of the [TRE Swagger UI](./auth.md#tre-swagger-ui) service principal. |
 | `AAD_TENANT_ID` | The tenant ID of the Azure AD. |
 | `API_CLIENT_ID` | The application (client) ID of the [TRE API](./auth.md#tre-api) service principal. |

--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -45,6 +45,8 @@ resource "azurerm_app_service" "api" {
     "API_CLIENT_SECRET"                          = var.api_client_secret
     "RESOURCE_GROUP_NAME"                        = var.resource_group_name
     "SUBSCRIPTION_ID"                            = data.azurerm_subscription.current.subscription_id
+    ADDRESS_SPACE                                = var.address_space
+    TRE_ADDRESS_SPACE                            = var.tre_address_space
   }
 
   identity {

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -22,3 +22,5 @@ variable "aad_tenant_id" {}
 variable "api_client_id" {}
 variable "api_client_secret" {}
 variable "acr_id" {}
+variable "address_space" {}
+variable "tre_address_space" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -106,6 +106,8 @@ module "api-webapp" {
   api_client_id                              = var.api_client_id
   api_client_secret                          = var.api_client_secret
   acr_id                                     = data.azurerm_container_registry.mgmt_acr.id
+  address_space                              = var.address_space
+  tre_address_space                          = var.tre_address_space
 }
 
 module "identity" {

--- a/templates/core/terraform/variables.tf
+++ b/templates/core/terraform/variables.tf
@@ -22,6 +22,11 @@ variable "address_space" {
   description = "Core services VNET Address Space"
 }
 
+variable "tre_address_space" {
+  type        = string
+  description = "Overall TRE Address Space pool, will be used for workspace VNETs, can be a supernet of address_space."
+}
+
 variable "api_image_repository" {
   type        = string
   description = "Repository for API image"

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -28,7 +28,6 @@ parameters:
   - name: address_space
     type: string
     description: "VNet address space for the workspace services"
-    default: "10.2.1.0/24"
   - name: tfstate_resource_group_name
     type: string
     description: "Resource group containing the Terraform state storage account"


### PR DESCRIPTION
# PR for issue #771 

## What is being addressed

Address spaces for workspaces should be calculated automatically without the user having to provide it.

## How is this addressed

- API allows creating a workspace without providing address_space in the payload which will result in an auto-generated one. 
- Auto-generated address space is a /24 free one within the overall TRE_ADDRESS_SPACE (new "core" param)
- No change in E2E which are still using custom addresses
