### PR TITLE
Modify default redirect uri

### DIFF
--- a/api_app/main.py
+++ b/api_app/main.py
@@ -25,6 +25,7 @@ def get_application() -> FastAPI:
         description=config.API_DESCRIPTION,
         version=config.VERSION,
         docs_url="/api/docs",
+        swagger_ui_oauth2_redirect_url="/api/docs/oauth2-redirect",
         swagger_ui_init_oauth={
             "usePkceWithAuthorizationCodeGrant": True,
             "clientId": config.SWAGGER_UI_CLIENT_ID,


### PR DESCRIPTION
# PR for issue

## What is being addressed

PR 866 changed the /docs => /api/docs

default redirect uri needs to be changed

from **/docs/oauth2-redirect** to **/api/docs/oauth2-redirect**
