### PR TITLE
Update compute API version to 2021-01-01

### DIFF
--- a/templates/workspace_services/innereye_deeplearning/terraform/nopipcompute/deploypl_aml_compute.json
+++ b/templates/workspace_services/innereye_deeplearning/terraform/nopipcompute/deploypl_aml_compute.json
@@ -50,7 +50,7 @@
     "resources": [
         {
             "type": "Microsoft.MachineLearningServices/workspaces/computes",
-            "apiVersion": "2020-05-15-preview",
+            "apiVersion": "2021-01-01",
             "name": "[concat(parameters('workspace_name'),'/',parameters('cluster_name'))]",
             "location": "[parameters('location')]",
             "properties": {

--- a/templates/workspace_services/innereye_deeplearning/terraform/nopipcompute/deploypl_compute_cluster.json
+++ b/templates/workspace_services/innereye_deeplearning/terraform/nopipcompute/deploypl_compute_cluster.json
@@ -50,7 +50,7 @@
     "resources": [
         {
             "type": "Microsoft.MachineLearningServices/workspaces/computes",
-            "apiVersion": "2020-05-15-preview",
+            "apiVersion": "2021-01-01",
             "name": "[concat(parameters('workspace_name'),'/',parameters('cluster_name'))]",
             "location": "[parameters('location')]",
             "identity": {

--- a/templates/workspace_services/innereye_deeplearning/terraform/nopipcompute/deploypl_compute_instance.json
+++ b/templates/workspace_services/innereye_deeplearning/terraform/nopipcompute/deploypl_compute_instance.json
@@ -36,7 +36,7 @@
     "resources": [
         {
             "type": "Microsoft.MachineLearningServices/workspaces/computes",
-            "apiVersion": "2020-05-15-preview",
+            "apiVersion": "2021-01-01",
             "name": "[concat(parameters('workspace_name'),'/',parameters('instance_name'))]",
             "location": "[parameters('location')]",
             "properties": {


### PR DESCRIPTION
# Update compute API version to 2021-01-01

## What is being addressed

Version for no-public-ip compute instance has changed to 2021-01-01

## How is this addressed

- Updated yaml files to use new version
