### PR TITLE
validate full routes

### DIFF
--- a/api_app/api/dependencies/workspaces.py
+++ b/api_app/api/dependencies/workspaces.py
@@ -19,11 +19,11 @@ def get_workspace_by_id(workspace_id: UUID4, workspaces_repo) -> Workspace:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.WORKSPACE_DOES_NOT_EXIST)
 
 
-async def get_workspace_by_workspace_id_from_path(workspace_id: UUID4 = Path(...), workspaces_repo=Depends(get_repository(WorkspaceRepository))) -> Workspace:
+async def get_workspace_by_id_from_path(workspace_id: UUID4 = Path(...), workspaces_repo=Depends(get_repository(WorkspaceRepository))) -> Workspace:
     return get_workspace_by_id(workspace_id, workspaces_repo)
 
 
-async def get_deployed_workspace_by_workspace_id_from_path(workspace_id: UUID4 = Path(...), workspaces_repo=Depends(get_repository(WorkspaceRepository))) -> Workspace:
+async def get_deployed_workspace_by_id_from_path(workspace_id: UUID4 = Path(...), workspaces_repo=Depends(get_repository(WorkspaceRepository))) -> Workspace:
     try:
         return workspaces_repo.get_deployed_workspace_by_workspace_id(workspace_id)
     except EntityDoesNotExist:
