### PR TITLE
Register workspace service templates

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -248,7 +248,7 @@ jobs:
           export PATH=~/.porter/:$PATH
           export USE_ENV_VARS_NOT_FILES=true
           export TRE_URL=$TRE_URL
-          export BUNDLE_TYPE=workspace-service
+          export BUNDLE_TYPE=workspace_service
 
           # Get TRE API access token
           # ************************

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -145,11 +145,130 @@ jobs:
           notification-color: dc3545
           timezone: Europe/Zurich
 
-  publish_bundles:
-    name: Publish Base Bundle
-    needs: deploy_mgmt_infra
+  publish_and_register_workspace_bundles:
+    name: Publish and Register Workspace Bundles
+    runs-on: ubuntu-latest
+    needs: [deploy_tre]
+    environment: Dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Publish and register workspace bundles
+        shell: bash
+        env:
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          RESOURCE_LOCATION: "${{ secrets.LOCATION }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
+          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          CLIENT_ID: "${{ secrets.TEST_APP_ID }}"
+          USERNAME: "${{ secrets.TEST_USER_NAME }}"
+          PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
+          AUTH_APP_CLIENT_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
+          TRE_URL: "https://${{secrets.TRE_ID}}.${{secrets.LOCATION}}.cloudapp.azure.com"
+        run: |
+          curl -L https://cdn.porter.sh/latest/install-linux.sh | bash && ~/.porter/porter mixin install docker
+          export PATH=~/.porter/:$PATH
+          export USE_ENV_VARS_NOT_FILES=true
+          export TRE_URL=$TRE_URL
+          export BUNDLE_TYPE=workspace
+
+          # Get TRE API access token
+          # ************************
+          export RESPONSE=$(curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&resource=${RESOURCE}&client_id=${CLIENT_ID}&username=${USERNAME}&password=${PASSWORD}&scope=default)" https://login.microsoftonline.com/${AUTH_TENANT_ID}/oauth2/token)
+          export TOKEN=$(jq -r '.access_token' <<< "$RESPONSE")
+          
+          # Check if base template is already registered
+          # ********************************************
+          export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-base" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
+          
+          if [[ ${STATUS_CODE} == 404 ]]
+          then
+            make register-bundle DIR=./templates/workspaces/base
+          fi
+
+          # Check if azureml_devtestlabs template is already registered
+          # ***********************************************************
+          export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-azureml-devtestlabs" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
+          
+          if [[ ${STATUS_CODE} == 404 ]]
+          then
+            make register-bundle DIR=./templates/workspaces/azureml_devtestlabs
+          fi
+
+          # Check if innereye_deeplearning template is already registered
+          # *************************************************************
+          export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-innereye-deeplearning" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
+          
+          if [[ ${STATUS_CODE} == 404 ]]
+          then
+            make register-bundle DIR=./templates/workspaces/innereye_deeplearning
+          fi
+
+          # Check if innereye_deeplearning_inference template is already registered
+          # ***********************************************************************
+          export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-templates/tre-workspace-innereye-deeplearning-inference" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
+          
+          if [[ ${STATUS_CODE} == 404 ]]
+          then
+            make register-bundle DIR=./templates/workspaces/innereye_deeplearning_inference
+          fi
+
+  publish_and_register_workspace_service_bundles:
+    name: Publish and Register Workspace Service Bundles
+    runs-on: ubuntu-latest
+    needs: [deploy_tre]
+    environment: Dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Publish and register workspace bundles
+        shell: bash
+        env:
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          RESOURCE_LOCATION: "${{ secrets.LOCATION }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
+          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          CLIENT_ID: "${{ secrets.TEST_APP_ID }}"
+          USERNAME: "${{ secrets.TEST_USER_NAME }}"
+          PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
+          AUTH_APP_CLIENT_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
+          TRE_URL: "https://${{secrets.TRE_ID}}.${{secrets.LOCATION}}.cloudapp.azure.com"
+        run: |
+          curl -L https://cdn.porter.sh/latest/install-linux.sh | bash && ~/.porter/porter mixin install docker
+          export PATH=~/.porter/:$PATH
+          export USE_ENV_VARS_NOT_FILES=true
+          export TRE_URL=$TRE_URL
+          export BUNDLE_TYPE=workspace-service
+
+          # Get TRE API access token
+          # ************************
+          export RESPONSE=$(curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&resource=${RESOURCE}&client_id=${CLIENT_ID}&username=${USERNAME}&password=${PASSWORD}&scope=default)" https://login.microsoftonline.com/${AUTH_TENANT_ID}/oauth2/token)
+          export TOKEN=$(jq -r '.access_token' <<< "$RESPONSE")
+          
+          # Check if guacamole service template is already registered
+          # *********************************************************
+          export STATUS_CODE=$(curl -X "GET" "${TRE_URL}/api/workspace-service-templates/tre-service-guacamole" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
+          
+          if [[ ${STATUS_CODE} == 404 ]]
+          then
+            make register-bundle DIR=./templates/workspace_services/guacamole
+          fi
+
+  publish_innereye_service_bundles:
+    name: Publish InnerEye Service Bundles
     runs-on: ubuntu-latest
     environment: Dev
+    needs: [deploy_tre]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -167,13 +286,16 @@ jobs:
 
           export USE_ENV_VARS_NOT_FILES=true
 
-          make porter-publish DIR=./templates/workspaces/base
+          make porter-publish DIR=./templates/workspace_services/azureml
+          make porter-publish DIR=./templates/workspace_services/devtestlabs
+          make porter-publish DIR=./templates/workspace_services/innereye_deeplearning
+          make porter-publish DIR=./templates/workspace_services/innereye_inference
 
   e2e_tests:
     name: "Run E2E Tests"
     runs-on: ubuntu-latest
     environment: Dev
-    needs: deploy_tre
+    needs: [publish_and_register_workspace_bundles, publish_and_register_workspace_service_bundles, publish_innereye_service_bundles]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -162,4 +162,4 @@ register-bundle:
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& cd ${DIR} \
-	&& ${ROOTPATH}/devops/scripts/publish_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type workspace --current --insecure
+	&& ${ROOTPATH}/devops/scripts/publish_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL} --access-token $${TOKEN}

