### PR TITLE
Firewall rules creation in sequence

### DIFF
--- a/templates/core/terraform/firewall/firewall.tf
+++ b/templates/core/terraform/firewall/firewall.tf
@@ -79,8 +79,6 @@ resource "azurerm_monitor_diagnostic_setting" "firewall" {
   }
 }
 
-
-
 resource "azurerm_firewall_application_rule_collection" "shared_services_subnet" {
   name                = "arc-shared_services_subnet"
   azure_firewall_name = azurerm_firewall.fw.name
@@ -155,7 +153,6 @@ resource "azurerm_firewall_network_rule_collection" "shared_services_subnet" {
     azurerm_firewall_application_rule_collection.shared_services_subnet
   ]
 }
-
 
 resource "azurerm_firewall_application_rule_collection" "resource_processor_subnet" {
   name                = "arc-resource_processor_subnet"
@@ -256,6 +253,10 @@ resource "azurerm_firewall_network_rule_collection" "web_app_subnet" {
     ]
     source_addresses = data.azurerm_subnet.web_app.address_prefixes
   }
+
+  depends_on = [
+    azurerm_firewall_network_rule_collection.resource_processor_subnet
+  ]
 }
 
 resource "azurerm_firewall_application_rule_collection" "web_app_subnet" {
@@ -277,4 +278,8 @@ resource "azurerm_firewall_application_rule_collection" "web_app_subnet" {
     ]
     source_addresses = data.azurerm_subnet.web_app.address_prefixes
   }
+
+  depends_on = [
+    azurerm_firewall_network_rule_collection.web_app_subnet
+  ]
 }


### PR DESCRIPTION
# PR for issue #842 

## What is being addressed

Creation of firewall rules sometimes fail.

It seems to be a concurrency issue. Terraform tries to do multiple operations on the Firewall at the same time. Perhaps setting dependencies between the rules might solve the problem.

## How is this addressed

- Added dependencies between the firewall rules, so Terraform applies them in sequence