@@ -32,24 +32,24 @@ async def get_deployed_workspace_by_workspace_id_from_path(workspace_id: UUID4 =
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=strings.WORKSPACE_IS_NOT_DEPLOYED)
 
 
-async def get_workspace_service_by_id_from_path(service_id: UUID4, workspace_services_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceService:
+async def get_workspace_service_by_id_from_path(workspace_id: UUID4 = Path(...), service_id: UUID4 = Path(...), workspace_services_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceService:
     try:
-        return workspace_services_repo.get_workspace_service_by_id(service_id)
+        return workspace_services_repo.get_workspace_service_by_id(workspace_id, service_id)
     except EntityDoesNotExist:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.WORKSPACE_SERVICE_DOES_NOT_EXIST)
 
 
-async def get_deployed_workspace_service_by_id_from_path(service_id: UUID4 = Path(...), workspace_services_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceService:
+async def get_deployed_workspace_service_by_id_from_path(workspace_id: UUID4 = Path(...), service_id: UUID4 = Path(...), workspace_services_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceService:
     try:
-        return workspace_services_repo.get_deployed_workspace_service_by_id(service_id)
+        return workspace_services_repo.get_deployed_workspace_service_by_id(workspace_id, service_id)
     except EntityDoesNotExist:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.WORKSPACE_SERVICE_DOES_NOT_EXIST)
     except ResourceIsNotDeployed:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=strings.WORKSPACE_SERVICE_IS_NOT_DEPLOYED)
 
 
-async def get_user_resource_by_id_from_path(resource_id: UUID4 = Path(...), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> UserResource:
+async def get_user_resource_by_id_from_path(workspace_id: UUID4 = Path(...), service_id: UUID4 = Path(...), resource_id: UUID4 = Path(...), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> UserResource:
     try:
-        return user_resource_repo.get_user_resource_by_id(resource_id)
+        return user_resource_repo.get_user_resource_by_id(workspace_id, service_id, resource_id)
     except EntityDoesNotExist:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.USER_RESOURCE_DOES_NOT_EXIST)

--- a/api_app/api/dependencies/workspaces.py
+++ b/api_app/api/dependencies/workspaces.py
@@ -14,7 +14,7 @@ from resources import strings
 
 def get_workspace_by_id(workspace_id: UUID4, workspaces_repo) -> Workspace:
     try:
-        return workspaces_repo.get_workspace_by_workspace_id(workspace_id)
+        return workspaces_repo.get_workspace_by_id(workspace_id)
     except EntityDoesNotExist:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.WORKSPACE_DOES_NOT_EXIST)
 
@@ -25,7 +25,7 @@ async def get_workspace_by_id_from_path(workspace_id: UUID4 = Path(...), workspa
 
 async def get_deployed_workspace_by_id_from_path(workspace_id: UUID4 = Path(...), workspaces_repo=Depends(get_repository(WorkspaceRepository))) -> Workspace:
     try:
-        return workspaces_repo.get_deployed_workspace_by_workspace_id(workspace_id)
+        return workspaces_repo.get_deployed_workspace_by_id(workspace_id)
     except EntityDoesNotExist:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=strings.WORKSPACE_DOES_NOT_EXIST)
     except ResourceIsNotDeployed:

--- a/api_app/api/routes/workspaces.py
+++ b/api_app/api/routes/workspaces.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from jsonschema.exceptions import ValidationError
 
 from api.dependencies.database import get_repository
-from api.dependencies.workspaces import get_workspace_by_workspace_id_from_path, get_deployed_workspace_by_workspace_id_from_path, get_deployed_workspace_service_by_id_from_path, get_workspace_service_by_id_from_path, get_user_resource_by_id_from_path
+from api.dependencies.workspaces import get_workspace_by_id_from_path, get_deployed_workspace_by_id_from_path, get_deployed_workspace_service_by_id_from_path, get_workspace_service_by_id_from_path, get_user_resource_by_id_from_path
 from db.repositories.resources import ResourceRepository
 from db.repositories.user_resources import UserResourceRepository
 from db.repositories.workspaces import WorkspaceRepository
@@ -99,7 +99,7 @@ async def retrieve_users_active_workspaces(user=Depends(get_current_user), works
 
 
 @workspaces_router.get("/workspaces/{workspace_id}", response_model=WorkspaceInResponse, name=strings.API_GET_WORKSPACE_BY_ID)
-async def retrieve_workspace_by_workspace_id(user=Depends(get_current_user), workspace=Depends(get_workspace_by_workspace_id_from_path)) -> WorkspaceInResponse:
+async def retrieve_workspace_by_workspace_id(user=Depends(get_current_user), workspace=Depends(get_workspace_by_id_from_path)) -> WorkspaceInResponse:
     validate_user_is_owner_or_researcher(user, workspace)
     return WorkspaceInResponse(workspace=workspace)
 
@@ -118,13 +118,13 @@ async def create_workspace(workspace_create: WorkspaceInCreate, workspace_repo=D
 
 
 @workspaces_router.patch("/workspaces/{workspace_id}", response_model=WorkspaceInResponse, name=strings.API_UPDATE_WORKSPACE, dependencies=[Depends(get_current_admin_user)])
-async def patch_workspace(workspace_patch: WorkspacePatchEnabled, workspace=Depends(get_workspace_by_workspace_id_from_path), workspace_repo=Depends(get_repository(WorkspaceRepository))) -> WorkspaceInResponse:
+async def patch_workspace(workspace_patch: WorkspacePatchEnabled, workspace=Depends(get_workspace_by_id_from_path), workspace_repo=Depends(get_repository(WorkspaceRepository))) -> WorkspaceInResponse:
     workspace_repo.patch_workspace(workspace, workspace_patch)
     return WorkspaceInResponse(workspace=workspace)
 
 
 @workspaces_router.delete("/workspaces/{workspace_id}", response_model=WorkspaceIdInResponse, name=strings.API_DELETE_WORKSPACE, dependencies=[Depends(get_current_admin_user)])
-async def delete_workspace(workspace=Depends(get_workspace_by_workspace_id_from_path), workspace_repo=Depends(get_repository(WorkspaceRepository)), workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceIdInResponse:
+async def delete_workspace(workspace=Depends(get_workspace_by_id_from_path), workspace_repo=Depends(get_repository(WorkspaceRepository)), workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceIdInResponse:
     if workspace.is_enabled():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=strings.WORKSPACE_NEEDS_TO_BE_DISABLED_BEFORE_DELETION)
     if len(workspace_service_repo.get_active_workspace_services_for_workspace(workspace.id)) > 0:
@@ -138,20 +138,20 @@ async def delete_workspace(workspace=Depends(get_workspace_by_workspace_id_from_
 
 # WORKSPACE SERVICES ROUTES
 @workspace_services_router.get("/workspaces/{workspace_id}/workspace-services", response_model=WorkspaceServicesInList, name=strings.API_GET_ALL_WORKSPACE_SERVICES)
-async def retrieve_users_active_workspace_services(user=Depends(get_current_user), workspace=Depends(get_workspace_by_workspace_id_from_path), workspace_services_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceServicesInList:
+async def retrieve_users_active_workspace_services(user=Depends(get_current_user), workspace=Depends(get_workspace_by_id_from_path), workspace_services_repo=Depends(get_repository(WorkspaceServiceRepository))) -> WorkspaceServicesInList:
     validate_user_is_owner_or_researcher(user, workspace)
     workspace_services = workspace_services_repo.get_active_workspace_services_for_workspace(workspace.id)
     return WorkspaceServicesInList(workspaceServices=workspace_services)
 
 
 @workspace_services_router.get("/workspaces/{workspace_id}/workspace-services/{service_id}", response_model=WorkspaceServiceInResponse, name=strings.API_GET_WORKSPACE_SERVICE_BY_ID)
-async def retrieve_workspace_service_by_id(user=Depends(get_current_user), workspace=Depends(get_workspace_by_workspace_id_from_path), workspace_service=Depends(get_workspace_service_by_id_from_path)) -> WorkspaceServiceInResponse:
+async def retrieve_workspace_service_by_id(user=Depends(get_current_user), workspace=Depends(get_workspace_by_id_from_path), workspace_service=Depends(get_workspace_service_by_id_from_path)) -> WorkspaceServiceInResponse:
     validate_user_is_owner_or_researcher(user, workspace)
     return WorkspaceServiceInResponse(workspaceService=workspace_service)
 
 
 @workspace_services_router.post("/workspaces/{workspace_id}/workspace-services", status_code=status.HTTP_202_ACCEPTED, response_model=WorkspaceServiceIdInResponse, name=strings.API_CREATE_WORKSPACE_SERVICE)
-async def create_workspace_service(workspace_service_input: WorkspaceServiceInCreate, workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository)), user=Depends(get_current_user), workspace=Depends(get_deployed_workspace_by_workspace_id_from_path)) -> WorkspaceServiceIdInResponse:
+async def create_workspace_service(workspace_service_input: WorkspaceServiceInCreate, workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository)), user=Depends(get_current_user), workspace=Depends(get_deployed_workspace_by_id_from_path)) -> WorkspaceServiceIdInResponse:
     validate_user_is_owner(user, workspace)
 
     try:
@@ -166,14 +166,14 @@ async def create_workspace_service(workspace_service_input: WorkspaceServiceInCr
 
 
 @workspace_services_router.patch("/workspaces/{workspace_id}/workspace-services/{service_id}", response_model=WorkspaceServiceInResponse, name=strings.API_UPDATE_WORKSPACE_SERVICE)
-async def patch_workspace_service(workspace_service_patch: WorkspaceServicePatchEnabled, workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository)), user=Depends(get_current_user), workspace_service=Depends(get_workspace_service_by_id_from_path), workspace=Depends(get_workspace_by_workspace_id_from_path)) -> WorkspaceServiceInResponse:
+async def patch_workspace_service(workspace_service_patch: WorkspaceServicePatchEnabled, workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository)), user=Depends(get_current_user), workspace_service=Depends(get_workspace_service_by_id_from_path), workspace=Depends(get_workspace_by_id_from_path)) -> WorkspaceServiceInResponse:
     validate_user_is_owner_or_researcher(user, workspace)
     workspace_service_repo.patch_workspace_service(workspace_service, workspace_service_patch)
     return WorkspaceServiceInResponse(workspaceService=workspace_service)
 
 
 @workspace_services_router.delete("/workspaces/{workspace_id}/workspace-services/{service_id}", response_model=WorkspaceServiceIdInResponse, name=strings.API_DELETE_WORKSPACE_SERVICE)
