### PR TITLE
Disable public client flows for Swagger UI app 

### DIFF
--- a/docs/tre-admins/deploying-the-tre/auth.md
+++ b/docs/tre-admins/deploying-the-tre/auth.md
@@ -74,10 +74,6 @@ Redirect URLs:
 - `https://<app name>.<location>.cloudapp.azure.com/docs/oauth2-redirect`
 - `http://localhost:8000/docs/oauth2-redirect` - For local testing
 
-The Swagger UI is a public client, so public client flows need to be enabled:
-
-![Allow public client flows - Yes](../../assets/app-reg-authentication-allow-public-client-flows-yes.png)
-
 ### TRE e2e test
 
 The **TRE e2e test** app registration is used to authorize end-to-end test scenarios. It has no scopes or app roles defined.

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -441,10 +441,6 @@ if [[ $grantAdminConsent -eq 1 ]]; then
     az ad app permission grant --id $swaggerSpId --api $apiAppId --scope "Workspace.Read Workspace.Write"
 fi
 
-# Allow public client flow
-echo "Enabling public client flow for ${appName} Swagger UI app"
-az ad app update --id ${swaggerAppId} --set publicClient=true
-
 echo "Done"
 
 # Output the variables for .env files


### PR DESCRIPTION
# PR for issue #915

## What is being addressed

`aad-app-reg.sh` creates an app registration for the Swagger UI app with the _allow public client flows_ set to true. This is not required since Swagger UI app use the authorization code flow.
Closes #915 

## How is this addressed

- Update app-reg script to not enable public client flows for Swagger UI app.
- Update auth.md to reflect this change.
