### PR TITLE
Guacamole connection URI generated during creation

### DIFF
--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/connection/ConnectionService.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/connection/ConnectionService.java
@@ -86,7 +86,6 @@ public class ConnectionService {
                         configs.putIfAbsent(config.getParameter("hostname"), config);
                     } else {
                         LOGGER.info("Missing ip or hostname, skipping...");
-                        break;
                     }
                 }
             } catch (final Exception ex) {

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -159,6 +159,7 @@ uninstall:
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
+        tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"

--- a/templates/workspace_services/guacamole/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/terraform/locals.tf
@@ -1,13 +1,7 @@
-# Random unique id
-resource "random_string" "unique_id" {
-  length      = 4
-  min_numeric = 4
-}
-
 locals {
-  service_id                   = random_string.unique_id.result
+  short_service_id             = substr(var.tre_resource_id, -4, -1)
   short_workspace_id           = substr(var.workspace_id, -4, -1)
-  service_resource_name_suffix = "${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.service_id}"
+  service_resource_name_suffix = "${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.short_service_id}"
   webapp_name                  = "guacamole-${local.service_resource_name_suffix}"
   core_vnet                    = "vnet-${var.tre_id}"
   core_resource_group_name     = "rg-${var.tre_id}"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/porter.yaml
@@ -53,6 +53,10 @@ outputs:
     type: string
     applyTo:
       - install
+  - name: connection_url
+    type: string
+    applyTo:
+      - install
 
 mixins:
   - exec
@@ -70,6 +74,7 @@ install:
         arm_client_secret: "{{ bundle.credentials.azure_client_secret }}"
         arm_tenant_id: "{{ bundle.credentials.azure_tenant_id }}"
         arm_use_msi: "{{ bundle.parameters.arm_use_msi }}"
+        tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
@@ -78,6 +83,7 @@ install:
       outputs:
       - name: ip
       - name: hostname
+      - name: connection_url
 
 upgrade:
   - exec:
@@ -97,6 +103,7 @@ uninstall:
         arm_client_secret: "{{ bundle.credentials.azure_client_secret }}"
         arm_tenant_id: "{{ bundle.credentials.azure_tenant_id }}"
         arm_use_msi: "{{ bundle.parameters.arm_use_msi }}"
+        tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/terraform/locals.tf
@@ -1,14 +1,9 @@
-# Random unique id
-resource "random_string" "unique_id" {
-  length      = 4
-  min_numeric = 4
-}
-
 locals {
-  service_id                   = random_string.unique_id.result
+  short_service_id             = substr(var.tre_resource_id, -4, -1)
   short_workspace_id           = substr(var.workspace_id, -4, -1)
-  service_resource_name_suffix = "${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.service_id}"
+  short_parent_id              = substr(var.parent_service_id, -4, -1)
+  service_resource_name_suffix = "${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.short_service_id}"
   core_vnet                    = "vnet-${var.tre_id}"
   core_resource_group_name     = "rg-${var.tre_id}"
-  vm_name                      = "win10vm${local.service_id}"
+  vm_name                      = "win10vm${local.short_service_id}"
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/terraform/main.tf
@@ -42,10 +42,19 @@ data "azurerm_key_vault" "kv" {
   resource_group_name = data.azurerm_resource_group.ws.name
 }
 
+data "azurerm_app_service" "guacamole" {
+  name                = "guacamole-${var.tre_id}-ws-${local.short_workspace_id}-svc-${local.short_parent_id}"
+  resource_group_name = data.azurerm_resource_group.ws.name
+}
+
 output "ip" {
   value = azurerm_network_interface.internal.private_ip_address
 }
 
 output "hostname" {
   value = azurerm_virtual_machine.win10vm.name
+}
+
+output "connection_url" {
+  value = "${data.azurerm_app_service.guacamole.default_site_hostname}/guacamole/#/client/${textencodebase64("${azurerm_network_interface.internal.private_ip_address}\u0000c\u0000azuretre", "UTF-8")}"
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm/terraform/variables.tf
@@ -6,3 +6,4 @@ variable "arm_client_id" {}
 variable "arm_client_secret" {}
 variable "arm_tenant_id" {}
 variable "arm_use_msi" {}
+variable "tre_resource_id" {}


### PR DESCRIPTION
# PR for issue #760 

## What is being addressed

- Generate the URI and save it as the user resource output.
- Change the names of the guacamole and windows machine services to have the service_id instead of random 4 chars.
- Fixed minor bug in the guacamole extension code.


