### PR TITLE
Remove duplicate job from CD workflow

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -247,9 +247,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
-          fetch-depth: 0
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -13,62 +13,8 @@ on:
 concurrency: deploy-e2e
 
 jobs:
-  deploy_mgmt_infra:
-    name: Deploy Management Infrastructure
-    runs-on: ubuntu-latest
-    environment: Dev
-    env:
-      TF_INPUT: 0 # interactive is off
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 1.0.5
-
-      - name: Create Management Infrastructure
-        shell: bash
-        env:
-          TRE_ID: ${{ secrets.TRE_ID }}
-          TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TF_STATE_CONTAINER }}
-          MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP }}
-          MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.STATE_STORAGE_ACCOUNT_NAME }}
-          LOCATION: ${{ secrets.LOCATION }}
-          ACR_NAME: ${{ secrets.ACR_NAME }}
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          PORTER_OUTPUT_CONTAINER_NAME: "${{ secrets.PORTER_OUTPUT_CONTAINER_NAME }}"
-
-        run: |
-          export USE_ENV_VARS_NOT_FILES=true
-          export ARM_CLIENT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientId')
-          export ARM_CLIENT_SECRET=$(echo "$AZURE_CREDENTIALS" | jq -r '.clientSecret')
-          export ARM_SUBSCRIPTION_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.subscriptionId')
-          export ARM_TENANT_ID=$(echo "$AZURE_CREDENTIALS" | jq -r '.tenantId')
-
-          export TF_VAR_tre_id=$TRE_ID
-          export TF_VAR_arm_subscription_id=$ARM_SUBSCRIPTION_ID
-          export TF_VAR_arm_client_id=$ARM_CLIENT_ID
-          export TF_VAR_arm_client_secret=$ARM_CLIENT_SECRET
-          export TF_VAR_mgmt_storage_account_name=$MGMT_STORAGE_ACCOUNT_NAME
-          export TF_VAR_mgmt_resource_group_name=$MGMT_RESOURCE_GROUP_NAME
-          export TF_VAR_terraform_state_container_name=$TERRAFORM_STATE_CONTAINER_NAME
-          export TF_VAR_location=$LOCATION
-          export TF_VAR_acr_name=$ACR_NAME
-          export TF_VAR_porter_output_container_name=$PORTER_OUTPUT_CONTAINER_NAME
-
-          make bootstrap
-          make mgmt-deploy
-
   deploy_tre:
     name: Deploy TRE
-    needs: deploy_mgmt_infra
     runs-on: ubuntu-latest
     environment: Dev
     env:


### PR DESCRIPTION
## What is being addressed

The CD workflow (deploy_tre) deploys the mgmt infra twice - one directly and another from the call to "make all". This PR removes the first one (which saves 1.5 minutes).