### PR TITLE
Add slash to docker COPY destination path

### DIFF
--- a/templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile
@@ -5,7 +5,7 @@ COPY ./guacamole-auth-azure/src src
 RUN mvn package
 
 FROM scratch as test-results
-COPY --from=client_build /target/surefire-reports/*.xml .
+COPY --from=client_build /target/surefire-reports/*.xml ./
 
 FROM guacamole/guacd:1.3.0
 


### PR DESCRIPTION
# PR for issue #892 

## What is being addressed

Ensure a directory is used as destination so multiple file copy works.

## How is this addressed

- Add a slash to the path
