### PR TITLE
Fix 905 - copy requirements.txt from docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,6 +50,7 @@ ENV PATH /home/vscode/.porter/:$PATH
 COPY ["requirements.txt", "/tmp/pip-tmp/" ]
 COPY ["api_app/requirements.txt", "api_app/requirements-dev.txt", "/tmp/pip-tmp/api_app/" ]
 COPY ["resource_processor/vmss_porter/requirements.txt", "/tmp/pip-tmp/resource_processor/vmss_porter/" ]
+COPY ["docs/requirements.txt", "/tmp/pip-tmp/docs/"]
 RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp
 
 RUN usermod -a -G docker vscode


### PR DESCRIPTION
# PR for issue #905 

## What is being addressed

Devcontainer fails to start due to missing requirements.txt file
Closes #905 

## How is this addressed

- docs/requirements.txt copied to tmp-pip
