### PR TITLE
Converted dockerfile to arch agnostic

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
 ARG VARIANT="3"
-FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-buster
+FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -11,10 +11,9 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 
 # Install terraform
 ARG TERRAFORM_VERSION
-RUN apt-get update && apt-get install -y gnupg software-properties-common curl \
-    && curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
-    && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
-    && apt-get update && apt-get install -y terraform "${TERRAFORM_VERSION}"
+RUN apt-get update -y && apt-get install -y unzip wget \
+    && wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_$(dpkg --print-architecture).zip" -O /tmp/terraform.zip \
+    && unzip /tmp/terraform.zip -d /usr/local/bin/
 
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
@@ -25,7 +24,7 @@ RUN groupadd --gid 1001 docker
 # Install Docker
 RUN apt-get update && sudo apt-get install -y  apt-transport-https ca-certificates curl gnupg  lsb-release \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
 
@@ -47,18 +46,24 @@ RUN export PORTER_HOME=/home/vscode/.porter \
 ENV PATH /home/vscode/.porter/:$PATH
 
 # Install PowerShell and Az module
-RUN apt-get update && apt-get install -y wget apt-transport-https software-properties-common && \
-    wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    apt-get update && apt-get install -y powershell && \
-    pwsh -c Install-Module Az -Force
+ARG POWERSHELL_VERSION="7.2.1"
+RUN apt-get update -y && apt-get install -y unzip wget \
+    && ARCH=$(dpkg --print-architecture) \
+    && if [[ $ARCH == "amd64" ]]; then $ARCH="x64"; fi \
+    && wget "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${ARCH}.tar.gz" -O /tmp/powershell.tar.gz \
+    && mkdir -p /opt/microsoft/powershell/7 \
+    && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh \
+    && pwsh -c Install-Module Az -Force
 
 # Install requirements
 COPY ["requirements.txt", "/tmp/pip-tmp/" ]
 COPY ["api_app/requirements.txt", "api_app/requirements-dev.txt", "/tmp/pip-tmp/api_app/" ]
 COPY ["resource_processor/vmss_porter/requirements.txt", "/tmp/pip-tmp/resource_processor/vmss_porter/" ]
 COPY ["docs/requirements.txt", "/tmp/pip-tmp/docs/"]
-RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp
+RUN apt-get update -y && apt-get install -y cmake \
+    && pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp
 
 RUN usermod -a -G docker vscode
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,11 @@ RUN apt-get update -y && apt-get install -y unzip wget \
     && unzip /tmp/terraform.zip -d /usr/local/bin/
 
 # Install Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+RUN apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null \
+    && echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
+    | sudo tee /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update && sudo apt-get install -y azure-cli=2.18.0-2
 
 # Make sure docker group id matches that on WSL.
 RUN groupadd --gid 1001 docker

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,13 +15,6 @@ RUN apt-get update -y && apt-get install -y unzip wget \
     && wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_$(dpkg --print-architecture).zip" -O /tmp/terraform.zip \
     && unzip /tmp/terraform.zip -d /usr/local/bin/
 
-# Install Azure CLI
-RUN apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null \
-    && echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
-    | sudo tee /etc/apt/sources.list.d/azure-cli.list \
-    && apt-get update && sudo apt-get install -y azure-cli=2.18.0-2
-
 # Make sure docker group id matches that on WSL.
 RUN groupadd --gid 1001 docker
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,7 +49,7 @@ ENV PATH /home/vscode/.porter/:$PATH
 ARG POWERSHELL_VERSION="7.2.1"
 RUN apt-get update -y && apt-get install -y unzip wget \
     && ARCH=$(dpkg --print-architecture) \
-    && if [[ $ARCH == "amd64" ]]; then $ARCH="x64"; fi \
+    && if [ $ARCH = "amd64" ]; then ARCH="x64"; fi \
     && wget "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${ARCH}.tar.gz" -O /tmp/powershell.tar.gz \
     && mkdir -p /opt/microsoft/powershell/7 \
     && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,9 +47,9 @@
 		"github.vscode-pull-request-github",
 		"ms-kubernetes-tools.porter-vscode",
 		"davidanson.vscode-markdownlint",
-    "editorconfig.editorconfig",
+    	"editorconfig.editorconfig",
 		"github.vscode-pull-request-github",
