### PR TITLE
Changes the devcontainer base image to buster

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
 ARG VARIANT="3"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-buster
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"


### PR DESCRIPTION
# PR for issue (bug) #770 

Changes the devcontainer base image from `bullseye` to `buster` to combat the Azure CLI problem with package version mismatch as described in bug report #770.
