### PR TITLE
Add prevent destroy to cosmos and firewall

### DIFF
--- a/templates/core/terraform/firewall/firewall.tf
+++ b/templates/core/terraform/firewall/firewall.tf
@@ -19,7 +19,10 @@ resource "azurerm_firewall" "fw" {
     public_ip_address_id = azurerm_public_ip.fwpip.id
   }
 
-  lifecycle { ignore_changes = [tags] }
+  lifecycle { 
+    ignore_changes = [tags] 
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_monitor_diagnostic_setting" "firewall" {

--- a/templates/core/terraform/state-store/statestore.tf
+++ b/templates/core/terraform/state-store/statestore.tf
@@ -18,7 +18,10 @@ resource "azurerm_cosmosdb_account" "tre-db-account" {
     failover_priority = 0
   }
 
-  lifecycle { ignore_changes = [tags] }
+  lifecycle { 
+    ignore_changes = [tags] 
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_cosmosdb_sql_database" "tre-db" {
@@ -26,6 +29,11 @@ resource "azurerm_cosmosdb_sql_database" "tre-db" {
   resource_group_name = var.resource_group_name
   account_name        = azurerm_cosmosdb_account.tre-db-account.name
   throughput          = 400
+
+  lifecycle { 
+    ignore_changes = [tags] 
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_private_dns_zone" "cosmos" {

--- a/templates/core/terraform/state-store/statestore.tf
+++ b/templates/core/terraform/state-store/statestore.tf
@@ -30,8 +30,7 @@ resource "azurerm_cosmosdb_sql_database" "tre-db" {
   account_name        = azurerm_cosmosdb_account.tre-db-account.name
   throughput          = 400
 
-  lifecycle { 
-    ignore_changes = [tags] 
+  lifecycle {
     prevent_destroy = true
   }
 }


### PR DESCRIPTION
Issue #916

Add prevent destroy to firewall and cosmos resources to ensure are not accidently deleted by terraform.