### PR TITLE
Removes AzureMonitor service tags from firewall rules

### DIFF
--- a/docs/azure-tre-overview/networking.md
+++ b/docs/azure-tre-overview/networking.md
@@ -38,6 +38,10 @@ The explicitly allowed egress traffic is described here:
 - [Gitea Shared Service](shared-services/gitea.md#network-requirements)
 - [Nexus Shared Service](shared-services/nexus.md#network-requirements)
 
+## Azure Monitor
+
+Azure Monitor resources are secured using [Azure Monitor Private Link Scope (AMPLS)](https://docs.microsoft.com/azure/azure-monitor/logs/private-link-security) keeping all traffic inside the Microsoft Azure backbone network. The Azure Monitor resources and their network configuration is defined in `/templates/core/terraform/azure-monitor` folder and the required private DNS zones in file `/templates/core/terraform/network/dns_zones.tf`.
+
 ## Network security groups
 
 ### TRE Core

--- a/docs/azure-tre-overview/shared-services/gitea.md
+++ b/docs/azure-tre-overview/shared-services/gitea.md
@@ -20,5 +20,4 @@ Gitea needs to be able to access the following resource outside the Azure TRE VN
 | --- | --- |
 | AzureActiveDirectory | Authorize the signed in user against Azure Active Directory. |
 | AzureContainerRegistry | Pull the Gitea container image, as it is located in Azure Container Registry.  |
-| AzureMonitor | Forwards tracing an logs to central location for troubleshooting. |
 | (www.)github.com | Allows Gitea to mirror any repo on GitHub |

--- a/docs/azure-tre-overview/shared-services/nexus.md
+++ b/docs/azure-tre-overview/shared-services/nexus.md
@@ -34,5 +34,4 @@ Notice that since Nexus Shared Service is running on an App Service, the outgoin
 | --- | --- |
 | AzureActiveDirectory | Authorize the signed in user against Azure Active Directory. |
 | AzureContainerRegistry | Pull the Nexus container image, as it is located in Azure Container Registry.  |
-| AzureMonitor | Forwards tracing an logs to central location for troubleshooting. |
 | pypi.org | Enables Nexus to "proxy" python packages to use inside of workspaces |

--- a/docs/tre-developers/api.md
+++ b/docs/tre-developers/api.md
@@ -265,7 +265,6 @@ To be able to run the TRE API it needs to access the following resource outside 
 | Service Tag / Destination | Justification |
 | --- | --- |
 | AzureActiveDirectory | Authenticate with the User Assigned identity to access Azure Cosmos DB and Azure Service Bus. |
-| AzureMonitor | Publish traces and logs to one central place for troubleshooting. |
 | AzureResourceManager | To perform control plane operations, such as create database in State Store. |
 | AzureContainerRegistry | Pull the TRE API container image, as it is located in Azure Container Registry.  |
 | graph.microsoft.com | Lookup role assignments for Azure Active Directory user, to only show TRE resources and user has access to. |

--- a/docs/tre-developers/resource-processor.md
+++ b/docs/tre-developers/resource-processor.md
@@ -83,7 +83,6 @@ The Resource Processor needs to access the following resources outside the Azure
 | --- | --- |
 | AzureActiveDirectory | Authenticate with the User Assigned identity to access Azure Resource Manager and Azure Service Bus. |
 | AzureResourceManager | Access the Azure control plane to deploy and manage Azure resources. |
-| AzureMonitor | Publish traces and logs to one central place for troubleshooting. |
 | AzureContainerRegistry | Pull the Resource Processor container image, as it is located in Azure Container Registry.  |
 | Storage | The Porter bundles stores state between executions in an Azure Storage Account. |
 | AzureKeyVault | The Porter bundles might need to create an Azure Key Vault inside of the Workspace. To verify the creation, before a private link connection is created, Terraform needs to reach Key Vault over public network |

--- a/templates/core/terraform/firewall/firewall.tf
+++ b/templates/core/terraform/firewall/firewall.tf
@@ -215,7 +215,6 @@ resource "azurerm_firewall_network_rule_collection" "resource_processor_subnet" 
       "AzureActiveDirectory",
       "AzureResourceManager",
       "AzureContainerRegistry",
-      "AzureMonitor",
       "Storage",
       "AzureKeyVault"
     ]
@@ -248,8 +247,7 @@ resource "azurerm_firewall_network_rule_collection" "web_app_subnet" {
     destination_addresses = [
       "AzureActiveDirectory",
       "AzureContainerRegistry",
-      "AzureResourceManager",
-      "AzureMonitor"
+      "AzureResourceManager"
     ]
 
     destination_ports = [


### PR DESCRIPTION
# PR for issue #1055 

## Changes

* Removes `AzureMonitor` service tags from firewall rules (API and Resource Processor)
* Updates documentation

Changes tested; logs not blocked after removing service tags.