-async def delete_workspace_service(user=Depends(get_current_user), workspace=Depends(get_workspace_by_workspace_id_from_path), workspace_service=Depends(get_workspace_service_by_id_from_path), workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository)), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> WorkspaceServiceIdInResponse:
+async def delete_workspace_service(user=Depends(get_current_user), workspace=Depends(get_workspace_by_id_from_path), workspace_service=Depends(get_workspace_service_by_id_from_path), workspace_service_repo=Depends(get_repository(WorkspaceServiceRepository)), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> WorkspaceServiceIdInResponse:
     validate_user_is_owner(user, workspace)
 
     if workspace_service.is_enabled():
@@ -190,8 +190,8 @@ async def delete_workspace_service(user=Depends(get_current_user), workspace=Dep
 
 # USER RESOURCE ROUTES
 @user_resources_router.get("/workspaces/{workspace_id}/workspace-services/{service_id}/user-resources", response_model=UserResourcesInList, name=strings.API_GET_MY_USER_RESOURCES)
-async def retrieve_user_resources_for_workspace_service(workspace_id: str, service_id: str, user=Depends(get_current_user), workspace=Depends(get_workspace_by_workspace_id_from_path), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> UserResourcesInList:
-    user_resources = user_resource_repo.get_user_resources_for_workspace_service(service_id)
+async def retrieve_user_resources_for_workspace_service(workspace_id: str, service_id: str, user=Depends(get_current_user), workspace=Depends(get_workspace_by_id_from_path), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> UserResourcesInList:
+    user_resources = user_resource_repo.get_user_resources_for_workspace_service(workspace_id, service_id)
     validate_user_is_owner_or_researcher(user, workspace)
 
     # filter only to the user - for researchers
@@ -203,13 +203,13 @@ async def retrieve_user_resources_for_workspace_service(workspace_id: str, servi
 
 
 @user_resources_router.get("/workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}", response_model=UserResourceInResponse, name=strings.API_GET_USER_RESOURCE)
-async def retrieve_user_resource_by_id(workspace_id: str, service_id: str, resource_id: str, workspace=Depends(get_workspace_by_workspace_id_from_path), user_resource=Depends(get_user_resource_by_id_from_path), user=Depends(get_current_user)) -> UserResourceInResponse:
+async def retrieve_user_resource_by_id(workspace=Depends(get_workspace_by_id_from_path), user_resource=Depends(get_user_resource_by_id_from_path), user=Depends(get_current_user)) -> UserResourceInResponse:
     validate_user_is_workspace_owner_or_resource_owner(user, workspace, user_resource)
     return UserResourceInResponse(userResource=user_resource)
 
 
 @user_resources_router.post("/workspaces/{workspace_id}/workspace-services/{service_id}/user-resources", status_code=status.HTTP_202_ACCEPTED, response_model=UserResourceIdInResponse, name=strings.API_CREATE_USER_RESOURCE)
-async def create_user_resource(user_resource_create: UserResourceInCreate, user_resource_repo=Depends(get_repository(UserResourceRepository)), user=Depends(get_current_user), workspace=Depends(get_deployed_workspace_by_workspace_id_from_path), workspace_service=Depends(get_deployed_workspace_service_by_id_from_path)) -> UserResourceIdInResponse:
+async def create_user_resource(user_resource_create: UserResourceInCreate, user_resource_repo=Depends(get_repository(UserResourceRepository)), user=Depends(get_current_user), workspace=Depends(get_deployed_workspace_by_id_from_path), workspace_service=Depends(get_deployed_workspace_service_by_id_from_path)) -> UserResourceIdInResponse:
     validate_user_is_owner_or_researcher(user, workspace)
 
     try:
@@ -224,7 +224,7 @@ async def create_user_resource(user_resource_create: UserResourceInCreate, user_
 
 
 @user_resources_router.delete("/workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}", response_model=UserResourceIdInResponse, name=strings.API_DELETE_USER_RESOURCE)
-async def delete_user_resource(workspace_id: str, service_id: str, resource_id: str, user=Depends(get_current_user), workspace=Depends(get_workspace_by_workspace_id_from_path), user_resource=Depends(get_user_resource_by_id_from_path), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> UserResourceIdInResponse:
+async def delete_user_resource(user=Depends(get_current_user), workspace=Depends(get_workspace_by_id_from_path), user_resource=Depends(get_user_resource_by_id_from_path), user_resource_repo=Depends(get_repository(UserResourceRepository))) -> UserResourceIdInResponse:
     validate_user_is_workspace_owner_or_resource_owner(user, workspace, user_resource)
 
     if user_resource.is_enabled():

--- a/api_app/db/repositories/resources.py
+++ b/api_app/db/repositories/resources.py
@@ -23,9 +23,6 @@ class ResourceRepository(BaseRepository):
     def _active_resources_by_id_query(self, resource_id: str):
         return self._active_resources_query() + f' AND c.id = "{resource_id}"'
 
-    def _active_resources_by_type_and_id_query(self, resource_id: str, resource_type: ResourceType):
-        return self._active_resources_by_type_query(resource_type) + f' AND c.id = "{resource_id}"'
-
     @staticmethod
     def _validate_resource_parameters(resource_input, resource_template):
         validate(instance=resource_input["properties"], schema=resource_template)
@@ -41,13 +38,6 @@ class ResourceRepository(BaseRepository):
 
     def get_resource_dict_by_id(self, resource_id: UUID4) -> dict:
         query = self._active_resources_by_id_query(str(resource_id))
-        resources = self.query(query=query)
-        if not resources:
-            raise EntityDoesNotExist
-        return resources[0]
-
-    def get_resource_dict_by_type_and_id(self, resource_id: str, resource_type: ResourceType) -> dict:
-        query = self._active_resources_by_type_and_id_query(resource_id, resource_type)
         resources = self.query(query=query)
         if not resources:
             raise EntityDoesNotExist

--- a/api_app/db/repositories/workspaces.py
+++ b/api_app/db/repositories/workspaces.py
@@ -27,15 +27,15 @@ class WorkspaceRepository(ResourceRepository):
         workspaces = self.query(query=query)
         return parse_obj_as(List[Workspace], workspaces)
 
-    def get_deployed_workspace_by_workspace_id(self, workspace_id: str) -> Workspace:
-        workspace = self.get_workspace_by_workspace_id(workspace_id)
+    def get_deployed_workspace_by_id(self, workspace_id: str) -> Workspace:
+        workspace = self.get_workspace_by_id(workspace_id)
 
         if workspace.deployment.status != Status.Deployed:
             raise ResourceIsNotDeployed
 
         return workspace
 
-    def get_workspace_by_workspace_id(self, workspace_id: str) -> Workspace:
+    def get_workspace_by_id(self, workspace_id: str) -> Workspace:
         query = self.active_workspaces_query_string() + f' AND c.id = "{workspace_id}"'
         workspaces = self.query(query=query)
         if not workspaces:

--- a/api_app/tests_ma/test_api/test_routes/test_api_access.py
+++ b/api_app/tests_ma/test_api/test_routes/test_api_access.py
@@ -87,7 +87,7 @@ class TestWorkspaceServiceRoutesAccess:
         app.dependency_overrides = {}
 
     # [GET] /workspaces/{workspace_id}/workspace-services
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     @patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace", return_value=[])
     async def test_get_workspace_services_raises_403_if_user_is_not_owner_or_researcher_of_workspace(self, _, __, ___, app, client):
@@ -95,7 +95,7 @@ class TestWorkspaceServiceRoutesAccess:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=sample_workspace_service())
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_get_workspace_service_raises_403_if_user_is_not_owner_or_researcher_in_workspace(self, _, __, ___, app, client):
@@ -105,7 +105,7 @@ class TestWorkspaceServiceRoutesAccess:
     # [POST] /workspaces/{workspace_id}/workspace-services/
     @pytest.mark.parametrize("role", [WorkspaceRole.NoRole, WorkspaceRole.Researcher])
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=sample_workspace_service())
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_workspace_id", return_value=sample_workspace())
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_id", return_value=sample_workspace())
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_post_workspace_service_raises_403_if_user_is_not_owner(self, get_role_mock, __, ___, role, app, client):
         get_role_mock.return_value = role
@@ -121,14 +121,14 @@ class TestWorkspaceServiceRoutesAccess:
 
     # [PATCH] /workspaces/{workspace_id}/services/{service_id}
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=None)
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=sample_workspace())
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=sample_workspace())
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_patch_workspaces_service_raises_403_if_user_is_not_workspace_owner(self, _, __, ___, app, client) -> None:
         response = await client.patch(app.url_path_for(strings.API_UPDATE_WORKSPACE_SERVICE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID), json={"enabled": False})
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=None)
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=sample_workspace())
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=sample_workspace())
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_delete_workspace_service_raises_403_if_user_is_not_workspace_owner(self, _, __, ___, app, client) -> None:
         response = await client.delete(app.url_path_for(strings.API_DELETE_WORKSPACE_SERVICE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID))
