### PR TITLE
Allows labelled fork PRs to execute workflows and documents PR security

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -2,6 +2,9 @@ name: Docker build
 
 on:
   pull_request:
+  pull_request_target:
+    types: [labeled]
+    branches: [develop]
   workflow_dispatch:
 
 # for each ref (branch/pr) run just the most recent, cancel other pending/running ones
@@ -13,6 +16,9 @@ jobs:
   docker_build:
     name: Build images
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -3,6 +3,9 @@ name: Build Validation
 on:
   pull_request:
     branches: [develop, main]
+  pull_request_target:
+    types: [labeled]
+    branches: [develop]
 
 # for each ref (branch/pr) run just the most recent, cancel other pending/running ones
 concurrency:
@@ -13,6 +16,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
+  pull_request_target:
+    types: [labeled]
+    branches: [develop]
   schedule:
     - cron: '41 3 * * 5'
 

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 1 * * *"
   push:
     branches: [develop, main]
+  pull_request_target:
+    types: [labeled]
+    branches: [develop]
   workflow_dispatch:
 
 # This will prevent multiple runs of this entire workflow.
@@ -21,6 +24,9 @@ jobs:
   deploy_mgmt_infra:
     name: Deploy Management Infrastructure
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     environment: Dev
     steps:
       - name: Checkout
@@ -66,6 +72,9 @@ jobs:
     name: Deploy TRE
     needs: deploy_mgmt_infra
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     environment: Dev
     steps:
       - name: Checkout
@@ -127,6 +136,9 @@ jobs:
   prepare_bundle_registration:
     name: Prepare Bundle Registration
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     needs: [deploy_tre]
     environment: Dev
     steps:
@@ -151,6 +163,9 @@ jobs:
   publish_and_register_bundles:
     name: Register Bundle
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     needs: [deploy_tre, prepare_bundle_registration]
     strategy:
       matrix:
@@ -223,6 +238,9 @@ jobs:
     name: "Run E2E Tests"
     runs-on: ubuntu-latest
     environment: Dev
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
     # needs: [publish_and_register_user_resources]
     needs: [publish_and_register_bundles]
     steps:

--- a/docs/tre-admins/workflows.md
+++ b/docs/tre-admins/workflows.md
@@ -52,12 +52,12 @@ jobs:
       || contains(github.event.pull_request.labels.*.name, 'safe to test')
 ```
 
-In the snippet above contains two conditions:
+The snippet above contains two conditions:
 
 1. Checking the name of the originating repository of the PR. In case the PR is from a fork the condition evaluates to `false`. `github.repository` (see [`github` context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) evaluates into string e.g., "microsoft/AzureTRE".
 2. Checking if the ull request has a label "safe to test".
 
-Effectively, the two conditions allow the job execution for all PRs originating from internal branches, but only allow PRs originating from a fork with "safe to test" label assigned to do so.
+Effectively, the two conditions allow the job execution for all PRs originating from internal branches, but only allow PRs originating from a fork with "safe to test" label assigned to do so. The workflows of fork PRs will remain in "skipped" state until the label is set.
 
 !!! caution
     Any job **without** the condition is allowed to execute even if the PR originates from a fork.

--- a/docs/tre-admins/workflows.md
+++ b/docs/tre-admins/workflows.md
@@ -55,7 +55,7 @@ jobs:
 The snippet above contains two conditions:
 
 1. Checking the name of the originating repository of the PR. In case the PR is from a fork the condition evaluates to `false`. `github.repository` (see [`github` context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) evaluates into string e.g., "microsoft/AzureTRE".
-2. Checking if the ull request has a label "safe to test".
+2. Checking if the pull request has a label "safe to test".
 
 Effectively, the two conditions allow the job execution for all PRs originating from internal branches, but only allow PRs originating from a fork with "safe to test" label assigned to do so. The workflows of fork PRs will remain in "skipped" state until the label is set.
 

--- a/docs/tre-admins/workflows.md
+++ b/docs/tre-admins/workflows.md
@@ -32,3 +32,32 @@ These are onetime configuration steps required to set up the GitHub Actions work
 | `TEST_USER_NAME` | The username of the [E2E Test User](auth.md#end-to-end-test-user). |
 | `TEST_USER_PASSWORD` | The password of the [E2E Test User](auth.md#end-to-end-test-user). |
 | `TEST_WORKSPACE_APP_ID` | The application (client) ID of the [Workspaces app](auth.md#workspaces) service principal. |
+
+## Pull request security
+
+Many of the workflows access [GitHub repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) and malicious code in workflows pose a security risk. Thus, pull requests (PRs) from forks cannot be allowed to execute workflows freely. By default, workflows are not run by pull requests from forks, but can be enabled with [`pull_request_target` event](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target).
+
+However, changes reviewed and found safe should be able to execute workflows. A label, that can only be assigned by authorized project members, can be used to safeguard workflow execution:
+
+```yaml
+on:
+  pull_request_target:
+    types: [labeled]
+    branches: [develop]
+
+jobs:
+  my_job:
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository
+      || contains(github.event.pull_request.labels.*.name, 'safe to test')
+```
+
+In the snippet above contains two conditions:
+
+1. Checking the name of the originating repository of the PR. In case the PR is from a fork the condition evaluates to `false`. `github.repository` (see [`github` context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) evaluates into string e.g., "microsoft/AzureTRE".
+2. Checking if the ull request has a label "safe to test".
+
+Effectively, the two conditions allow the job execution for all PRs originating from internal branches, but only allow PRs originating from a fork with "safe to test" label assigned to do so.
+
+!!! caution
+    Any job **without** the condition is allowed to execute even if the PR originates from a fork.


### PR DESCRIPTION
# PR for issue #478 

* Modifies workflows to allow PRs originating from forks to execute, in `develop` branch, if "safe to test" label is set
* Documents PR security
