### PR TITLE
Line break consistency between deploy.sh and destroy.sh

### DIFF
--- a/templates/core/terraform/destroy.sh
+++ b/templates/core/terraform/destroy.sh
@@ -3,4 +3,7 @@ export TF_VAR_docker_registry_username=$TF_VAR_acr_name
 export TF_VAR_docker_registry_password=$(az acr credential show --name ${TF_VAR_acr_name} --query passwords[0].value -o tsv | sed 's/"//g')
 export TF_VAR_api_image_tag=$TF_VAR_image_tag
 
-../../../devops/scripts/terraform_wrapper.sh -g $TF_VAR_mgmt_resource_group_name -s $TF_VAR_mgmt_storage_account_name  -n $TF_VAR_terraform_state_container_name -k $TF_VAR_tre_id -c "terraform destroy -auto-approve"
+../../../devops/scripts/terraform_wrapper.sh -g $TF_VAR_mgmt_resource_group_name \
+                                             -s $TF_VAR_mgmt_storage_account_name \
+                                             -n $TF_VAR_terraform_state_container_name \
+                                             -k $TF_VAR_tre_id -c "terraform destroy -auto-approve"


### PR DESCRIPTION
## What is being addressed

Formatting only

## How is this addressed

- Add line breaks to destroy.sh to break the Terraform wrapper call across lines for readability and consistency with line breaks found in deploy.sh.