@@ -144,7 +144,7 @@ class TestUserResourcesRoutesAccess:
         app.dependency_overrides = {}
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service")
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_get_user_resources_raises_403_if_user_is_not_researcher_or_owner_of_workspace(self, _, __, get_user_resources_mock, app, client):
@@ -154,7 +154,7 @@ class TestUserResourcesRoutesAccess:
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.Researcher)
     async def test_get_user_resource_raises_403_if_user_is_researcher_and_not_owner_of_resource(self, _, __, get_user_resource_mock, app, client):
         user_resource = sample_user_resource()
@@ -167,14 +167,14 @@ class TestUserResourcesRoutesAccess:
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_get_user_resource_raises_403_if_user_is_not_workspace_owner_or_researcher(self, _, __, ___, app, client):
         response = await client.get(app.url_path_for(strings.API_GET_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID, resource_id=USER_RESOURCE_ID))
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_id", return_value=None)
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_deployed_workspace_service_by_id", return_value=None)
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_post_user_resource_raises_403_if_user_is_not_workspace_owner_or_researcher(self, _, __, ___, app, client):
@@ -187,7 +187,7 @@ class TestUserResourcesRoutesAccess:
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.Researcher)
     async def test_delete_user_resource_raises_403_if_user_is_researcher_and_not_owner_of_resource(self, _, __, get_user_resource_mock, app, client):
         user_resource = sample_user_resource()
@@ -200,7 +200,7 @@ class TestUserResourcesRoutesAccess:
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     @patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.NoRole)
     async def test_delete_user_resource_raises_403_if_user_is_not_workspace_owner_or_researcher(self, _, __, ___, app, client):
         response = await client.delete(app.url_path_for(strings.API_DELETE_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID, resource_id=USER_RESOURCE_ID))

--- a/api_app/tests_ma/test_api/test_routes/test_workspaces.py
+++ b/api_app/tests_ma/test_api/test_routes/test_workspaces.py
@@ -280,19 +280,19 @@ class TestWorkspaceRoutesThatDontRequireAdminRights:
         assert valid_ws_2 in workspaces_from_response
 
     # [GET] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", side_effect=EntityDoesNotExist)
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", side_effect=EntityDoesNotExist)
     async def test_get_workspace_by_id_get_returns_404_if_resource_is_not_found(self, _, app, client):
         response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id=WORKSPACE_ID))
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # [GET] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     async def test_get_workspace_by_id_get_returns_422_if_workspace_id_is_not_a_uuid(self, _, app, client):
         response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_BY_ID, workspace_id="not_valid"))
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # [GET] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     async def test_get_workspace_by_id_get_returns_workspace_if_found(self, get_workspace_mock, app, client):
         auth_info_user_in_workspace_owner_role = {'sp_id': 'ab123', 'roles': {'WorkspaceOwner': 'ab124', 'WorkspaceResearcher': 'ab125'}}
         workspace = sample_workspace(auth_info=auth_info_user_in_workspace_owner_role)
