### PR TITLE
Uninstall Innereye workspace

### DIFF
--- a/templates/workspaces/innereye/porter.yaml
+++ b/templates/workspaces/innereye/porter.yaml
@@ -35,7 +35,7 @@ parameters:
   - name: inference_sp_client_id
     type: string
   - name: inference_sp_client_secret
-    type: string 
+    type: string
   - name: tfstate_resource_group_name
     type: string
     description: "Resource group containing the Terraform state storage account"
@@ -87,9 +87,17 @@ upgrade:
       arguments:
         - "This workspace does not implement upgrade action"
 
-uninstall:  
-- exec:
-      description: "Uninstall workspace"
-      command: echo
+uninstall:
+  - az:
+      description: "az login"
       arguments:
-        - "This workspace does not implement uninstall action"
+        - login
+      flags:
+        identity:
+        username: "{{ bundle.credentials.azure_client_id}}"
+  - exec:
+      description: "Delete resource group and vnet peering"
+      command: ./uninstall_workspace.sh
+      arguments:
+        - "{{ bundle.parameters.tre_id }}"
+        - "{{ bundle.parameters.id }}"

--- a/templates/workspaces/innereye/uninstall_workspace.sh
+++ b/templates/workspaces/innereye/uninstall_workspace.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+TRE_ID=$1
+ID=$2
+SHORT_ID=${ID: -4}
+
+az group delete \
+  --name "rg-${TRE_ID}-ws-${SHORT_ID}" --yes
+
+az network vnet peering delete \
+  --resource-group "rg-${TRE_ID}" \
+  --name "core-ws-peer-${TRE_ID}-ws-${SHORT_ID}" \
+  --vnet-name "vnet-${TRE_ID}"


### PR DESCRIPTION
# PR for issue #876 

Closing #876 

## What is being addressed

Implementing a method to delete the InnerEye workspace.

## How is this addressed

Since InnerEye is installed using porter inside porter the normal uninstall method is not available. This method deletes the workspace resource group and VNet peering.