--- a/devops/scripts/publish_register_bundle.sh
+++ b/devops/scripts/publish_register_bundle.sh
@@ -8,7 +8,7 @@ function usage() {
 
     Options:
         -r, --acr-name        Azure Container Registry Name 
-        -t, --bundle-type     Bundle type, workspace
+        -t, --bundle-type     Bundle type, workspace or workspace_service
         -c, --current:        Make this the currently deployed version of this template
         -i, --insecure:       Bypass SSL certificate checks
         -u, --tre_url:        URL for the TRE (required for automatic registration)
@@ -39,8 +39,10 @@ while [ "$1" != "" ]; do
         case $1 in
         workspace)
         ;;
+        workspace_service)
+        ;;
         *)
-            echo "Bundle type must be workspace, not $1"
+            echo "Bundle type must be workspace or workspace_service, not $1"
             exit 1
         esac
         bundle_type=$1
@@ -100,7 +102,13 @@ if [[ -n  ${access_token+x} ]]; then
     fi
 
     echo -e "Server Response:\n"
-    eval "curl -X 'POST'  $tre_url/api/workspace-templates -H 'accept: application/json'  -H 'Content-Type: application/json'  -H 'Authorization: Bearer $access_token' -d '$payload'  $options"
+
+    if [[ $bundle_type == workspace ]]
+    then
+      eval "curl -X 'POST'  $tre_url/api/workspace-templates -H 'accept: application/json'  -H 'Content-Type: application/json'  -H 'Authorization: Bearer $access_token' -d '$payload'  $options"
+    else
+      eval "curl -X 'POST'  $tre_url/api/workspace-service-templates -H 'accept: application/json'  -H 'Content-Type: application/json'  -H 'Authorization: Bearer $access_token' -d '$payload'  $options"
+    fi
     echo -e "\n"
 else
     echo -e "Use the following payload to register the template:\n\n"


### PR DESCRIPTION
# PR for issue #693

## What is being addressed

CI/CD workflow checks whether bundles have been registered to the TRE API and publishes and registers missing bundles. 

## How is this addressed

1) Bundle creation is delayed until TRE is fully deployed.
2) Three types of bundles
    a) Workspace bundles                          - need publishing to ACR registration to TRE API
    b) InnerEye (semi)service bundles        - only published to ACR
    c) Proper workspace service bundles   - need publishing to ACR registration to TRE API