@@ -361,13 +361,13 @@ class TestWorkspaceRoutesThatRequireAdminRights:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # [PATCH] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", side_effect=EntityDoesNotExist)
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", side_effect=EntityDoesNotExist)
     async def test_patch_workspaces_returns_404_if_workspace_does_not_exist(self, _, app, client):
         response = await client.patch(app.url_path_for(strings.API_UPDATE_WORKSPACE, workspace_id=WORKSPACE_ID), json='{"enabled": true}')
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # [PATCH] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceRepository.patch_workspace", return_value=None)
     async def test_patch_workspaces_patches_workspace(self, patch_workspace_mock, get_workspace_mock, app, client):
         workspace_to_patch = sample_workspace()
@@ -380,7 +380,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
         assert response.status_code == status.HTTP_200_OK
 
     # [DELETE] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     async def test_delete_workspace_returns_400_if_workspace_is_enabled(self, get_workspace_mock, app, client):
         workspace = sample_workspace()
         workspace.resourceTemplateParameters["enabled"] = True
@@ -390,7 +390,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # [DELETE] /workspaces/{workspace_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace")
     async def test_delete_workspace_returns_400_if_associated_workspace_services_are_not_deleted(self, get_active_workspace_services_for_workspace_mock, get_workspace_mock, disabled_workspace, app, client):
         get_workspace_mock.return_value = disabled_workspace
@@ -402,7 +402,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
 
     # [DELETE] /workspaces/{workspace_id}
     @ patch("api.dependencies.workspaces.get_repository")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace", return_value=[])
     @ patch('azure.cosmos.CosmosClient')
     @ patch('api.routes.workspaces.WorkspaceRepository.mark_resource_as_deleting')
@@ -417,7 +417,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
 
     # [DELETE] /workspaces/{workspace_id}
     @ patch("api.dependencies.workspaces.get_repository")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace", return_value=[])
     @ patch('azure.cosmos.CosmosClient')
     @ patch('api.routes.workspaces.WorkspaceRepository.mark_resource_as_deleting')
@@ -432,7 +432,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
 
     # [DELETE] /workspaces/{workspace_id}
     @ patch("api.dependencies.workspaces.get_repository")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace", return_value=[])
     @ patch('azure.cosmos.CosmosClient')
     @ patch('api.routes.workspaces.WorkspaceRepository.mark_resource_as_deleting')
@@ -449,7 +449,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
 
     # [DELETE] /workspaces/{workspace_id}
     @ patch("api.dependencies.workspaces.get_repository")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace")
     @ patch('azure.cosmos.CosmosClient')
     @ patch('api.routes.workspaces.WorkspaceRepository.mark_resource_as_deleting', side_effect=Exception)
@@ -469,7 +469,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         app.dependency_overrides = {}
 
     # [GET] /workspaces/{workspace_id}/workspace-services
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=sample_workspace())
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=sample_workspace())
     @ patch("api.routes.workspaces.validate_user_has_valid_role_in_workspace")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.get_active_workspace_services_for_workspace", return_value=None)
     async def test_get_workspace_services_returns_workspace_services_for_workspace(self, get_active_workspace_services_mock, _, __, app, client):
@@ -483,7 +483,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
 
     # [GET] /workspaces/{workspace_id}/workspace-services/{service_id}
     @ patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=sample_workspace())
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=sample_workspace())
     @ patch("api.routes.workspaces.validate_user_has_valid_role_in_workspace")
     async def test_get_workspace_service_returns_workspace_service_result(self, _, __, get_workspace_service_mock, app, client):
         workspace_service = sample_workspace_service()
@@ -495,13 +495,13 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         assert response.json()["workspaceService"] == workspace_service
 
     @ patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", side_effect=EntityDoesNotExist)
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", return_value=None)
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", return_value=None)
     async def test_get_workspace_service_raises_404_if_workspace_service_is_not_found(self, _, __, app, client):
         response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_SERVICE_BY_ID, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID))
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @ patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", side_effect=EntityDoesNotExist)
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", side_effect=EntityDoesNotExist)
     async def test_get_workspace_service_raises_404_if_associated_workspace_is_not_found(self, _, get_workspace_service_mock, app, client):
         get_workspace_service_mock.return_value = sample_workspace_service(SERVICE_ID, WORKSPACE_ID)
 
@@ -510,7 +510,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # [POST] /workspaces/{workspace_id}/workspace-services
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.send_resource_request_message")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.save_item")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.create_workspace_service_item", return_value=sample_workspace_service())
@@ -526,7 +526,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         assert response.json()["workspaceServiceId"] == SERVICE_ID
 
     # [POST] /workspaces/{workspace_id}/workspace-services
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.create_workspace_service_item", side_effect=ValueError)
     async def test_post_workspace_services_raises_400_bad_request_if_input_is_bad(self, _, get_workspace_mock, app, client, workspace_service_input):
         auth_info_user_in_workspace_owner_role = {'sp_id': 'ab123', 'roles': {'WorkspaceOwner': 'ab124', 'WorkspaceResearcher': 'ab125'}}
@@ -546,7 +546,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
 
     # [PATCH] /workspaces/{workspace_id}/services/{service_id}
     @ patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=sample_workspace_service())
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id", side_effect=EntityDoesNotExist)
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id", side_effect=EntityDoesNotExist)
     async def test_patch_workspaces_service_returns_404_if_workspace_does_not_exist(self, _, __, app, client):
         response = await client.patch(app.url_path_for(strings.API_UPDATE_WORKSPACE_SERVICE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID), json='{"enabled": true}')
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -554,7 +554,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
     # [PATCH] /workspaces/{workspace_id}/services/{service_id}
     @pytest.mark.parametrize('workspace_id, workspace_service_id', [("933ad738-7265-4b5f-9eae-a1a62928772e", "IAmNotEvenAGUID!"), ("IAmNotEvenAGUID!", "933ad738-7265-4b5f-9eae-a1a62928772e")])
     @ patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     async def test_patch_workspaces_service_returns_422_if_invalid_id(self, get_workspace_mock, get_workspace_service_mock, app, client, workspace_id, workspace_service_id):
         workspace_service_to_patch = sample_workspace_service(workspace_service_id, workspace_id)
         get_workspace_service_mock.return_value = workspace_service_to_patch
