### PR TITLE
Guacamole OpenID extension support

### DIFF
--- a/templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile
@@ -52,6 +52,13 @@ COPY ./docker/services /etc/services.d/
 COPY --from=client_build /target/lib/* ${GUACAMOLE_LIB}
 COPY --from=client_build /target/guacamole-auth-tre-${GUACAMOLE_AZURE_VERSION}.jar "${GUACAMOLE_HOME}/extensions/"
 
+RUN wget https://apache.org/dyn/closer.lua/guacamole/1.3.0/binary/guacamole-auth-openid-1.3.0.tar.gz?action=download -O guacamole-auth-openid-1.3.0.tar.gz \
+&& tar zxvpf guacamole-auth-openid-1.3.0.tar.gz && rm guacamole-auth-openid-1.3.0.tar.gz
+
+RUN cp ./guacamole-auth-openid-1.3.0/guacamole-auth-openid-1.3.0.jar "${GUACAMOLE_HOME}/extensions/"
+
+RUN rm -rf ./guacamole-auth-openid-1.3.0
+
 RUN wget -O ${GUACAMOLE_HOME}/guacamole.war 'http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/1.3.0/binary/guacamole-1.3.0.war'
 
 ENTRYPOINT [ "/init" ]

--- a/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
@@ -1,6 +1,6 @@
 # The OpenID extension requires multiple parameters, by setting the 'enable-environment-properties', these parameters are fetched from env vars.
 # (see https://guacamole.apache.org/doc/gug/configuring-guacamole.html). The required parameters are defined here (https://guacamole.apache.org/doc/gug/openid-auth.html):
 # openid-authorization-endpoint, openid-jwks-endpoint, openid-issuer, openid-client-id and openid-redirect-uri.
-# We assume Azure deployment, so the first 4 are built using the given tenantId, the last one is built using the given web app name
+# We assume Azure deployment, so the first 3 are built using the given tenantId, the last one is built using the given web app name (only openid-client-id is passed explicitly)
 
 enable-environment-properties:true

--- a/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
@@ -1,0 +1,3 @@
+# Hostname and port of guacamole proxy
+
+enable-environment-properties:true

--- a/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
@@ -1,3 +1,6 @@
-# Hostname and port of guacamole proxy
+# The OpenID extension requires multiple parameters, by setting the 'enable-environment-properties', these parameters are fetched from env vars.
+# (see https://guacamole.apache.org/doc/gug/configuring-guacamole.html). The required parameters are defined here (https://guacamole.apache.org/doc/gug/openid-auth.html):
+# openid-authorization-endpoint, openid-jwks-endpoint, openid-issuer, openid-client-id and openid-redirect-uri.
+# The first four are passed using the porter schema, the last is built dynamically.
 
 enable-environment-properties:true

--- a/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/guacamole/guacamole.properties
@@ -1,6 +1,6 @@
 # The OpenID extension requires multiple parameters, by setting the 'enable-environment-properties', these parameters are fetched from env vars.
 # (see https://guacamole.apache.org/doc/gug/configuring-guacamole.html). The required parameters are defined here (https://guacamole.apache.org/doc/gug/openid-auth.html):
 # openid-authorization-endpoint, openid-jwks-endpoint, openid-issuer, openid-client-id and openid-redirect-uri.
-# The first four are passed using the porter schema, the last is built dynamically.
+# We assume Azure deployment, so the first 4 are built using the given tenantId, the last one is built using the given web app name
 
 enable-environment-properties:true

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/readme.md
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/readme.md
@@ -8,6 +8,6 @@ Read more [here](https://guacamole.apache.org/doc/gug/guacamole-ext.html).
 
 This extension works in the following manner:
 
-1. recieves the acccess token from the header : x-access-token
+1. receives a token from the OpenId extension
 2. The extension call the project api to get the user's vm list
 3. When connect request is made, the extension call the project api to get the password to the selected vm and inject it into the Guacamole configurations.

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/AuthenticationProviderService.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/AuthenticationProviderService.java
@@ -37,7 +37,7 @@ public class AuthenticationProviderService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureTREAuthenticationProvider.class);
 
-    public void validateToken(final String accessToken, final UrlJwkProvider jwkProvider) throws GuacamoleInvalidCredentialsException {
+    public void validateToken(final String token, final UrlJwkProvider jwkProvider) throws GuacamoleInvalidCredentialsException {
 
         try {
             if (System.getenv("AUDIENCE").length() == 0) {
@@ -47,7 +47,7 @@ public class AuthenticationProviderService {
                 throw new Exception("ISSUER is not provided");
             }
 
-            final Jwk jwk = jwkProvider.get(JWT.decode(accessToken).getKeyId());
+            final Jwk jwk = jwkProvider.get(JWT.decode(token).getKeyId());
             final Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
             final JWTVerifier verifier = JWT.require(algorithm)
                 .withAudience(System.getenv("AUDIENCE"))
@@ -55,7 +55,7 @@ public class AuthenticationProviderService {
                 .withIssuer(System.getenv("ISSUER"))
                 .build();
 
-            final DecodedJWT jwt = verifier.verify(accessToken);
+            final DecodedJWT jwt = verifier.verify(token);
             // Since we verify we have the correct Audience we validate the token if at least one role is present, no
             // matter which one.
             final Claim roles = jwt.getClaim("roles");

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/AuthenticationProviderService.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/AuthenticationProviderService.java
@@ -47,30 +47,6 @@ public class AuthenticationProviderService {
     @Inject
     private Provider<AzureTREAuthenticatedUser> authenticatedUserProvider;
 
-    public AzureTREAuthenticatedUser authenticateUser(final Credentials credentials) throws GuacamoleException {
-        LOGGER.info("authenticateUser");
-        // Pull HTTP header from request if present
-        final HttpServletRequest request = credentials.getRequest();
-        // Get the username from the header
-        final String accessToken = request.getHeader("x-Access-Token");
-        LOGGER.info("### access token {}", accessToken);
-        if (accessToken != null) {
-            final AzureTREAuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
-            try {
-                final UrlJwkProvider jwkProvider = new UrlJwkProvider(new URL(
-                    "https://login.microsoftonline.com/" + System.getenv("TENANT_ID") + "/discovery/v2.0/keys"));
-                validateToken(credentials, accessToken, authenticatedUser, jwkProvider);
-
-                return authenticatedUser;
-            } catch (final MalformedURLException ex) {
-                LOGGER.error("Could not parse JWK Provider URL", ex);
-                throw new GuacamoleException("Could not parse JWK Provider URL");
-            }
-        }
-
-        // Authentication not provided via header, yet, so we request it.
-        throw new GuacamoleInvalidCredentialsException("Invalid login.", CredentialsInfo.USERNAME_PASSWORD);
-    }
 
     private void validateToken(final Credentials credentials, final String accessToken,
                                final AzureTREAuthenticatedUser authenticatedUser,

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/connection/ConnectionService.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/connection/ConnectionService.java
@@ -103,10 +103,11 @@ public class ConnectionService {
             System.getenv("API_URL"), System.getenv("WORKSPACE_ID"), System.getenv("SERVICE_ID"));
         final var client = HttpClient.newHttpClient();
         final var request = HttpRequest.newBuilder(URI.create(url))
-            .header("accept", "application/json")
+            .header("Accept", "application/json")
             .header("Authorization", "Bearer " + user.getAccessToken())
             .timeout(Duration.ofSeconds(5))
             .build();
+
         final HttpResponse<String> response;
         try {
             response = client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/user/AzureTREAuthenticatedUser.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/main/java/org/apache/guacamole/auth/azuretre/user/AzureTREAuthenticatedUser.java
@@ -33,14 +33,14 @@ public class AzureTREAuthenticatedUser extends AbstractAuthenticatedUser {
 
     private String objectId;
 
-    private String accessToken;
+    private String token;
 
     public void init(final Credentials credentials,
-                     final String accessToken,
+                     final String token,
                      final String username,
                      final String objectId) {
         this.credentials = credentials;
-        this.accessToken = accessToken;
+        this.token = token;
         this.objectId = objectId;
         setIdentifier(username.toLowerCase());
     }
@@ -56,7 +56,7 @@ public class AzureTREAuthenticatedUser extends AbstractAuthenticatedUser {
     }
 
     public String getAccessToken() {
-        return accessToken;
+        return token;
     }
     public String getObjectId() {
         return objectId;

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/test/java/AuthenticationProviderServiceTests.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/test/java/AuthenticationProviderServiceTests.java
@@ -243,7 +243,6 @@ public class AuthenticationProviderServiceTests {
             environmentVariables.set("AUDIENCE", audience);
             environmentVariables.set("ISSUER", issuer);
 
-            environmentVariables.set("OPENID_JWKS_ENDPOINT", "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys");
             final AuthenticationProviderService azureTREAuthenticationProviderService =
                 new AuthenticationProviderService();
             final Method validateToken =
@@ -280,7 +279,6 @@ public class AuthenticationProviderServiceTests {
             environmentVariables.set("AUDIENCE", audience);
             environmentVariables.set("ISSUER", issuer);
 
-            environmentVariables.set("OPENID_JWKS_ENDPOINT", "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys");
             final AuthenticationProviderService azureTREAuthenticationProviderService =
                 new AuthenticationProviderService();
             final Method validateToken =

--- a/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/test/java/AuthenticationProviderServiceTests.java
+++ b/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/src/test/java/AuthenticationProviderServiceTests.java
@@ -26,7 +26,6 @@ import org.apache.guacamole.auth.azuretre.user.AzureTREAuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -168,7 +167,7 @@ public class AuthenticationProviderServiceTests {
         return jwtToken;
     }
 
-    private String generateValidJWTToken()
+    private String internalGenerateValidJWTToken(String validRole)
         throws IllegalArgumentException, NoSuchAlgorithmException, InvalidKeySpecException {
 
         final Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) getPublicKey(), (RSAPrivateKey) getPrivateKey());
@@ -179,7 +178,7 @@ public class AuthenticationProviderServiceTests {
         c.add(Calendar.HOUR, 24);
         final Date expireDate = c.getTime();
 
-        final String[] validUserRoles = {"Project-User", "Another-Role"};
+        final String[] validUserRoles = {validRole, "Another-Role"};
 
         final String jwtToken = JWT.create().withIssuer(issuer).withKeyId("dummy_keyid").withAudience(audience)
             .withIssuedAt(currentDate).withExpiresAt(expireDate).withClaim("oid", "dummy_oid")
@@ -187,6 +186,18 @@ public class AuthenticationProviderServiceTests {
             .sign(algorithm);
 
         return jwtToken;
+    }
+
+    private String generateValidJWTToken()
+        throws IllegalArgumentException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        return internalGenerateValidJWTToken("WorkspaceOwner");
+    }
+
+    private String generateValidJWTTokenWithWrongRole()
+        throws IllegalArgumentException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        return internalGenerateValidJWTToken("NotTheRightRole");
     }
 
     private String generateExpiredJWTToken()
@@ -211,10 +222,10 @@ public class AuthenticationProviderServiceTests {
     }
 
     @Test
-    public void validateTokenReturnsValidAzureTREAuthenticatedUser()
+    public void validateTokenFailsWhenNoNeededRole()
         throws Exception {
 
-        final String jwtToken = generateValidJWTToken();
+        final String jwtToken = generateValidJWTTokenWithWrongRole();
         final PublicKey publicKey = getPublicKey();
         final Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) publicKey, null);
 
@@ -232,19 +243,65 @@ public class AuthenticationProviderServiceTests {
             environmentVariables.set("AUDIENCE", audience);
             environmentVariables.set("ISSUER", issuer);
 
+            environmentVariables.set("OPENID_JWKS_ENDPOINT", "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys");
             final AuthenticationProviderService azureTREAuthenticationProviderService =
                 new AuthenticationProviderService();
             final Method validateToken =
-                AuthenticationProviderService.class.getDeclaredMethod("validateToken", Credentials.class,
-                    String.class, AzureTREAuthenticatedUser.class, UrlJwkProvider.class);
+                AuthenticationProviderService.class.getDeclaredMethod("validateToken", String.class, UrlJwkProvider.class);
             validateToken.setAccessible(true);
-            validateToken.invoke(azureTREAuthenticationProviderService, credentials, jwtToken, authenticatedUser,
-                jwkProvider);
 
-            Assert.assertEquals("dummy_oid", authenticatedUser.getObjectId());
-            Assert.assertEquals("dummy_preferred_username", authenticatedUser.getIdentifier());
-
+            try {
+                validateToken.invoke(azureTREAuthenticationProviderService, jwtToken, jwkProvider);
+                fail("Exception not thrown");
+            } catch (final InvocationTargetException e) {
+                assertEquals(GuacamoleInvalidCredentialsException.class, e.getTargetException().getClass());
+            }
         }
+    }
+
+    private void validateTokenSucceedWhenValidRole(String role)
+        throws Exception {
+
+        final String jwtToken = internalGenerateValidJWTToken(role);
+        final PublicKey publicKey = getPublicKey();
+        final Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) publicKey, null);
+
+        try (MockedStatic<Algorithm> mockAlgorithm = Mockito.mockStatic(Algorithm.class)) {
+
+            mockAlgorithm.when(() -> Algorithm.RSA256((RSAPublicKey) publicKey, null)).thenReturn(algorithm);
+
+            final Jwk jwk = mock(Jwk.class);
+            final UrlJwkProvider jwkProvider = mock(UrlJwkProvider.class);
+            final Credentials credentials = mock(Credentials.class);
+            final AzureTREAuthenticatedUser authenticatedUser = new AzureTREAuthenticatedUser();
+
+            when(jwk.getPublicKey()).thenReturn(publicKey);
+            when(jwkProvider.get("dummy_keyid")).thenReturn(jwk);
+            environmentVariables.set("AUDIENCE", audience);
+            environmentVariables.set("ISSUER", issuer);
+
+            environmentVariables.set("OPENID_JWKS_ENDPOINT", "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys");
+            final AuthenticationProviderService azureTREAuthenticationProviderService =
+                new AuthenticationProviderService();
+            final Method validateToken =
+                AuthenticationProviderService.class.getDeclaredMethod("validateToken", String.class, UrlJwkProvider.class);
+            validateToken.setAccessible(true);
+            validateToken.invoke(azureTREAuthenticationProviderService, jwtToken, jwkProvider);
+        }
+    }
+
+    @Test
+    public void validateTokenSucceedWhenResearcherRole()
+        throws Exception {
+
+        validateTokenSucceedWhenValidRole("WorkspaceResearcher");
+    }
+
+    @Test
+    public void validateTokenSucceedWhenOwnerRole()
+        throws Exception {
+
+        validateTokenSucceedWhenValidRole("WorkspaceOwner");
     }
 
 
@@ -274,13 +331,11 @@ public class AuthenticationProviderServiceTests {
             final AuthenticationProviderService azureTREAuthenticationProviderService =
                 new AuthenticationProviderService();
             final Method validateToken =
-                AuthenticationProviderService.class.getDeclaredMethod("validateToken", Credentials.class,
-                    String.class, AzureTREAuthenticatedUser.class, UrlJwkProvider.class);
+                AuthenticationProviderService.class.getDeclaredMethod("validateToken", String.class, UrlJwkProvider.class);
             validateToken.setAccessible(true);
 
             try {
-                validateToken.invoke(azureTREAuthenticationProviderService, credentials, jwtToken, authenticatedUser,
-                    jwkProvider);
+                validateToken.invoke(azureTREAuthenticationProviderService, jwtToken, jwkProvider);
                 fail("Exception not thrown");
             } catch (final InvocationTargetException e) {
                 assertEquals(GuacamoleInvalidCredentialsException.class, e.getTargetException().getClass());
@@ -315,13 +370,11 @@ public class AuthenticationProviderServiceTests {
             final AuthenticationProviderService azureTREAuthenticationProviderService =
                 new AuthenticationProviderService();
             final Method validateToken =
-                AuthenticationProviderService.class.getDeclaredMethod("validateToken", Credentials.class,
-                    String.class, AzureTREAuthenticatedUser.class, UrlJwkProvider.class);
+                AuthenticationProviderService.class.getDeclaredMethod("validateToken", String.class, UrlJwkProvider.class);
             validateToken.setAccessible(true);
 
             try {
-                validateToken.invoke(azureTREAuthenticationProviderService, credentials, jwtToken, authenticatedUser,
-                    jwkProvider);
+                validateToken.invoke(azureTREAuthenticationProviderService, jwtToken, jwkProvider);
                 fail("Exception not thrown");
             } catch (final InvocationTargetException e) {
                 assertEquals(GuacamoleInvalidCredentialsException.class, e.getTargetException().getClass());
@@ -355,13 +408,11 @@ public class AuthenticationProviderServiceTests {
             final AuthenticationProviderService azureTREAuthenticationProviderService =
                 new AuthenticationProviderService();
             final Method validateToken =
-                AuthenticationProviderService.class.getDeclaredMethod("validateToken", Credentials.class,
-                    String.class, AzureTREAuthenticatedUser.class, UrlJwkProvider.class);
+                AuthenticationProviderService.class.getDeclaredMethod("validateToken", String.class, UrlJwkProvider.class);
             validateToken.setAccessible(true);
 
             try {
-                validateToken.invoke(azureTREAuthenticationProviderService, credentials, jwtToken, authenticatedUser,
-                    jwkProvider);
+                validateToken.invoke(azureTREAuthenticationProviderService, jwtToken, jwkProvider);
                 fail("Exception not thrown");
             } catch (final InvocationTargetException e) {
                 assertEquals(GuacamoleInvalidCredentialsException.class, e.getTargetException().getClass());

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -71,6 +71,22 @@ parameters:
     default: false
     env: IS_EXPOSED_EXTERNALLY
     description: "Determines if the web app will be available over public/internet or private networks"
+  - name: openid_authorization_endpoint
+    type: string
+    env: OPENID_AUTHORIZATION_ENDPOINT
+    description: "The authorization endpoint (URI) of the OpenID service"
+  - name: openid_jwks_endpoint
+    type: string
+    env: OPENID_JWKS_ENDPOINT
+    description: "The endpoint (URI) of the JWKS service which defines how received ID tokens (JSON Web Tokens or JWTs) shall be validated"
+  - name: openid_issuer
+    type: string
+    env: OPENID_ISSUER
+    description: "The issuer to expect for all received ID tokens"
+  - name: openid_client_id
+    type: string
+    env: OPENID_CLIENT_ID
+    description: "The OpenID client ID which should be submitted to the OpenID service when necessary. This value is typically provided to you by the OpenID service when OpenID credentials are generated for your application"
   # the following are added automatically by the resource processor
   - name: id
     type: string
@@ -123,6 +139,10 @@ install:
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
+        openid_authorization_endpoint: "{{ bundle.parameters.openid_authorization_endpoint }}"
+        openid_jwks_endpoint: "{{ bundle.parameters.openid_jwks_endpoint }}"
+        openid_issuer: "{{ bundle.parameters.openid_issuer }}"
+        openid_client_id: "{{ bundle.parameters.openid_client_id }}"
         tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
@@ -160,6 +180,10 @@ uninstall:
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
+        openid_authorization_endpoint: "{{ bundle.parameters.openid_authorization_endpoint }}"
+        openid_jwks_endpoint: "{{ bundle.parameters.openid_jwks_endpoint }}"
+        openid_issuer: "{{ bundle.parameters.openid_issuer }}"
+        openid_client_id: "{{ bundle.parameters.openid_client_id }}"
         tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -71,18 +71,6 @@ parameters:
     default: false
     env: IS_EXPOSED_EXTERNALLY
     description: "Determines if the web app will be available over public/internet or private networks"
-  - name: openid_authorization_endpoint
-    type: string
-    env: OPENID_AUTHORIZATION_ENDPOINT
-    description: "The authorization endpoint (URI) of the OpenID service"
-  - name: openid_jwks_endpoint
-    type: string
-    env: OPENID_JWKS_ENDPOINT
-    description: "The endpoint (URI) of the JWKS service which defines how received ID tokens (JSON Web Tokens or JWTs) shall be validated"
-  - name: openid_issuer
-    type: string
-    env: OPENID_ISSUER
-    description: "The issuer to expect for all received ID tokens"
   - name: openid_client_id
     type: string
     env: OPENID_CLIENT_ID
@@ -139,9 +127,6 @@ install:
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
-        openid_authorization_endpoint: "{{ bundle.parameters.openid_authorization_endpoint }}"
-        openid_jwks_endpoint: "{{ bundle.parameters.openid_jwks_endpoint }}"
-        openid_issuer: "{{ bundle.parameters.openid_issuer }}"
         openid_client_id: "{{ bundle.parameters.openid_client_id }}"
         tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:
@@ -180,9 +165,6 @@ uninstall:
         guac_drive_path: "{{ bundle.parameters.guac_drive_path }}"
         guac_disable_download: "{{ bundle.parameters.guac_disable_download }}"
         is_exposed_externally: "{{ bundle.parameters.is_exposed_externally }}"
-        openid_authorization_endpoint: "{{ bundle.parameters.openid_authorization_endpoint }}"
-        openid_jwks_endpoint: "{{ bundle.parameters.openid_jwks_endpoint }}"
-        openid_issuer: "{{ bundle.parameters.openid_issuer }}"
         openid_client_id: "{{ bundle.parameters.openid_client_id }}"
         tre_resource_id: "{{ bundle.parameters.id }}"
       backendConfig:

--- a/templates/workspace_services/guacamole/template_schema.json
+++ b/templates/workspace_services/guacamole/template_schema.json
@@ -36,24 +36,6 @@
       "title": "Expose externally",
       "description": "Is the Guacamole service exposed outside of the vnet"
     },
-    "openid_authorization_endpoint": {
-      "$id": "#/properties/openid_authorization_endpoint",
-      "type": "string",
-      "title": "OpenID authorization endpoint",
-      "description": "The authorization endpoint (URI) of the OpenID service."
-    },
-    "openid_jwks_endpoint": {
-      "$id": "#/properties/openid_jwks_endpoint",
-      "type": "string",
-      "title": "OpenID JWKS endpoint",
-      "description": "The endpoint (URI) of the JWKS service which defines how received ID tokens (JSON Web Tokens or JWTs) shall be validated"
-    },
-    "openid_issuer": {
-      "$id": "#/properties/openid_issuer",
-      "type": "string",
-      "title": "OpenID issuer",
-      "description": "The issuer to expect for all received ID tokens"
-    },
     "openid_client_id": {
       "$id": "#/properties/openid_client_id",
       "type": "string",

--- a/templates/workspace_services/guacamole/template_schema.json
+++ b/templates/workspace_services/guacamole/template_schema.json
@@ -35,6 +35,30 @@
       "type": "boolean",
       "title": "Expose externally",
       "description": "Is the Guacamole service exposed outside of the vnet"
+    },
+    "openid_authorization_endpoint": {
+      "$id": "#/properties/openid_authorization_endpoint",
+      "type": "string",
+      "title": "OpenID authorization endpoint",
+      "description": "The authorization endpoint (URI) of the OpenID service."
+    },
+    "openid_jwks_endpoint": {
+      "$id": "#/properties/openid_jwks_endpoint",
+      "type": "string",
+      "title": "OpenID JWKS endpoint",
+      "description": "The endpoint (URI) of the JWKS service which defines how received ID tokens (JSON Web Tokens or JWTs) shall be validated"
+    },
+    "openid_issuer": {
+      "$id": "#/properties/openid_issuer",
+      "type": "string",
+      "title": "OpenID issuer",
+      "description": "The issuer to expect for all received ID tokens"
+    },
+    "openid_client_id": {
+      "$id": "#/properties/openid_client_id",
+      "type": "string",
+      "title": "OpenID client id",
+      "description": "The OpenID client ID which should be submitted to the OpenID service when necessary. This value is typically provided to you by the OpenID service when OpenID credentials are generated for your application."
     }
   }
 }

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -16,3 +16,7 @@ variable "guac_drive_path" {}
 variable "guac_disable_download" {}
 variable "is_exposed_externally" {}
 variable "tre_resource_id" {}
+variable "openid_authorization_endpoint" {}
+variable "openid_jwks_endpoint" {}
+variable "openid_issuer" {}
+variable "openid_client_id" {}

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -16,7 +16,4 @@ variable "guac_drive_path" {}
 variable "guac_disable_download" {}
 variable "is_exposed_externally" {}
 variable "tre_resource_id" {}
-variable "openid_authorization_endpoint" {}
-variable "openid_jwks_endpoint" {}
-variable "openid_issuer" {}
 variable "openid_client_id" {}

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -43,8 +43,16 @@ resource "azurerm_app_service" "guacamole" {
     GUAC_DRIVE_NAME       = "${var.guac_drive_name}"
     GUAC_DRIVE_PATH       = "${var.guac_drive_path}"
     GUAC_DISABLE_DOWNLOAD = "${var.guac_disable_download}"
-    AUDIENCE              = data.azurerm_app_service.api_core.app_settings["API_CLIENT_ID"]
+    AUDIENCE              = "${var.openid_client_id}"
     ISSUER                = local.issuer
+
+    OPENID_AUTHORIZATION_ENDPOINT = "${var.openid_authorization_endpoint}"
+    OPENID_JWKS_ENDPOINT          = "${var.openid_jwks_endpoint}"
+    OPENID_ISSUER                 = "${var.openid_issuer}"
+    OPENID_CLIENT_ID              = "${var.openid_client_id}"
+    OPENID_REDIRECT_URI           = "https://${local.webapp_name}.azurewebsites.net/guacamole/"
+    OPENID_USERNAME_CLAIM_TYPE    = "email"
+
     # Solving the pulling from acr problem
     DOCKER_REGISTRY_SERVER_URL      = "${data.azurerm_container_registry.mgmt_acr.login_server}"
     DOCKER_REGISTRY_SERVER_USERNAME = "${data.azurerm_container_registry.mgmt_acr.admin_username}"

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -46,9 +46,9 @@ resource "azurerm_app_service" "guacamole" {
     AUDIENCE              = "${var.openid_client_id}"
     ISSUER                = local.issuer
 
-    OPENID_AUTHORIZATION_ENDPOINT = "${var.openid_authorization_endpoint}"
-    OPENID_JWKS_ENDPOINT          = "${var.openid_jwks_endpoint}"
-    OPENID_ISSUER                 = "${var.openid_issuer}"
+    OPENID_AUTHORIZATION_ENDPOINT = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/oauth2/v2.0/authorize"
+    OPENID_JWKS_ENDPOINT          = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/discovery/v2.0/keys"
+    OPENID_ISSUER                 = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
     OPENID_CLIENT_ID              = "${var.openid_client_id}"
     OPENID_REDIRECT_URI           = "https://${local.webapp_name}.azurewebsites.net/guacamole/"
     OPENID_USERNAME_CLAIM_TYPE    = "email"

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -46,9 +46,9 @@ resource "azurerm_app_service" "guacamole" {
     AUDIENCE              = "${var.openid_client_id}"
     ISSUER                = local.issuer
 
-    OPENID_AUTHORIZATION_ENDPOINT = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/oauth2/v2.0/authorize"
-    OPENID_JWKS_ENDPOINT          = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/discovery/v2.0/keys"
-    OPENID_ISSUER                 = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
+    OPENID_AUTHORIZATION_ENDPOINT = "https://login.microsoftonline.com/${local.aad_tenant_id}/oauth2/v2.0/authorize"
+    OPENID_JWKS_ENDPOINT          = "https://login.microsoftonline.com/${local.aad_tenant_id}/discovery/v2.0/keys"
+    OPENID_ISSUER                 = "https://login.microsoftonline.com/${local.aad_tenant_id}/v2.0"
     OPENID_CLIENT_ID              = "${var.openid_client_id}"
     OPENID_REDIRECT_URI           = "https://${local.webapp_name}.azurewebsites.net/guacamole/"
     OPENID_USERNAME_CLAIM_TYPE    = "email"


### PR DESCRIPTION
#835 

## What is being addressed

Guacamole currently accepts a header containing a token. This token is passed as-is to the api app to get the list of VMs.
This PR suggests to use the OpenID extension which is configured to get a token from the Azure AD provider (can be extended to other providers), and the validation part is done by this new extension.
This PR builds on top another feature, which is using the correct app registration in the api app.


## How is this addressed

- Installed the OpenID extension
- Removed the authorization part from TREs custom extension and instead got the token from the oid extension

## Notes
a new param was added to the porter schema : 'openid_client_id' which must be passed for Guacamole to operate correctly.