### PR TITLE
Allow ability to pass in docker group ID

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,10 +4,12 @@
 ARG VARIANT="3"
 FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-buster
 
+ARG USERNAME=vscode
+
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su $USERNAME -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # Install terraform
 ARG TERRAFORM_VERSION
@@ -19,8 +21,9 @@ RUN apt-get update && apt-get install -y gnupg software-properties-common curl \
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
-# Make sure docker group id matches that on WSL.
-RUN groupadd --gid 1001 docker
+ARG DOCKER_GROUP_ID
+COPY .devcontainer/scripts/docker-client.sh /tmp/
+RUN /tmp/docker-client.sh $USERNAME
 
 # Install Docker
 RUN apt-get update && sudo apt-get install -y  apt-transport-https ca-certificates curl gnupg  lsb-release \
@@ -39,12 +42,12 @@ RUN apt-get install -y python3 python3-venv libaugeas0 \
     && /opt/certbot/bin/pip install certbot
 
 # Install Porter
-RUN export PORTER_HOME=/home/vscode/.porter \
+RUN export PORTER_HOME=/home/$USERNAME/.porter \
     && curl -L https://cdn.porter.sh/latest/install-linux.sh | bash \
     && ${PORTER_HOME}/porter mixin install docker \
-    && chown -R vscode ${PORTER_HOME}
+    && chown -R $USERNAME ${PORTER_HOME}
 
-ENV PATH /home/vscode/.porter/:$PATH
+ENV PATH /home/$USERNAME/.porter/:$PATH
 
 # Install PowerShell and Az module
 RUN apt-get update && apt-get install -y wget apt-transport-https software-properties-common && \
@@ -60,6 +63,4 @@ COPY ["resource_processor/vmss_porter/requirements.txt", "/tmp/pip-tmp/resource_
 COPY ["docs/requirements.txt", "/tmp/pip-tmp/docs/"]
 RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp
 
-RUN usermod -a -G docker vscode
-
-USER vscode
+USER $USERNAME

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,11 @@ services:
         INSTALL_NODE: "false"
         NODE_VERSION: "lts/*"
         TERRAFORM_VERSION: "1.0.5"
+        # We need to sync the docker group id within WSL and the container. This will
+        # default to 1001. If yours is set to something different,
+        # add the following line to your .bash_profile on the host
+        # export DOCKER_GROUP_ID=$(getent group docker | awk -F ":" '{ print $3 }')
+        DOCKER_GROUP_ID: ${DOCKER_GROUP_ID:-1001}
     extra_hosts:
     - "host.docker.internal:host-gateway"
     volumes:

--- a/.devcontainer/scripts/docker-client.sh
+++ b/.devcontainer/scripts/docker-client.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [ -z "$DOCKER_GROUP_ID" ]; then
+    groupadd g docker
+else
+    groupadd -g $DOCKER_GROUP_ID docker
+fi
+
+usermod -aG docker $1 && newgrp docker
+getent group docker


### PR DESCRIPTION
This PR is for issue #1102 

## What is being addressed
Currently the docker group is hardcoded to 1001. This change will allow users to set a variable in their bash profile if their group id is not 1001. If they do not set this variable, then it will fall back and default to 1001 which is the current behaviour.

Without this fix, users with a different group id will not have the permission to run docker commands (without sudo)