@@ -565,7 +565,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
 
     # [PATCH] /workspaces/{workspace_id}/services/{service_id}
     @ patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.WorkspaceServiceRepository.patch_workspace_service", return_value=None)
     async def test_patch_workspaces_services_patches_workspace(self, patch_workspace_service_mock, get_workspace_mock, get_workspace_service_mock, app, client):
         auth_info_user_in_workspace_owner_role = {'sp_id': 'ab123', 'roles': {'WorkspaceOwner': 'ab124', 'WorkspaceResearcher': 'ab125'}}
@@ -583,7 +583,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
 
     # [DELETE] /workspaces/{workspace_id}/services/{service_id}
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.routes.workspaces.validate_user_is_owner")
     async def test_delete_workspace_service_raises_400_if_workspace_service_is_enabled(self, _, __, get_workspace_service_mock, app, client):
         workspace_service = sample_workspace_service()
@@ -595,7 +595,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=disabled_workspace_service())
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.routes.workspaces.validate_user_is_owner")
     @patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service")
     async def test_delete_workspace_service_raises_404_if_workspace_service_has_active_resources(self, get_user_resources_mock, __, ___, ____, app, client):
@@ -606,7 +606,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=disabled_workspace_service())
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.routes.workspaces.validate_user_is_owner")
     @patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service", return_value=[])
     @patch("api.routes.workspaces.mark_resource_as_deleting", return_value=None)
@@ -616,7 +616,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         mark_resource_mock.assert_called_once()
 
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id", return_value=disabled_workspace_service())
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.routes.workspaces.validate_user_is_owner")
     @patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service", return_value=[])
     @patch("api.routes.workspaces.mark_resource_as_deleting")
@@ -626,7 +626,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
         send_uninstall_mock.assert_called_once()
 
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.routes.workspaces.validate_user_is_owner")
     @patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service", return_value=[])
     @patch("api.routes.workspaces.mark_resource_as_deleting")
@@ -648,7 +648,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         app.dependency_overrides = {}
 
     # GET /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service")
     @ patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.Owner)
     async def test_get_user_resources_returns_all_user_resources_for_workspace_service_if_owner(self, _, get_user_resources_mock, __, app, client):
@@ -663,7 +663,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["userResources"] == user_resources
 
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.routes.workspaces.UserResourceRepository.get_user_resources_for_workspace_service")
     @ patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.Researcher)
     async def test_get_user_resources_returns_own_user_resources_for_researcher(self, _, get_user_resources_mock, __, app, client, non_admin_user):
@@ -687,7 +687,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert not_my_user_resource not in actual_returned_resources
 
     # GET /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources/{resource_id}
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
     @ patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.Owner)
     async def test_get_user_resource_returns_a_user_resource_if_found(self, _, get_user_resource_mock, __, app, client):
@@ -699,7 +699,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["userResource"] == user_resource
 
-    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @ patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id", side_effect=EntityDoesNotExist)
     @ patch("api.routes.workspaces.get_user_role_in_workspace", return_value=WorkspaceRole.Owner)
     async def test_get_user_resource_raises_404_if_resource_not_found(self, _, __, ___, app, client):
@@ -707,7 +707,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_id")
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_deployed_workspace_service_by_id")
     @patch("api.routes.workspaces.UserResourceRepository.create_user_resource_item", side_effect=ValueError)
     async def test_post_user_resources_raises_400_bad_request_if_input_is_bad(self, _, __, get_workspace_mock, app, client, sample_user_resource_input_data):
@@ -719,7 +719,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_id")
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_deployed_workspace_service_by_id")
     @patch("api.routes.workspaces.send_resource_request_message")
     @patch("api.routes.workspaces.UserResourceRepository.save_item")
@@ -736,20 +736,20 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.json()["resourceId"] == USER_RESOURCE_ID
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_workspace_id", side_effect=EntityDoesNotExist)
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_id", side_effect=EntityDoesNotExist)
     async def test_post_user_resources_with_non_existing_workspace_id_returns_404(self, _, app, client, sample_user_resource_input_data):
         response = await client.post(app.url_path_for(strings.API_CREATE_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID), json=sample_user_resource_input_data)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_deployed_workspace_by_id")
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_deployed_workspace_service_by_id", side_effect=EntityDoesNotExist)
     async def test_post_user_resources_with_non_existing_service_id_returns_404(self, _, __, app, client, sample_user_resource_input_data):
         response = await client.post(app.url_path_for(strings.API_CREATE_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID), json=sample_user_resource_input_data)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     async def test_post_user_resources_with_non_deployed_workspace_id_returns_404(self, get_deployed_workspace_by_workspace_id_mock, app, client, sample_user_resource_input_data):
         workspace = sample_workspace()
         workspace.deployment.status = Status.Failed
@@ -761,7 +761,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.text == strings.WORKSPACE_IS_NOT_DEPLOYED
 
     # [POST] /workspaces/{workspace_id}/workspace-services/{service_id}/user-resources
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.dependencies.workspaces.WorkspaceServiceRepository.get_workspace_service_by_id")
     async def test_post_user_resources_with_non_deployed_service_id_returns_404(self, get_workspace_service_mock, get_workspace_mock, app, client, sample_user_resource_input_data):
         workspace = sample_workspace()
@@ -777,7 +777,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.text == strings.WORKSPACE_SERVICE_IS_NOT_DEPLOYED
 
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
     @patch("api.routes.workspaces.validate_user_is_workspace_owner_or_resource_owner")
     async def test_delete_user_resource_raises_400_if_user_resource_is_enabled(self, _, get_user_resource_mock, ___, app, client):
