### PR TITLE
Add missing parameter

### DIFF
--- a/api_app/api/routes/workspaces.py
+++ b/api_app/api/routes/workspaces.py
@@ -179,7 +179,7 @@ async def delete_workspace_service(user=Depends(get_current_user), workspace=Dep
     if workspace_service.is_enabled():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=strings.WORKSPACE_SERVICE_NEEDS_TO_BE_DISABLED_BEFORE_DELETION)
 
-    if len(user_resource_repo.get_user_resources_for_workspace_service(workspace_service.id)) > 0:
+    if len(user_resource_repo.get_user_resources_for_workspace_service(workspace.id, workspace_service.id)) > 0:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=strings.USER_RESOURCES_NEED_TO_BE_DELETED_BEFORE_WORKSPACE)
 
     previous_deletion_status = mark_resource_as_deleting(workspace_service, workspace_service_repo, ResourceType.WorkspaceService)


### PR DESCRIPTION
# PR for issue

## What is being addressed

Deleting workspace service fails with server error 500

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.8/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 580, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 241, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 52, in app
    response = await func(request)
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 219, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 152, in run_endpoint_function
    return await dependant.call(**values)
  File "/api/./api/routes/workspaces.py", line 182, in delete_workspace_service
    if len(user_resource_repo.get_user_resources_for_workspace_service(workspace_service.id)) > 0:
TypeError: get_user_resources_for_workspace_service() missing 1 required positional argument: 'service_id'
```

## How is this addressed

Missing parameter added to the call.

```python
    def get_user_resources_for_workspace_service(self, workspace_id: str, service_id: str) -> List[UserResource]:
        """
        returns a list of "non-deleted" user resources linked to this workspace service
        """
        query = self.active_user_resources_query(workspace_id, service_id)
        user_resources = self.query(query=query)
        return parse_obj_as(List[UserResource], user_resources)
```
