### PR TITLE
Removes unnecessary, failing check from letsencrypt.sh script

### DIFF
--- a/templates/core/terraform/appgateway/locals.tf
+++ b/templates/core/terraform/appgateway/locals.tf
@@ -1,6 +1,8 @@
 locals {
   staticweb_storage_name = lower(replace("stweb${var.tre_id}", "-", ""))
 
+  staticweb_index_file_content = "<!DOCTYPE html><html lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta charset=\"utf-8\"/><title></title></head><body></body></html>"
+
   staticweb_backend_pool_name = "beap-staticweb"
   api_backend_pool_name       = "beap-api"
   nexus_backend_pool_name     = "beap-nexus"

--- a/templates/core/terraform/appgateway/locals.tf
+++ b/templates/core/terraform/appgateway/locals.tf
@@ -1,8 +1,6 @@
 locals {
   staticweb_storage_name = lower(replace("stweb${var.tre_id}", "-", ""))
 
-  staticweb_index_file_content = "<!DOCTYPE html><html lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta charset=\"utf-8\"/><title></title></head><body></body></html>"
-
   staticweb_backend_pool_name = "beap-staticweb"
   api_backend_pool_name       = "beap-api"
   nexus_backend_pool_name     = "beap-nexus"

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -10,21 +10,16 @@ resource "azurerm_storage_account" "staticweb" {
   enable_https_traffic_only = true
   allow_blob_public_access  = false
 
+  tags = {
+    tre_id = var.tre_id
+  }
+
   static_website {
     index_document     = "index.html"
     error_404_document = "404.html"
   }
 
-  tags = {
-    tre_id = var.tre_id
-  }
-
   lifecycle { ignore_changes = [tags] }
-
-  network_rules {
-    bypass         = ["AzureServices"]
-    default_action = "Deny"
-  }
 }
 
 resource "azurerm_storage_container" "staticweb" {
@@ -42,12 +37,16 @@ resource "azurerm_storage_blob" "staticweb" {
   source_content         = local.staticweb_index_file_content
 }
 
-# Assign the identity deploying data contibutor rights.
-# Needed to upload content to static web.
-resource "azurerm_role_assignment" "stgwriter" {
-  scope                = azurerm_storage_account.staticweb.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = data.azurerm_client_config.deployer.object_id
+resource "azurerm_storage_account_network_rules" "staticweb" {
+  resource_group_name  = var.resource_group_name
+  storage_account_name = azurerm_storage_account.staticweb.name
+
+  default_action = "Deny"
+  bypass         = ["AzureServices"]
+
+  depends_on = [
+    azurerm_storage_blob.staticweb
+  ]
 }
 
 resource "azurerm_private_endpoint" "webpe" {

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -43,6 +43,14 @@ resource "azurerm_storage_account_network_rules" "staticweb" {
   ]
 }
 
+# Assign the role to allow uploading content to the storage account
+# Needed for uploading certificates
+resource "azurerm_role_assignment" "stgwriter" {
+  scope                = azurerm_storage_account.staticweb.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = data.azurerm_client_config.deployer.object_id
+}
+
 resource "azurerm_private_endpoint" "webpe" {
   name                = "pe-web-${local.staticweb_storage_name}"
   location            = var.location

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -9,10 +9,12 @@ resource "azurerm_storage_account" "staticweb" {
   account_replication_type  = "LRS"
   enable_https_traffic_only = true
   allow_blob_public_access  = false
+
   static_website {
     index_document     = "index.html"
     error_404_document = "404.html"
   }
+
   tags = {
     tre_id = var.tre_id
   }
@@ -23,6 +25,20 @@ resource "azurerm_storage_account" "staticweb" {
     bypass         = ["AzureServices"]
     default_action = "Deny"
   }
+}
+
+resource "azurerm_storage_container" "staticweb" {
+  name                  = "$web"
+  storage_account_name  = azurerm_storage_account.staticweb.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_blob" "staticweb" {
+  name                   = "index.html"
+  storage_account_name   = azurerm_storage_account.staticweb.name
+  storage_container_name = azurerm_storage_container.staticweb.name
+  type                   = "Block"
+  source_content         = local.staticweb_index_file_content
 }
 
 # Assign the identity deploying data contibutor rights.

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -29,6 +29,8 @@ resource "azurerm_storage_blob" "staticweb" {
   type                   = "Block"
   content_type           = "text/html"
   source_content         = local.staticweb_index_file_content
+
+  lifecycle { ignore_changes = [tags] }
 }
 
 resource "azurerm_storage_account_network_rules" "staticweb" {

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -30,11 +30,9 @@ resource "azurerm_storage_blob" "staticweb" {
   content_type           = "text/html"
   source_content         = local.staticweb_index_file_content
 
-  tags = {
-    tre_id = var.tre_id
+  lifecycle {
+    ignore_changes = all
   }
-
-  lifecycle { ignore_changes = [tags] }
 }
 
 resource "azurerm_storage_account_network_rules" "staticweb" {

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -22,16 +22,10 @@ resource "azurerm_storage_account" "staticweb" {
   lifecycle { ignore_changes = [tags] }
 }
 
-resource "azurerm_storage_container" "staticweb" {
-  name                  = "$web"
-  storage_account_name  = azurerm_storage_account.staticweb.name
-  container_access_type = "private"
-}
-
 resource "azurerm_storage_blob" "staticweb" {
   name                   = "index.html"
   storage_account_name   = azurerm_storage_account.staticweb.name
-  storage_container_name = azurerm_storage_container.staticweb.name
+  storage_container_name = "$web"
   type                   = "Block"
   content_type           = "text/html"
   source_content         = local.staticweb_index_file_content

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -43,8 +43,7 @@ resource "azurerm_storage_account_network_rules" "staticweb" {
   ]
 }
 
-# Assign the role to allow uploading content to the storage account
-# Needed for uploading certificates
+# Assign the "Storage Blob Data Contributor" role needed for uploading certificates to the storage account
 resource "azurerm_role_assignment" "stgwriter" {
   scope                = azurerm_storage_account.staticweb.id
   role_definition_name = "Storage Blob Data Contributor"

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -41,8 +41,8 @@ resource "azurerm_storage_account_network_rules" "staticweb" {
   resource_group_name  = var.resource_group_name
   storage_account_name = azurerm_storage_account.staticweb.name
 
-  default_action = "Deny"
   bypass         = ["AzureServices"]
+  default_action = "Deny"
 
   depends_on = [
     azurerm_storage_blob.staticweb

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -30,6 +30,10 @@ resource "azurerm_storage_blob" "staticweb" {
   content_type           = "text/html"
   source_content         = local.staticweb_index_file_content
 
+  tags = {
+    tre_id = var.tre_id
+  }
+
   lifecycle { ignore_changes = [tags] }
 }
 

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -38,6 +38,7 @@ resource "azurerm_storage_blob" "staticweb" {
   storage_account_name   = azurerm_storage_account.staticweb.name
   storage_container_name = azurerm_storage_container.staticweb.name
   type                   = "Block"
+  content_type           = "text/html"
   source_content         = local.staticweb_index_file_content
 }
 

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -30,6 +30,9 @@ resource "azurerm_storage_blob" "staticweb" {
   content_type           = "text/html"
   source_content         = local.staticweb_index_file_content
 
+  # The storage will not be accessible to Terraform once the network security rules have been applied
+  # Luckily, this blob will not have to be changed once it is created
+  # Hence, we tell Terraform not to touch it again:
   lifecycle {
     ignore_changes = all
   }
@@ -42,6 +45,8 @@ resource "azurerm_storage_account_network_rules" "staticweb" {
   bypass         = ["AzureServices"]
   default_action = "Deny"
 
+  # The rule has to be applied AFTER the blob has been created
+  # Otherwise Terraform will fail as it cannot access the storage account
   depends_on = [
     azurerm_storage_blob.staticweb
   ]

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -20,36 +20,11 @@ resource "azurerm_storage_account" "staticweb" {
   }
 
   lifecycle { ignore_changes = [tags] }
-}
 
-resource "azurerm_storage_blob" "staticweb" {
-  name                   = "index.html"
-  storage_account_name   = azurerm_storage_account.staticweb.name
-  storage_container_name = "$web"
-  type                   = "Block"
-  content_type           = "text/html"
-  source_content         = local.staticweb_index_file_content
-
-  # The storage will not be accessible to Terraform once the network security rules have been applied
-  # Luckily, this blob will not have to be changed once it is created
-  # Hence, we tell Terraform not to touch it again:
-  lifecycle {
-    ignore_changes = all
+  network_rules {
+    bypass         = ["AzureServices"]
+    default_action = "Deny"
   }
-}
-
-resource "azurerm_storage_account_network_rules" "staticweb" {
-  resource_group_name  = var.resource_group_name
-  storage_account_name = azurerm_storage_account.staticweb.name
-
-  bypass         = ["AzureServices"]
-  default_action = "Deny"
-
-  # The rule has to be applied AFTER the blob has been created
-  # Otherwise Terraform will fail as it cannot access the storage account
-  depends_on = [
-    azurerm_storage_blob.staticweb
-  ]
 }
 
 # Assign the "Storage Blob Data Contributor" role needed for uploading certificates to the storage account

--- a/templates/core/terraform/scripts/letsencrypt.sh
+++ b/templates/core/terraform/scripts/letsencrypt.sh
@@ -10,6 +10,8 @@ fi
 
 IPADDR=$(curl ipecho.net/plain; echo)
 
+# The storage account is protected by network rules
+# The rules need to be temporarily lifted so that the certificate can be uploaded
 echo "Creating network rule on storage account ${STORAGE_ACCOUNT} for $IPADDR"
 az storage account network-rule add --account-name "${STORAGE_ACCOUNT}" --ip-address $IPADDR
 echo "Waiting for network rule to take effect"

--- a/templates/core/terraform/scripts/letsencrypt.sh
+++ b/templates/core/terraform/scripts/letsencrypt.sh
@@ -3,6 +3,19 @@ set -e
 
 script_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 
+if [[ -z ${STORAGE_ACCOUNT} ]]; then
+  echo "STORAGE_ACCOUNT not set"
+  exit 1
+fi
+
+IPADDR=$(curl ipecho.net/plain; echo)
+
+echo "Creating network rule on storage account ${STORAGE_ACCOUNT} for $IPADDR"
+az storage account network-rule add --account-name "${STORAGE_ACCOUNT}" --ip-address $IPADDR
+echo "Waiting for network rule to take effect"
+sleep 30s
+echo "Created network rule on storage account"
+
 ledir=$(pwd)/letsencrypt
 
 mkdir -p "${ledir}/logs"
@@ -44,7 +57,6 @@ if [[ -n ${KEYVAULT} ]]; then
         --gateway-name "${APPLICATION_GATEWAY}" \
         --name 'cert-primary' \
         --key-vault-secret-id "${sid}"
-
 else
     az network application-gateway ssl-cert update \
         --resource-group "${RESOURCE_GROUP}" \
@@ -53,3 +65,7 @@ else
         --cert-file "${CERT_DIR}/aci.pfx" \
         --cert-password "${CERT_PASSWORD}"
 fi
+
+echo "Removing network rule on storage account"
+az storage account network-rule remove --account-name ${STORAGE_ACCOUNT} --ip-address ${IPADDR}
+echo "Removed network rule on storage account"


### PR DESCRIPTION
# Fixes #815 #979 

`letsencrypt.sh` script checks if property `staticWebsite` is enabled in the web storage account. Terraform already enables this so the check is unnecessary. In addition, the check requires `Owner` role, which the user does not have, and fails due to it.

This change removes the unnecessary, failing step from the script. 

The consecutive steps e.g., uploading the index file and the certificate require only blob contributor role, which is assigned by Terraform so the script works.