@@ -789,7 +789,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id", return_value=disabled_user_resource())
     @patch("api.routes.workspaces.validate_user_is_workspace_owner_or_resource_owner")
     @patch("api.routes.workspaces.mark_resource_as_deleting", return_value=None)
@@ -798,7 +798,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         await client.delete(app.url_path_for(strings.API_DELETE_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID, resource_id=USER_RESOURCE_ID))
         mark_resource_mock.assert_called_once()
 
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id", return_value=disabled_user_resource())
     @patch("api.routes.workspaces.validate_user_is_workspace_owner_or_resource_owner")
     @patch("api.routes.workspaces.mark_resource_as_deleting")
@@ -807,7 +807,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
         await client.delete(app.url_path_for(strings.API_DELETE_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID, resource_id=USER_RESOURCE_ID))
         send_uninstall_mock.assert_called_once()
 
-    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_workspace_id")
+    @patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     @patch("api.dependencies.workspaces.UserResourceRepository.get_user_resource_by_id")
     @patch("api.routes.workspaces.validate_user_is_workspace_owner_or_resource_owner")
     @patch("api.routes.workspaces.mark_resource_as_deleting")

--- a/api_app/tests_ma/test_db/test_repositories/test_user_resource_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_user_resource_repository.py
@@ -8,6 +8,12 @@ from models.domain.user_resource import UserResource
 from models.schemas.user_resource import UserResourceInCreate
 
 
+WORKSPACE_ID = "def000d3-82da-4bfc-b6e9-9a7853ef753e"
+SERVICE_ID = "937453d3-82da-4bfc-b6e9-9a7853ef753e"
+RESOURCE_ID = "000000d3-82da-4bfc-b6e9-9a7853ef753e"
+USER_ID = "abc000d3-82da-4bfc-b6e9-9a7853ef753e"
+
+
 @pytest.fixture
 def basic_user_resource_request():
     return UserResourceInCreate(userResourceType="user-resource-type", properties={"display_name": "test", "description": "test", "tre_id": "test"})
