### PR TITLE
query all accessible connections per page refresh

### DIFF
--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/user/UserContext.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/user/UserContext.java
@@ -55,6 +55,8 @@ public class UserContext extends AbstractUserContext {
 
     private User self;
 
+    private AzureTREAuthenticatedUser treUser;
+
     private Directory<User> userDirectory;
 
     private Directory<UserGroup> userGroupDirectory;
@@ -86,6 +88,8 @@ public class UserContext extends AbstractUserContext {
             Collections.emptyList()
         );
 
+        // Store TRE user to allow refresh of connection directory (github issue #850)
+        treUser = user;
         self = new SimpleUser(user.getIdentifier()) {
 
             @Override
@@ -137,9 +141,12 @@ public class UserContext extends AbstractUserContext {
     }
 
     @Override
-    public Directory<Connection> getConnectionDirectory() {
+    public Directory<Connection> getConnectionDirectory() throws GuacamoleException {
         LOGGER.debug("getConnectionDirectory");
-        return connectionDirectory;
+        // fix for github issue #850 - instead of returning connectionDirectory object we query again to get all accessible connections
+        return new SimpleDirectory<>(
+             connectionService.getConnections(treUser)
+        );
     }
 
     @Override


### PR DESCRIPTION
# PR for issue #850 


## What is being addressed

accessible connections got stored in user context upon login and were not refreshed after that,
in case someone updates user resources it won't reflect in guacamole.

## How is this addressed

Get all accessible connections per page refresh and not only during login