### PR TITLE
fix issue where only last role assigned was counted

### DIFF
--- a/api_app/models/domain/authentication.py
+++ b/api_app/models/domain/authentication.py
@@ -1,6 +1,10 @@
+from collections import namedtuple
 from typing import List
 
 from pydantic import BaseModel, Field
+
+
+RoleAssignment = namedtuple("RoleAssignment", "resource_id, role_id")
 
 
 class User(BaseModel):
@@ -8,4 +12,4 @@ class User(BaseModel):
     name: str
     email: str
     roles: List[str] = Field([])
-    roleAssignments: dict = Field({})
+    roleAssignments: List[RoleAssignment] = Field([])

--- a/api_app/tests_ma/test_api/conftest.py
+++ b/api_app/tests_ma/test_api/conftest.py
@@ -18,14 +18,14 @@ def no_database():
 
 def override_get_user():
     from models.domain.authentication import User
-    return User(id="1234", name="test", email="test", roles=[""], roleAssignments={"ab123": "ab124"})
+    return User(id="1234", name="test", email="test", roles=[""], roleAssignments=[("ab123", "ab124")])
 
 
 @pytest.fixture(scope='module')
 def admin_user():
     def inner():
         from models.domain.authentication import User
-        return User(id="1234", name="test", email="test", roles=["TREAdmin"], roleAssignments={"ab123": "ab124"})
+        return User(id="1234", name="test", email="test", roles=["TREAdmin"], roleAssignments=[("ab123", "ab124")])
     return inner
 
 
@@ -33,7 +33,7 @@ def admin_user():
 def non_admin_user():
     def inner():
         from models.domain.authentication import User
-        return User(id="1234", name="test", email="test", roles=[], roleAssignments={"ab123": "ab124"})
+        return User(id="1234", name="test", email="test", roles=[], roleAssignments=[("ab123", "ab124")])
     return inner
 
 

--- a/api_app/tests_ma/test_services/test_aad_access_service.py
+++ b/api_app/tests_ma/test_services/test_aad_access_service.py
@@ -1,7 +1,7 @@
 import pytest
 from mock import patch
 
-from models.domain.authentication import User
+from models.domain.authentication import User, RoleAssignment
 from models.domain.workspace import Workspace, WorkspaceRole
 from services.aad_access_service import AADAccessService
 from services.access_service import AuthConfigValidationError
@@ -61,22 +61,22 @@ def test_extract_workspace__returns_sp_id_and_roles(get_app_sp_graph_data_mock):
 @pytest.mark.parametrize('user, workspace, expected_role',
                          [
                              # user not a member of the workspace app
-                             (User(roleAssignments={'abc123': 'abc124'}, id='123', name="test", email="t@t.com"),
+                             (User(roleAssignments=[RoleAssignment(resource_id="ab123", role_id="ab124")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
                                         id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
                               WorkspaceRole.NoRole),
                              # user is member of the workspace app but not in role
-                             (User(roleAssignments={'abc127': 'abc124'}, id='123', name="test", email="t@t.com"),
+                             (User(roleAssignments=[RoleAssignment(resource_id="ab127", role_id="ab124")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
                                         id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
                               WorkspaceRole.NoRole),
                              # user has owner role in workspace
-                             (User(roleAssignments={'abc127': 'abc128'}, id='123', name="test", email="t@t.com"),
+                             (User(roleAssignments=[RoleAssignment(resource_id="abc127", role_id="abc128")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
                                         id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
                               WorkspaceRole.Owner),
                              # user has researcher role in workspace
-                             (User(roleAssignments={'abc127': 'abc129'}, id='123', name="test", email="t@t.com"),
+                             (User(roleAssignments=[RoleAssignment(resource_id="abc127", role_id="abc129")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
                                         id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
                               WorkspaceRole.Researcher)
@@ -92,7 +92,7 @@ def test_get_workspace_role_returns_correct_owner(user: User, workspace: Workspa
 def test_raises_auth_config_error_if_workspace_auth_config_is_not_set():
     access_service = AADAccessService()
 
-    user = User(id='123', name="test", email="t@t.com", roleAssignments={'abc123': 'abc124'})
+    user = User(id='123', name="test", email="t@t.com", roleAssignments=[("ab123", "ab124")])
     workspace_with_no_auth_config = Workspace(id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0')
 
     with pytest.raises(AuthConfigValidationError):
@@ -102,7 +102,7 @@ def test_raises_auth_config_error_if_workspace_auth_config_is_not_set():
 def test_raises_auth_config_error_if_auth_info_has_incorrect_roles():
     access_service = AADAccessService()
 
-    user = User(id='123', name="test", email="t@t.com", roleAssignments={'abc123': 'abc124'})
+    user = User(id='123', name="test", email="t@t.com", roleAssignments=[("ab123", "ab124")])
     workspace_with_auth_info_but_no_roles = Workspace(
         id='abc',
         resourceTemplateName='template-name',


### PR DESCRIPTION
# PR for issue #883 

## What is being addressed

If a user is both researcher and workspace owner - only one of the roles were assigned (whatever came last for the workspace)
Owner should take precedence

## How is this addressed

- Changed implementation so that we use a list of role assignments to check against, not just a dict (resource: role)
- Update related tests