@@ -22,7 +28,7 @@ def user_resource_repo():
 @pytest.fixture
 def user_resource():
     user_resource = UserResource(
-        id="000000d3-82da-4bfc-b6e9-9a7853ef753e",
+        id=RESOURCE_ID,
         resourceTemplateVersion="0.1.0",
         resourceTemplateParameters={},
         resourceTemplateName="my-workspace-service",
@@ -36,47 +42,39 @@ def test_create_user_resource_item_creates_a_user_resource_with_the_right_values
     user_resource_to_create = basic_user_resource_request
     validate_input_mock.return_value = basic_user_resource_request.userResourceType
 
-    workspace_id = "000000d3-82da-4bfc-b6e9-9a7853ef753e"
-    parent_workspace_service_id = "937453d3-82da-4bfc-b6e9-9a7853ef753e"
-    user_id = "abc000d3-82da-4bfc-b6e9-9a7853ef753e"
-    user_resource = user_resource_repo.create_user_resource_item(user_resource_to_create, workspace_id, parent_workspace_service_id, "parent-service-type", user_id)
+    user_resource = user_resource_repo.create_user_resource_item(user_resource_to_create, WORKSPACE_ID, SERVICE_ID, "parent-service-type", USER_ID)
 
     assert user_resource.resourceTemplateName == basic_user_resource_request.userResourceType
     assert user_resource.resourceType == ResourceType.UserResource
     assert user_resource.deployment.status == Status.NotDeployed
-    assert user_resource.workspaceId == workspace_id
-    assert user_resource.parentWorkspaceServiceId == parent_workspace_service_id
-    assert user_resource.ownerId == user_id
+    assert user_resource.workspaceId == WORKSPACE_ID
+    assert user_resource.parentWorkspaceServiceId == SERVICE_ID
+    assert user_resource.ownerId == USER_ID
     assert len(user_resource.resourceTemplateParameters["tre_id"]) > 0
     # need to make sure request doesn't override system param
     assert user_resource.resourceTemplateParameters["tre_id"] != "test"
 
 
-@patch('db.repositories.user_resources.UserResourceRepository.validate_input_against_template')
-def test_create_user_resource_item_raises_value_error_if_template_is_invalid(validate_input_mock, user_resource_repo, basic_user_resource_request):
-    workspace_id = "000000d3-82da-4bfc-b6e9-9a7853ef753e"
-    parent_workspace_service_id = "937453d3-82da-4bfc-b6e9-9a7853ef753e"
-    user_id = "abc000d3-82da-4bfc-b6e9-9a7853ef753e"
-    validate_input_mock.side_effect = ValueError
-
+@patch('db.repositories.user_resources.UserResourceRepository.validate_input_against_template', side_effect=ValueError)
+def test_create_user_resource_item_raises_value_error_if_template_is_invalid(_, user_resource_repo, basic_user_resource_request):
     with pytest.raises(ValueError):
-        user_resource_repo.create_user_resource_item(basic_user_resource_request, workspace_id, parent_workspace_service_id, "parent-service-type", user_id)
+        user_resource_repo.create_user_resource_item(basic_user_resource_request, WORKSPACE_ID, SERVICE_ID, "parent-service-type", USER_ID)
 
 
 @patch('db.repositories.user_resources.UserResourceRepository.query', return_value=[])
 def test_get_user_resources_for_workspace_queries_db(query_mock, user_resource_repo):
-    parent_workspace_service_id = "937453d3-82da-4bfc-b6e9-9a7853ef753e"
+    expected_query = f'SELECT * FROM c WHERE c.resourceType = "user-resource" AND c.deployment.status != "deleted" AND c.parentWorkspaceServiceId = "{SERVICE_ID}" AND c.workspaceId = "{WORKSPACE_ID}"'
 
-    user_resource_repo.get_user_resources_for_workspace_service(parent_workspace_service_id)
+    user_resource_repo.get_user_resources_for_workspace_service(WORKSPACE_ID, SERVICE_ID)
 
-    query_mock.assert_called_once_with(query='SELECT * FROM c WHERE c.resourceType = "user-resource" AND c.deployment.status != "deleted" AND c.parentWorkspaceServiceId = "937453d3-82da-4bfc-b6e9-9a7853ef753e"')
+    query_mock.assert_called_once_with(query=expected_query)
 
 
-@patch('db.repositories.user_resources.UserResourceRepository.get_resource_dict_by_type_and_id')
-def test_get_user_resource_returns_resource_if_found(get_resource_mock, user_resource_repo, user_resource):
-    get_resource_mock.return_value = user_resource.dict()
+@patch('db.repositories.user_resources.UserResourceRepository.query')
+def test_get_user_resource_returns_resource_if_found(query_mock, user_resource_repo, user_resource):
+    query_mock.return_value = [user_resource.dict()]
 
-    actual_resource = user_resource_repo.get_user_resource_by_id("000000d3-82da-4bfc-b6e9-9a7853ef753e")
+    actual_resource = user_resource_repo.get_user_resource_by_id(WORKSPACE_ID, SERVICE_ID, RESOURCE_ID)
 
     assert actual_resource == user_resource
 
@@ -84,12 +82,14 @@ def test_get_user_resource_returns_resource_if_found(get_resource_mock, user_res
 @patch('db.repositories.user_resources.UserResourceRepository.query')
 def test_get_user_resource_by_id_queries_db(query_mock, user_resource_repo, user_resource):
     query_mock.return_value = [user_resource.dict()]
-    user_resource_repo.get_user_resource_by_id("000000d3-82da-4bfc-b6e9-9a7853ef753e")
+    expected_query = f'SELECT * FROM c WHERE c.resourceType = "user-resource" AND c.deployment.status != "deleted" AND c.parentWorkspaceServiceId = "{SERVICE_ID}" AND c.workspaceId = "{WORKSPACE_ID}" AND c.id = "{RESOURCE_ID}"'
 
-    query_mock.assert_called_once_with(query='SELECT * FROM c WHERE c.deployment.status != "deleted" AND c.resourceType = "user-resource" AND c.id = "000000d3-82da-4bfc-b6e9-9a7853ef753e"')
+    user_resource_repo.get_user_resource_by_id(WORKSPACE_ID, SERVICE_ID, RESOURCE_ID)
+
+    query_mock.assert_called_once_with(query=expected_query)
 
 
 @patch('db.repositories.user_resources.UserResourceRepository.query', return_value=[])
 def test_get_user_resource_by_id_raises_entity_does_not_exist_if_not_found(_, user_resource_repo):
     with pytest.raises(EntityDoesNotExist):
-        user_resource_repo.get_user_resource_by_id("000000d3-82da-4bfc-b6e9-9a7853ef753e")
+        user_resource_repo.get_user_resource_by_id(WORKSPACE_ID, SERVICE_ID, RESOURCE_ID)

--- a/api_app/tests_ma/test_db/test_repositories/test_workpaces_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_workpaces_repository.py
@@ -45,10 +45,10 @@ def test_get_deployed_workspace_by_id_raises_resource_is_not_deployed_if_not_dep
     sample_workspace = workspace
     sample_workspace.deployment = Deployment(status=Status.NotDeployed)
 
-    workspace_repo.get_workspace_by_workspace_id = MagicMock(return_value=sample_workspace)
+    workspace_repo.get_workspace_by_id = MagicMock(return_value=sample_workspace)
 
     with pytest.raises(ResourceIsNotDeployed):
-        workspace_repo.get_deployed_workspace_by_workspace_id(workspace_id)
+        workspace_repo.get_deployed_workspace_by_id(workspace_id)
 
 
 def test_get_workspace_by_id_raises_entity_does_not_exist_if_item_does_not_exist(workspace_repo):
@@ -56,14 +56,14 @@ def test_get_workspace_by_id_raises_entity_does_not_exist_if_item_does_not_exist
     workspace_repo.container.query_items = MagicMock(return_value=[])
 
     with pytest.raises(EntityDoesNotExist):
-        workspace_repo.get_workspace_by_workspace_id(workspace_id)
+        workspace_repo.get_workspace_by_id(workspace_id)
 
 
 def test_get_workspace_by_id_queries_db(workspace_repo, workspace):
     workspace_repo.container.query_items = MagicMock(return_value=[workspace.dict()])
     expected_query = f'SELECT * FROM c WHERE c.resourceType = "workspace" AND c.deployment.status != "deleted" AND c.id = "{workspace.id}"'
 
-    workspace_repo.get_workspace_by_workspace_id(workspace.id)
+    workspace_repo.get_workspace_by_id(workspace.id)
 
     workspace_repo.container.query_items.assert_called_once_with(query=expected_query, enable_cross_partition_query=True)
 

--- a/api_app/tests_ma/test_db/test_repositories/test_workpaces_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_workpaces_repository.py
@@ -61,7 +61,7 @@ def test_get_workspace_by_id_raises_entity_does_not_exist_if_item_does_not_exist
 
 def test_get_workspace_by_id_queries_db(workspace_repo, workspace):
     workspace_repo.container.query_items = MagicMock(return_value=[workspace.dict()])
-    expected_query = workspace_repo._active_resources_by_type_and_id_query(workspace.id, workspace.resourceType)
+    expected_query = f'SELECT * FROM c WHERE c.resourceType = "workspace" AND c.deployment.status != "deleted" AND c.id = "{workspace.id}"'
 
     workspace_repo.get_workspace_by_workspace_id(workspace.id)
 


### PR DESCRIPTION
# PR for issue #797 #762 

## What is being addressed

For all URIs with long form ex. /workspace/workspace-service/user-resource - this validates that the user resource actually belongs to the workspace service and the workspace .

This is to disallow for someone to provide a workspace id they have access to - but that is not related to the actual service or resource

## How is this addressed

- Query for all ids, ex. user resource with id AND workspace id AND parent service id, not just id
- Update routes and tests to pass in all parameters and update test validation