-    "mikestead.dotenv"
+    	"mikestead.dotenv"
 	],
 	"forwardPorts": [8000]
 }

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-api-image:
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
 	&& source <(grep = ./api_app/_version.py | sed 's/ *= */=/g') \
-	&& docker build -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/api:$${__version__}" ./api_app/
+	&& docker build --platform linux/amd64 -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/api:$${__version__}" ./api_app/
 
 build-resource-processor-vm-porter-image:
 	echo -e "\n\e[34m»»» 🧩 \e[96mBuilding Resource Processor Image\e[0m..." \
@@ -40,7 +40,7 @@ build-resource-processor-vm-porter-image:
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
 	&& source <(grep = ./resource_processor/version.txt | sed 's/ *= */=/g') \
-	&& docker build -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/resource-processor-vm-porter:$${__version__}" -f ./resource_processor/vmss_porter/Dockerfile ./resource_processor/
+	&& docker build --platform linux/amd64 -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/resource-processor-vm-porter:$${__version__}" -f ./resource_processor/vmss_porter/Dockerfile ./resource_processor/
 
 build-gitea-image:
 	echo -e "\n\e[34m»»» 🧩 \e[96mBuilding Gitea Image\e[0m..." \
@@ -48,7 +48,7 @@ build-gitea-image:
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
 	&& source <(grep = ./templates/shared_services/gitea/version.txt | sed 's/ *= */=/g') \
-	&& docker build -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/gitea:$${__version__}" -f ./templates/shared_services/gitea/Dockerfile .
+	&& docker build --platform linux/amd64 -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/gitea:$${__version__}" -f ./templates/shared_services/gitea/Dockerfile .
 
 build-guacamole-image:
 	echo -e "\n\e[34m»»» 🧩 \e[96mBuilding Guacamole Image\e[0m..." \
@@ -57,7 +57,7 @@ build-guacamole-image:
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
 	&& source <(grep = ./templates/workspace_services/guacamole/version.txt | sed 's/ *= */=/g') \
 	&& cd ./templates/workspace_services/guacamole/guacamole-server/ \
-	&& docker build -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/guac-server:$${__version__}" -f ./docker/Dockerfile .
+	&& docker build --platform linux/amd64 -t "$${ACR_NAME}.azurecr.io/microsoft/azuretre/guac-server:$${__version__}" -f ./docker/Dockerfile .
 
 push-resource-processor-vm-porter-image:
 	echo -e "\n\e[34m»»» 🧩 \e[96mPushing Resource Processor Image\e[0m..." \

--- a/api_app/Dockerfile
+++ b/api_app/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.8-slim-buster as base
+FROM python:3.8-slim-bullseye as base
 COPY requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN apt-get update && apt-get install -y cmake libssl-dev build-essential \
+    && pip3 install -r requirements.txt
 
 FROM base as test
 COPY requirements-dev.txt .

--- a/api_app/Dockerfile
+++ b/api_app/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.8-slim-bullseye as base
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y cmake libssl-dev build-essential \
-    && pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 FROM base as test
 COPY requirements-dev.txt .

--- a/devops/terraform/.terraform.lock.hcl
+++ b/devops/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.86.0"
   constraints = "2.86.0"
   hashes = [
+    "h1:4kfqQUjKx0xrjwZKgVprzpvgldkNkj73hPc9WCoMDMc=",
     "h1:a6RoAhhRW4fUN1hvZOS6TPARzyPwBoa4vXQZE8uNsUw=",
     "zh:1568f5eb15da2e4fc31c0c63c56471825f875a5fe3ee2f12be3221e91089f268",
     "zh:227cd0562f950319dc13d2bf57d921f7fada2fe864bff98572db21ed1c1cfc6e",


### PR DESCRIPTION
# PR for issue

## What is being addressed

Currently the dev container will only run on x86/x64 architectures and will not work on arm32 or arm64 architectures (like the newer Mac M1 chipsets). This PR makes the dev container Dockerfile architecture agnostic so it can run on both.

## How is this addressed

- Changed the container base image from the older buster variant to the latest default (bullseye) which works cross-platform
- Converted Terraform and Powershell installs from apt repositories to zip/gz packages as their apt repositories don't currenctly have any arm images available
- Fixed some arm dependency issues with python wheel installs
- Installed az cli manually and pinned version 2.18.0 as this is the only version currently available supporting both Debian amd & arm64
