### PR TITLE
KV Purge permissions to deployer account

### DIFF
--- a/templates/core/terraform/keyvault/keyvault.tf
+++ b/templates/core/terraform/keyvault/keyvault.tf
@@ -16,8 +16,8 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   tenant_id    = data.azurerm_client_config.deployer.tenant_id
   object_id    = data.azurerm_client_config.deployer.object_id
 
-  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
-  secret_permissions      = ["Get", "List", "Set", "Delete"]
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete"]
+  secret_permissions      = ["Get", "List", "Set", "Delete", "Purge"]
   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge"]
   storage_permissions     = ["Get", "List", "Update", "Delete"]
 }

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -229,7 +229,8 @@ module "gitea" {
 
   depends_on = [
     module.network,
-    module.api-webapp # it would have been better to depend on the plan itself and not the whole module
+    module.api-webapp, # it would have been better to depend on the plan itself and not the whole module
+    module.keyvault
   ]
 }
 
@@ -242,6 +243,7 @@ module "nexus" {
 
   depends_on = [
     module.network,
-    module.api-webapp # it would have been better to depend on the plan itself and not the whole module
+    module.api-webapp, # it would have been better to depend on the plan itself and not the whole module
+    module.keyvault
   ]
 }


### PR DESCRIPTION
## What is being addressed

`make tre-destroy` failed to remove keyvault secrets since deployment account was lacking purge permission

## How is this addressed

- Access policy for _deployer_  account updated to grant purge permission on secrets.
- Nexus and Gitea modules now having dependency on KeyVault module to ensure order of removal.

Closing #792 