### PR TITLE
Rename resourceTemplateParameters to properties and resourceTemplateName to templateName and resourceTemplateVersion to templateVersion

### DIFF
--- a/api_app/api/routes/workspaces.py
+++ b/api_app/api/routes/workspaces.py
@@ -213,7 +213,7 @@ async def create_user_resource(user_resource_create: UserResourceInCreate, user_
     validate_user_is_owner_or_researcher(user, workspace)
 
     try:
-        user_resource = user_resource_repo.create_user_resource_item(user_resource_create, workspace.id, workspace_service.id, workspace_service.resourceTemplateName, user.id)
+        user_resource = user_resource_repo.create_user_resource_item(user_resource_create, workspace.id, workspace_service.id, workspace_service.templateName, user.id)
     except (ValidationError, ValueError) as e:
         logging.error(f"Failed create user resource model instance: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/api_app/db/repositories/user_resources.py
+++ b/api_app/db/repositories/user_resources.py
@@ -33,9 +33,9 @@ class UserResourceRepository(ResourceRepository):
             workspaceId=workspace_id,
             ownerId=user_id,
             parentWorkspaceServiceId=parent_workspace_service_id,
-            resourceTemplateName=user_resource_input.userResourceType,
-            resourceTemplateVersion=template_version,
-            resourceTemplateParameters=resource_spec_parameters,
+            templateName=user_resource_input.userResourceType,
+            templateVersion=template_version,
+            properties=resource_spec_parameters,
             deployment=Deployment(status=Status.NotDeployed, message=strings.RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE)
         )
 
@@ -60,5 +60,5 @@ class UserResourceRepository(ResourceRepository):
         return self.get_resource_base_spec_params()
 
     def patch_user_resource(self, user_resource: UserResource, user_resource_patch: UserResourcePatchEnabled):
-        user_resource.resourceTemplateParameters["enabled"] = user_resource_patch.enabled
+        user_resource.properties["enabled"] = user_resource_patch.enabled
         self.update_item(user_resource)

--- a/api_app/db/repositories/workspace_services.py
+++ b/api_app/db/repositories/workspace_services.py
@@ -57,14 +57,14 @@ class WorkspaceServiceRepository(ResourceRepository):
         workspace_service = WorkspaceService(
             id=full_workspace_service_id,
             workspaceId=workspace_id,
-            resourceTemplateName=workspace_service_input.workspaceServiceType,
-            resourceTemplateVersion=template_version,
-            resourceTemplateParameters=resource_spec_parameters,
+            templateName=workspace_service_input.workspaceServiceType,
+            templateVersion=template_version,
+            properties=resource_spec_parameters,
             deployment=Deployment(status=Status.NotDeployed, message=strings.RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE)
         )
 
         return workspace_service
 
     def patch_workspace_service(self, workspace_service: WorkspaceService, workspace_service_patch: WorkspaceServicePatchEnabled):
-        workspace_service.resourceTemplateParameters["enabled"] = workspace_service_patch.enabled
+        workspace_service.properties["enabled"] = workspace_service_patch.enabled
         self.update_item(workspace_service)

--- a/api_app/db/repositories/workspaces.py
+++ b/api_app/db/repositories/workspaces.py
@@ -60,9 +60,9 @@ class WorkspaceRepository(ResourceRepository):
 
         workspace = Workspace(
             id=full_workspace_id,
-            resourceTemplateName=workspace_input.workspaceType,
-            resourceTemplateVersion=template_version,
-            resourceTemplateParameters=resource_spec_parameters,
+            templateName=workspace_input.workspaceType,
+            templateVersion=template_version,
+            properties=resource_spec_parameters,
             deployment=Deployment(status=Status.NotDeployed, message=strings.RESOURCE_STATUS_NOT_DEPLOYED_MESSAGE),
             authInformation=auth_info
         )
@@ -70,13 +70,13 @@ class WorkspaceRepository(ResourceRepository):
         return workspace
 
     def get_new_address_space(self, cidr_netmask: int = 24):
-        networks = [x.resourceTemplateParameters["address_space"] for x in self.get_active_workspaces()]
+        networks = [x.properties["address_space"] for x in self.get_active_workspaces()]
 
         new_address_space = generate_new_cidr(networks, cidr_netmask)
         return new_address_space
 
     def patch_workspace(self, workspace: Workspace, workspace_patch: WorkspacePatchEnabled):
-        workspace.resourceTemplateParameters["enabled"] = workspace_patch.enabled
+        workspace.properties["enabled"] = workspace_patch.enabled
         self.update_item(workspace)
 
     def get_workspace_spec_params(self, full_workspace_id: str):

--- a/api_app/models/domain/resource.py
+++ b/api_app/models/domain/resource.py
@@ -38,24 +38,24 @@ class Resource(AzureTREModel):
     Resource request
     """
     id: str = Field(title="Id", description="GUID identifying the resource request")
-    resourceTemplateName: str = Field(title="Resource template name", description="The resource template (bundle) to deploy")
-    resourceTemplateVersion: str = Field(title="Resource template version", description="The version of the resource template (bundle) to deploy")
-    resourceTemplateParameters: dict = Field({}, title="Resource template parameters", description="Parameters for the deployment")
+    templateName: str = Field(title="Resource template name", description="The resource template (bundle) to deploy")
+    templateVersion: str = Field(title="Resource template version", description="The version of the resource template (bundle) to deploy")
+    properties: dict = Field({}, title="Resource template parameters", description="Parameters for the deployment")
     deployment: Deployment = Field(Deployment(status=Status.NotDeployed, message=""), title="Deployment", description="Fields related to deployment of this resource")
     resourceType: ResourceType
 
     def is_enabled(self) -> bool:
-        if "enabled" not in self.resourceTemplateParameters:
+        if "enabled" not in self.properties:
             return True     # default behavior is enabled = True
-        return self.resourceTemplateParameters["enabled"] is True
+        return self.properties["enabled"] is True
 
     def get_resource_request_message_payload(self, action: RequestAction) -> dict:
         return {
             "action": action,
             "id": self.id,
-            "name": self.resourceTemplateName,
-            "version": self.resourceTemplateVersion,
-            "parameters": self.resourceTemplateParameters
+            "name": self.templateName,
+            "version": self.templateVersion,
+            "parameters": self.properties
         }
 
 

--- a/api_app/models/schemas/user_resource.py
+++ b/api_app/models/schemas/user_resource.py
@@ -12,9 +12,9 @@ def get_sample_user_resource(user_resource_id: str) -> dict:
         "ownerId": "abc9ru33-7265-4b5f-9eae-a1a62928772e",
         "workspaceId": "7289ru33-7265-4b5f-9eae-a1a62928772e",
         "parentWorkspaceServiceId": "e75f1ee1-9f55-414c-83da-aff677669249",
-        "resourceTemplateName": "vm",
-        "resourceTemplateVersion": "0.1.0",
-        "resourceTemplateParameters": {
+        "templateName": "vm",
+        "templateVersion": "0.1.0",
+        "properties": {
             "display_name": "my user resource",
             "description": "some description",
         },

--- a/api_app/models/schemas/workspace.py
+++ b/api_app/models/schemas/workspace.py
@@ -10,9 +10,9 @@ from models.domain.workspace import Workspace
 def get_sample_workspace(workspace_id: str, spec_workspace_id: str = "0001") -> dict:
     return {
         "id": workspace_id,
-        "resourceTemplateName": "tre-workspace-base",
-        "resourceTemplateVersion": "0.1.0",
-        "resourceTemplateParameters": {
+        "templateName": "tre-workspace-base",
+        "templateVersion": "0.1.0",
+        "properties": {
             "azure_location": "westeurope",
             "workspace_id": spec_workspace_id,
             "tre_id": "mytre-dev-1234",

--- a/api_app/models/schemas/workspace_service.py
+++ b/api_app/models/schemas/workspace_service.py
@@ -10,9 +10,9 @@ def get_sample_workspace_service(workspace_id: str, workspace_service_id: str) -
     return {
         "id": workspace_service_id,
         "workspaceId": workspace_id,
-        "resourceTemplateName": "guacamole",
-        "resourceTemplateVersion": "0.1.0",
-        "resourceTemplateParameters": {
+        "templateName": "guacamole",
+        "templateVersion": "0.1.0",
+        "properties": {
             "display_name": "my workspace service",
             "description": "some description",
         },

--- a/api_app/service_bus/deployment_status_update.py
+++ b/api_app/service_bus/deployment_status_update.py
@@ -78,7 +78,7 @@ def create_updated_deployment_document(resource: dict, message: DeploymentStatus
     # lets not limit when we update them and have the resource process make that decision.
     output_dict = {output.Name: output.Value.strip("'").strip('"') for output in message.outputs}
 
-    resource["resourceTemplateParameters"].update(output_dict)
+    resource["properties"].update(output_dict)
 
     return resource
 

--- a/api_app/tests_ma/test_api/test_routes/test_api_access.py
+++ b/api_app/tests_ma/test_api/test_routes/test_api_access.py
@@ -19,15 +19,15 @@ USER_RESOURCE_ID = 'abcad738-7265-4b5f-9eae-a1a62928772e'
 
 
 def sample_workspace():
-    return Workspace(id=WORKSPACE_ID, resourceTemplateName='template name', resourceTemplateVersion='1.0')
+    return Workspace(id=WORKSPACE_ID, templateName='template name', templateVersion='1.0')
 
 
 def sample_workspace_service():
-    return WorkspaceService(id=SERVICE_ID, resourceTemplateName='template name', resourceTemplateVersion='1.0')
+    return WorkspaceService(id=SERVICE_ID, templateName='template name', templateVersion='1.0')
 
 
 def sample_user_resource():
-    return UserResource(id=USER_RESOURCE_ID, resourceTemplateName='template name', resourceTemplateVersion='1.0')
+    return UserResource(id=USER_RESOURCE_ID, templateName='template name', templateVersion='1.0')
 
 
 # TEMPLATES

--- a/api_app/tests_ma/test_api/test_routes/test_workspaces.py
+++ b/api_app/tests_ma/test_api/test_routes/test_workspaces.py
@@ -65,16 +65,16 @@ def sample_user_resource_input_data():
 @pytest.fixture
 def disabled_workspace() -> Workspace:
     workspace = sample_workspace(WORKSPACE_ID)
-    workspace.resourceTemplateParameters["enabled"] = False
+    workspace.properties["enabled"] = False
     return workspace
 
 
 def sample_workspace(workspace_id=WORKSPACE_ID, auth_info: dict = {}):
     workspace = Workspace(
         id=workspace_id,
-        resourceTemplateName="tre-workspace-base",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="tre-workspace-base",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.NotDeployed, message=""),
     )
     if auth_info:
@@ -85,9 +85,9 @@ def sample_workspace(workspace_id=WORKSPACE_ID, auth_info: dict = {}):
 def sample_deployed_workspace(workspace_id=WORKSPACE_ID, auth_info: dict = {}):
     workspace = Workspace(
         id=workspace_id,
-        resourceTemplateName="tre-workspace-base",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="tre-workspace-base",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.Deployed, message=""),
     )
     if auth_info:
@@ -99,9 +99,9 @@ def sample_workspace_service(workspace_service_id=SERVICE_ID, workspace_id=WORKS
     return WorkspaceService(
         id=workspace_service_id,
         workspaceId=workspace_id,
-        resourceTemplateName="tre-workspace-base",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="tre-workspace-base",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.NotDeployed, message=""),
     )
 
@@ -111,9 +111,9 @@ def sample_user_resource_object(user_resource_id=USER_RESOURCE_ID, workspace_id=
         id=user_resource_id,
         workspaceId=workspace_id,
         parentWorkspaceServiceId=parent_workspace_service_id,
-        resourceTemplateName="tre-user-resource",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="tre-user-resource",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.NotDeployed, message=""),
     )
 
@@ -121,11 +121,11 @@ def sample_user_resource_object(user_resource_id=USER_RESOURCE_ID, workspace_id=
 
 
 def disabled_workspace_service():
-    return WorkspaceService(id=SERVICE_ID, resourceTemplateName='template name', resourceTemplateVersion='1.0', resourceTemplateParameters={"enabled": False})
+    return WorkspaceService(id=SERVICE_ID, templateName='template name', templateVersion='1.0', properties={"enabled": False})
 
 
 def disabled_user_resource():
-    return UserResource(id=USER_RESOURCE_ID, resourceTemplateName='template name', resourceTemplateVersion='1.0', resourceTemplateParameters={"enabled": False})
+    return UserResource(id=USER_RESOURCE_ID, templateName='template name', templateVersion='1.0', properties={"enabled": False})
 
 
 class TestWorkspaceHelpers:
@@ -383,7 +383,7 @@ class TestWorkspaceRoutesThatRequireAdminRights:
     @ patch("api.dependencies.workspaces.WorkspaceRepository.get_workspace_by_id")
     async def test_delete_workspace_returns_400_if_workspace_is_enabled(self, get_workspace_mock, app, client):
         workspace = sample_workspace()
-        workspace.resourceTemplateParameters["enabled"] = True
+        workspace.properties["enabled"] = True
         get_workspace_mock.return_value = workspace
 
         response = await client.delete(app.url_path_for(strings.API_DELETE_WORKSPACE, workspace_id=WORKSPACE_ID))
@@ -587,7 +587,7 @@ class TestWorkspaceServiceRoutesThatDontRequireAdminRights:
     @patch("api.routes.workspaces.validate_user_is_owner")
     async def test_delete_workspace_service_raises_400_if_workspace_service_is_enabled(self, _, __, get_workspace_service_mock, app, client):
         workspace_service = sample_workspace_service()
-        workspace_service.resourceTemplateParameters["enabled"] = True
+        workspace_service.properties["enabled"] = True
         get_workspace_service_mock.return_value = workspace_service
 
         response = await client.delete(app.url_path_for(strings.API_DELETE_WORKSPACE_SERVICE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID))
@@ -782,7 +782,7 @@ class TestUserResourcesRoutesThatDontRequireAdminRights:
     @patch("api.routes.workspaces.validate_user_is_workspace_owner_or_resource_owner")
     async def test_delete_user_resource_raises_400_if_user_resource_is_enabled(self, _, get_user_resource_mock, ___, app, client):
         user_resource = sample_user_resource_object()
-        user_resource.resourceTemplateParameters["enabled"] = True
+        user_resource.properties["enabled"] = True
         get_user_resource_mock.return_value = user_resource
 
         response = await client.delete(app.url_path_for(strings.API_DELETE_USER_RESOURCE, workspace_id=WORKSPACE_ID, service_id=SERVICE_ID, resource_id=USER_RESOURCE_ID))

--- a/api_app/tests_ma/test_db/test_repositories/test_resource_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_resource_repository.py
@@ -28,9 +28,9 @@ def test_delete_workspace_marks_workspace_as_deleted(resource_repo):
 
     workspace = Workspace(
         id="1234",
-        resourceTemplateName="base-tre",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="base-tre",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.NotDeployed, message=""),
     )
     resource_repo.mark_resource_as_deleting(workspace)
@@ -43,9 +43,9 @@ def test_restore_deletion_status_updates_db(resource_repo):
 
     workspace = Workspace(
         id="1234",
-        resourceTemplateName="base-tre",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="base-tre",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.Deleting, message=""),
     )
     resource_repo.restore_previous_deletion_state(workspace, Status.Deployed)

--- a/api_app/tests_ma/test_db/test_repositories/test_user_resource_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_user_resource_repository.py
@@ -29,9 +29,9 @@ def user_resource_repo():
 def user_resource():
     user_resource = UserResource(
         id=RESOURCE_ID,
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
-        resourceTemplateName="my-workspace-service",
+        templateVersion="0.1.0",
+        properties={},
+        templateName="my-workspace-service",
     )
     return user_resource
 
@@ -44,15 +44,15 @@ def test_create_user_resource_item_creates_a_user_resource_with_the_right_values
 
     user_resource = user_resource_repo.create_user_resource_item(user_resource_to_create, WORKSPACE_ID, SERVICE_ID, "parent-service-type", USER_ID)
 
-    assert user_resource.resourceTemplateName == basic_user_resource_request.userResourceType
+    assert user_resource.templateName == basic_user_resource_request.userResourceType
     assert user_resource.resourceType == ResourceType.UserResource
     assert user_resource.deployment.status == Status.NotDeployed
     assert user_resource.workspaceId == WORKSPACE_ID
     assert user_resource.parentWorkspaceServiceId == SERVICE_ID
     assert user_resource.ownerId == USER_ID
-    assert len(user_resource.resourceTemplateParameters["tre_id"]) > 0
+    assert len(user_resource.properties["tre_id"]) > 0
     # need to make sure request doesn't override system param
-    assert user_resource.resourceTemplateParameters["tre_id"] != "test"
+    assert user_resource.properties["tre_id"] != "test"
 
 
 @patch('db.repositories.user_resources.UserResourceRepository.validate_input_against_template', side_effect=ValueError)
@@ -100,5 +100,5 @@ def test_patch_user_resource_updates_item(user_resource, user_resource_repo):
     user_resource_patch = UserResourcePatchEnabled(enabled=True)
 
     user_resource_repo.patch_user_resource(user_resource, user_resource_patch)
-    user_resource.resourceTemplateParameters["enabled"] = False
+    user_resource.properties["enabled"] = False
     user_resource_repo.update_item.assert_called_once_with(user_resource)

--- a/api_app/tests_ma/test_db/test_repositories/test_workpaces_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_workpaces_repository.py
@@ -24,9 +24,9 @@ def workspace_repo():
 def workspace():
     workspace = Workspace(
         id="000000d3-82da-4bfc-b6e9-9a7853ef753e",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
-        resourceTemplateName="my-workspace-service",
+        templateVersion="0.1.0",
+        properties={},
+        templateName="my-workspace-service",
     )
     return workspace
 
@@ -83,18 +83,18 @@ def test_create_workspace_item_creates_a_workspace_with_the_right_values(validat
 
     workspace = workspace_repo.create_workspace_item(workspace_to_create)
 
-    assert workspace.resourceTemplateName == workspace_to_create.workspaceType
+    assert workspace.templateName == workspace_to_create.workspaceType
     assert workspace.resourceType == ResourceType.Workspace
     assert workspace.deployment.status == Status.NotDeployed
 
     for key in ["display_name", "description", "azure_location", "workspace_id", "tre_id", "address_space"]:
-        assert key in workspace.resourceTemplateParameters
-        assert len(workspace.resourceTemplateParameters[key]) > 0
+        assert key in workspace.properties
+        assert len(workspace.properties[key]) > 0
 
     # need to make sure request doesn't override system param
-    assert workspace.resourceTemplateParameters["tre_id"] != workspace_to_create.properties["tre_id"]
+    assert workspace.properties["tre_id"] != workspace_to_create.properties["tre_id"]
     # a new CIDR was allocated
-    assert workspace.resourceTemplateParameters["address_space"] == "1.2.3.4/24"
+    assert workspace.properties["address_space"] == "1.2.3.4/24"
 
 
 @patch('db.repositories.workspaces.extract_auth_information', return_value={})
@@ -108,7 +108,7 @@ def test_create_workspace_item_creates_a_workspace_with_custom_address_space(val
 
     workspace = workspace_repo.create_workspace_item(workspace_to_create)
 
-    assert workspace.resourceTemplateParameters["address_space"] == workspace_to_create.properties["address_space"]
+    assert workspace.properties["address_space"] == workspace_to_create.properties["address_space"]
 
 
 @patch('db.repositories.workspaces.extract_auth_information', return_value={})
@@ -125,14 +125,14 @@ def test_patch_workspace_updates_item(workspace_repo):
     workspace_repo.update_item = MagicMock(return_value=None)
     workspace_to_patch = Workspace(
         id="1234",
-        resourceTemplateName="base-tre",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="base-tre",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.NotDeployed, message=""),
     )
     workspace_patch = WorkspacePatchEnabled(enabled=False)
 
     workspace_repo.patch_workspace(workspace_to_patch, workspace_patch)
 
-    workspace_to_patch.resourceTemplateParameters["enabled"] = False
+    workspace_to_patch.properties["enabled"] = False
     workspace_repo.update_item.assert_called_once_with(workspace_to_patch)

--- a/api_app/tests_ma/test_db/test_repositories/test_workpaces_service_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_workpaces_service_repository.py
@@ -27,9 +27,9 @@ def workspace_service_repo():
 def workspace_service():
     workspace_service = WorkspaceService(
         id=SERVICE_ID,
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
-        resourceTemplateName="my-workspace-service",
+        templateVersion="0.1.0",
+        properties={},
+        templateName="my-workspace-service",
     )
     return workspace_service
 
@@ -94,13 +94,13 @@ def test_create_workspace_service_item_creates_a_workspace_with_the_right_values
 
     workspace_service = workspace_service_repo.create_workspace_service_item(workspace_service_to_create, WORKSPACE_ID)
 
-    assert workspace_service.resourceTemplateName == basic_workspace_service_request.workspaceServiceType
+    assert workspace_service.templateName == basic_workspace_service_request.workspaceServiceType
     assert workspace_service.resourceType == ResourceType.WorkspaceService
     assert workspace_service.deployment.status == Status.NotDeployed
     assert workspace_service.workspaceId == WORKSPACE_ID
-    assert len(workspace_service.resourceTemplateParameters["tre_id"]) > 0
+    assert len(workspace_service.properties["tre_id"]) > 0
     # need to make sure request doesn't override system param
-    assert workspace_service.resourceTemplateParameters["tre_id"] != "test"
+    assert workspace_service.properties["tre_id"] != "test"
 
 
 @patch('db.repositories.workspace_services.WorkspaceServiceRepository.validate_input_against_template', side_effect=ValueError)
@@ -118,5 +118,5 @@ def test_patch_workspace_service_updates_item(workspace_service, workspace_servi
     )
 
     workspace_service_repo.patch_workspace_service(workspace_service, workspace_service_patch)
-    workspace_service.resourceTemplateParameters["enabled"] = False
+    workspace_service.properties["enabled"] = False
     workspace_service_repo.update_item.assert_called_once_with(workspace_service)

--- a/api_app/tests_ma/test_models/test_resource.py
+++ b/api_app/tests_ma/test_models/test_resource.py
@@ -8,11 +8,11 @@ from models.domain.workspace_service import WorkspaceService
 
 @pytest.mark.parametrize('resource, expected', [
     # enabled = True
-    (Resource(resourceTemplateName="", resourceTemplateVersion="", resourceTemplateParameters={"enabled": True}, id="1234", resourceType=ResourceType.Workspace), True),
+    (Resource(templateName="", templateVersion="", properties={"enabled": True}, id="1234", resourceType=ResourceType.Workspace), True),
     # enabled = False
-    (Resource(resourceTemplateName="", resourceTemplateVersion="", resourceTemplateParameters={"enabled": False}, id="1234", resourceType=ResourceType.Workspace), False),
+    (Resource(templateName="", templateVersion="", properties={"enabled": False}, id="1234", resourceType=ResourceType.Workspace), False),
     # enabled not set - defaults to True
-    (Resource(resourceTemplateName="", resourceTemplateVersion="", resourceTemplateParameters={}, id="1234", resourceType=ResourceType.Workspace), True),
+    (Resource(templateName="", templateVersion="", properties={}, id="1234", resourceType=ResourceType.Workspace), True),
 ])
 def test_resource_is_enabled_returns_correct_value(resource, expected):
     assert resource.is_enabled() == expected
@@ -23,7 +23,7 @@ def test_user_resource_get_resource_request_message_payload_augments_payload_wit
     workspace_id = "123"
     parent_service_id = "abcdef"
 
-    user_resource = UserResource(id="123", resourceTemplateName="user-template", resourceTemplateVersion="1.0", ownerId=owner_id, workspaceId=workspace_id, parentWorkspaceServiceId=parent_service_id)
+    user_resource = UserResource(id="123", templateName="user-template", templateVersion="1.0", ownerId=owner_id, workspaceId=workspace_id, parentWorkspaceServiceId=parent_service_id)
 
     message_payload = user_resource.get_resource_request_message_payload(RequestAction.Install)
 
@@ -34,7 +34,7 @@ def test_user_resource_get_resource_request_message_payload_augments_payload_wit
 
 def test_workspace_service_get_resource_request_message_payload_augments_payload_with_extra_params():
     workspace_id = "123"
-    workspace_service = WorkspaceService(id="123", resourceTemplateName="service-template", resourceTemplateVersion="1.0", workspaceId=workspace_id)
+    workspace_service = WorkspaceService(id="123", templateName="service-template", templateVersion="1.0", workspaceId=workspace_id)
 
     message_payload = workspace_service.get_resource_request_message_payload(RequestAction.Install)
 

--- a/api_app/tests_ma/test_service_bus/test_deployment_status_update.py
+++ b/api_app/tests_ma/test_service_bus/test_deployment_status_update.py
@@ -48,9 +48,9 @@ class ServiceBusReceivedMessageMock:
 def create_sample_workspace_object(workspace_id):
     return Workspace(
         id=workspace_id,
-        resourceTemplateName="tre-workspace-base",
-        resourceTemplateVersion="0.1.0",
-        resourceTemplateParameters={},
+        templateName="tre-workspace-base",
+        templateVersion="0.1.0",
+        properties={},
         deployment=Deployment(status=Status.NotDeployed, message="")
     )
 
@@ -210,13 +210,13 @@ async def test_outputs_are_added_to_resource_item(app, sb_client, logging_mock, 
     sb_client().get_queue_receiver().complete_message = AsyncMock()
 
     resource = create_sample_workspace_object(received_message["id"])
-    resource.resourceTemplateParameters = {"exitingName": "exitingValue"}
+    resource.properties = {"exitingName": "exitingValue"}
     repo().get_resource_dict_by_id.return_value = resource.dict()
 
     new_params = {"name1": "value1", "name2": "value2"}
 
     expected_resource = resource
-    expected_resource.resourceTemplateParameters = {**resource.resourceTemplateParameters, **new_params}
+    expected_resource.properties = {**resource.properties, **new_params}
     expected_resource.deployment = Deployment(status=Status.Deployed, message=received_message["message"])
 
     await receive_message_and_update_deployment(app)
@@ -228,7 +228,7 @@ async def test_outputs_are_added_to_resource_item(app, sb_client, logging_mock, 
 @patch('logging.error')
 @patch('service_bus.deployment_status_update.ServiceBusClient')
 @patch('fastapi.FastAPI')
-async def test_resourceTemplateParameters_dont_change_with_no_outputs(app, sb_client, logging_mock, repo):
+async def test_properties_dont_change_with_no_outputs(app, sb_client, logging_mock, repo):
     received_message = test_sb_message
     received_message["status"] = Status.Deployed
     service_bus_received_message_mock = ServiceBusReceivedMessageMock(received_message)
@@ -237,7 +237,7 @@ async def test_resourceTemplateParameters_dont_change_with_no_outputs(app, sb_cl
     sb_client().get_queue_receiver().complete_message = AsyncMock()
 
     resource = create_sample_workspace_object(received_message["id"])
-    resource.resourceTemplateParameters = {"exitingName": "exitingValue"}
+    resource.properties = {"exitingName": "exitingValue"}
     repo().get_resource_dict_by_id.return_value = resource.dict()
 
     expected_resource = resource

--- a/api_app/tests_ma/test_service_bus/test_resource_request_sender.py
+++ b/api_app/tests_ma/test_service_bus/test_resource_request_sender.py
@@ -16,9 +16,9 @@ def create_test_resource():
     return Resource(
         id=str(uuid.uuid4()),
         resourceType=ResourceType.Workspace,
-        resourceTemplateName="Test resource template name",
-        resourceTemplateVersion="2.718",
-        resourceTemplateParameters={"testParameter": "testValue"},
+        templateName="Test resource template name",
+        templateVersion="2.718",
+        properties={"testParameter": "testValue"},
         deployment=Deployment(
             status=Status.NotDeployed,
             message="Deployment test message"

--- a/api_app/tests_ma/test_services/test_aad_access_service.py
+++ b/api_app/tests_ma/test_services/test_aad_access_service.py
@@ -63,22 +63,22 @@ def test_extract_workspace__returns_sp_id_and_roles(get_app_sp_graph_data_mock):
                              # user not a member of the workspace app
                              (User(roleAssignments=[RoleAssignment(resource_id="ab123", role_id="ab124")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
-                                        id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
+                                        id='abc', templateName='template-name', templateVersion='0.1.0'),
                               WorkspaceRole.NoRole),
                              # user is member of the workspace app but not in role
                              (User(roleAssignments=[RoleAssignment(resource_id="ab127", role_id="ab124")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
-                                        id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
+                                        id='abc', templateName='template-name', templateVersion='0.1.0'),
                               WorkspaceRole.NoRole),
                              # user has owner role in workspace
                              (User(roleAssignments=[RoleAssignment(resource_id="abc127", role_id="abc128")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
-                                        id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
+                                        id='abc', templateName='template-name', templateVersion='0.1.0'),
                               WorkspaceRole.Owner),
                              # user has researcher role in workspace
                              (User(roleAssignments=[RoleAssignment(resource_id="abc127", role_id="abc129")], id='123', name="test", email="t@t.com"),
                               Workspace(authInformation={'sp_id': 'abc127', 'roles': {'WorkspaceOwner': 'abc128', 'WorkspaceResearcher': 'abc129'}},
-                                        id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0'),
+                                        id='abc', templateName='template-name', templateVersion='0.1.0'),
                               WorkspaceRole.Researcher)
                          ])
 def test_get_workspace_role_returns_correct_owner(user: User, workspace: Workspace, expected_role: WorkspaceRole):
@@ -93,7 +93,7 @@ def test_raises_auth_config_error_if_workspace_auth_config_is_not_set():
     access_service = AADAccessService()
 
     user = User(id='123', name="test", email="t@t.com", roleAssignments=[("ab123", "ab124")])
-    workspace_with_no_auth_config = Workspace(id='abc', resourceTemplateName='template-name', resourceTemplateVersion='0.1.0')
+    workspace_with_no_auth_config = Workspace(id='abc', templateName='template-name', templateVersion='0.1.0')
 
     with pytest.raises(AuthConfigValidationError):
         _ = access_service.get_workspace_role(user, workspace_with_no_auth_config)
@@ -105,8 +105,8 @@ def test_raises_auth_config_error_if_auth_info_has_incorrect_roles():
     user = User(id='123', name="test", email="t@t.com", roleAssignments=[("ab123", "ab124")])
     workspace_with_auth_info_but_no_roles = Workspace(
         id='abc',
-        resourceTemplateName='template-name',
-        resourceTemplateVersion='0.1.0',
+        templateName='template-name',
+        templateVersion='0.1.0',
         authInformation={'sp_id': '123', 'roles': {}})
 
     with pytest.raises(AuthConfigValidationError):

--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -99,7 +99,7 @@ async def disable_workspace(token, verify) -> None:
 
         response = await client.patch(f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_WORKSPACES}/{workspace_id}", headers=get_auth_header(token), json=payload)
 
-        enabled = response.json()["workspace"]["resourceTemplateParameters"]["enabled"]
+        enabled = response.json()["workspace"]["properties"]["enabled"]
         assert (enabled is False), "The workspace wasn't disabled"
 
 
@@ -194,7 +194,7 @@ async def disable_workspace_service(workspace_id, workspace_service_id, token, v
 
         response = await client.patch(f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_WORKSPACES}/{workspace_id}/{strings.API_WORKSPACE_SERVICES}/{workspace_service_id}", headers=get_auth_header(token), json=payload)
 
-        enabled = response.json()["workspaceService"]["resourceTemplateParameters"]["enabled"]
+        enabled = response.json()["workspaceService"]["properties"]["enabled"]
         assert (enabled is False), "The workspace service wasn't disabled"
 
 

--- a/scripts/db_migrations.py
+++ b/scripts/db_migrations.py
@@ -1,0 +1,37 @@
+#!/usr/local/bin/python3
+
+import os
+from azure.cosmos.cosmos_client import CosmosClient
+
+
+class TRECosmosDBMigrations:
+
+    def __init__(self):
+
+        url = os.environ['STATE_STORE_ENDPOINT']
+        key = os.environ['STATE_STORE_KEY']
+        self.client = CosmosClient(url=url, credential=key)
+        self.database = self.client.get_database_client(database=os.environ['COSMOSDB_ACCOUNT_NAME'])
+
+    def renameCosmosDBFields(self, container_name, old_field_name, new_field_name):
+
+        container = self.database.get_container_client(container_name)
+
+        import json
+        for item in container.query_items(query=f'SELECT * FROM {container_name}', enable_cross_partition_query=True):
+            print(json.dumps(item, indent=True))
+            if old_field_name in item:
+                item[new_field_name] = item[old_field_name]
+                del item[old_field_name]
+                container.upsert_item(item)
+
+
+def main():
+    migrations = TRECosmosDBMigrations()
+    migrations.renameCosmosDBFields("Resources", 'resourceTemplateName', 'templateName')
+    migrations.renameCosmosDBFields("Resources", 'resourceTemplateVersion', 'templateVersion')
+    migrations.renameCosmosDBFields("Resources", 'resourceTemplateParameters', 'properties')
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/pom.xml
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.1</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/connection/ConnectionService.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/connection/ConnectionService.java
@@ -66,7 +66,7 @@ public class ConnectionService {
                 for (int i = 0; i < vmsJsonArray.length(); i++) {
                     final GuacamoleConfiguration config = new GuacamoleConfiguration();
                     final JSONObject vmJsonObject = vmsJsonArray.getJSONObject(i);
-                    final JSONObject templateParameters = (JSONObject) vmJsonObject.get("resourceTemplateParameters");
+                    final JSONObject templateParameters = (JSONObject) vmJsonObject.get("properties");
                     if (templateParameters.has("hostname") && templateParameters.has("ip")) {
                         final String azureResourceId = templateParameters.getString("hostname");
                         final String ip = templateParameters.getString("ip");


### PR DESCRIPTION
# PR for issue #833

## What is being addressed

Rename resourceTemplateParameters to properties and resourceTemplateName to templateName and resourceTemplateVersion to templateVersion

## How is this addressed

- Renamed fields 
- Updated tests
- Added migration script (likely not suitable for production, but fine for dev
- Updated guacamole with new field name
