### PR TITLE
Remove the prompt from bash example. Fixes #1104

### DIFF
--- a/docs/tre-admins/setup-instructions/deploying-azure-tre.md
+++ b/docs/tre-admins/setup-instructions/deploying-azure-tre.md
@@ -3,7 +3,7 @@
 You are now ready to deploy the Azure TRE instance. Execute the `all` action of the makefile using `make`:
 
 ```bash
-/workspaces/tre> make all
+make all
 ```
 
 Deploying a new Azure TRE instance takes approximately 30 minutes.
@@ -22,7 +22,7 @@ static_web_storage = "stwebmytre"
 The Azure TRE instance is initially deployed with an invalid self-signed SSL certificate. This certificate needs to be replaced with one valid for your configured domain name. To use a certificate from [Let's Encrypt](https://letsencrypt.org/), run the command:
 
 ```bash
-/workspaces/tre> make letsencrypt
+make letsencrypt
 ```
 
 !!! caution
@@ -35,7 +35,7 @@ The Azure TRE instance is initially deployed with an invalid self-signed SSL cer
 Use `curl` to make a simple request to the status endpoint of the API:
 
 ```bash
-/workspaces/tre> curl https://<azure_tre_fqdn>/api/status
+curl https://<azure_tre_fqdn>/api/status
 ```
 
 The expected response is:

--- a/docs/tre-admins/setup-instructions/installing-base-workspace.md
+++ b/docs/tre-admins/setup-instructions/installing-base-workspace.md
@@ -5,7 +5,7 @@
 1. Run:
 
     ```cmd
-    /workspaces/tre> make register-bundle DIR=./templates/workspaces/base BUNDLE_TYPE=workspace
+    make register-bundle DIR=./templates/workspaces/base BUNDLE_TYPE=workspace
     ```
 
     Copy the resulting JSON payload.

--- a/docs/tre-admins/setup-instructions/installing-workspace-service-and-user-resource.md
+++ b/docs/tre-admins/setup-instructions/installing-workspace-service-and-user-resource.md
@@ -7,7 +7,7 @@ We will use the [Guacamole workspace service bundle](./tre-templates/workspace-s
 1. Run:
 
     ```cmd
-    /workspaces/tre> make register-bundle DIR=./templates/workspace_services/guacamole BUNDLE_TYPE=workspace_service
+    make register-bundle DIR=./templates/workspace_services/guacamole BUNDLE_TYPE=workspace_service
     ```
 
     Copy the resulting JSON payload.
@@ -29,7 +29,7 @@ The Guacamole workspace service also has user resources, there are the VMs that 
 1. Run:
 
     ```cmd
-    /workspaces/tre> make register-bundle DIR=./templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm BUNDLE_TYPE=user_resource
+    make register-bundle DIR=./templates/workspace_services/guacamole/user_resources/guacamole-azure-win10vm BUNDLE_TYPE=user_resource
     ```
 
     Copy the resulting JSON payload.

--- a/docs/tre-admins/setup-instructions/pre-deployment-steps.md
+++ b/docs/tre-admins/setup-instructions/pre-deployment-steps.md
@@ -48,7 +48,7 @@ Next, you will set the configuration variables for the specific Azure TRE instan
 1. Use the terminal window in Visual Studio Code to execute the following script from within the development container:
 
    ```bash
-   /workspaces/tre> az login
+   az login
    ```
 
   !!! note
@@ -59,7 +59,7 @@ Next, you will set the configuration variables for the specific Azure TRE instan
 1. Run the `/scripts/aad-app-reg.sh` script to create API and Swagger UI app registrations and their service principals. The details of the script are covered [app registration script](../auth.md#app-registration-script) section of the auth document. Below is a sample where `TRE_ID` has value `mytre` and the Azure location is `westeurope`:
 
   ```bash
-  /workspaces/tre> ./scripts/aad-app-reg.sh -n TRE -r https://mytre.westeurope.cloudapp.azure.com/api/docs/oauth2-redirect -a
+  ./scripts/aad-app-reg.sh -n TRE -r https://mytre.westeurope.cloudapp.azure.com/api/docs/oauth2-redirect -a
   ```
 
   !!! note

--- a/docs/tre-admins/setup-instructions/tear-down.md
+++ b/docs/tre-admins/setup-instructions/tear-down.md
@@ -3,7 +3,7 @@
 To remove the Azure TRE and its resources from your Azure subscription run:
 
 ```cmd
-/workspaces/tre> make tre-destroy
+make tre-destroy
 ```
 
 Alternatively, you can delete the resource groups in Azure Portal or using the CLI:


### PR DESCRIPTION
# PR for issue #1104 

This makes the copied script examples within the doc executable, and prevents someone accidentally deleting files by redirecting output. 