### PR TITLE
Output list of subnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ bootstrap:
 	&& . ./devops/scripts/load_terraform_env.sh ./devops/.env \
 	&& cd ./devops/terraform && ./bootstrap.sh
 
+format:
+	echo -e "\n\e[34m»»» 🧩 \e[96mLinting Terraform\e[0m..." \
+	&& cd ./templates && terraform fmt -check -recursive -diff
+
 mgmt-deploy:
 	echo -e "\n\e[34m»»» 🧩 \e[96mDeploying management infrastructure\e[0m..." \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \

--- a/templates/core/terraform/admin-jumpbox/variables.tf
+++ b/templates/core/terraform/admin-jumpbox/variables.tf
@@ -1,5 +1,5 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
-variable "shared_subnet" {}
+variable "subnet_id" {}
 variable "keyvault_id" {}

--- a/templates/core/terraform/admin-jumpbox/vm.tf
+++ b/templates/core/terraform/admin-jumpbox/vm.tf
@@ -7,7 +7,7 @@ resource "azurerm_network_interface" "jumpbox_nic" {
 
   ip_configuration {
     name                          = "internalIPConfig"
-    subnet_id                     = var.shared_subnet
+    subnet_id                     = var.subnet_id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/templates/core/terraform/api-webapp/api-webapp.tf
+++ b/templates/core/terraform/api-webapp/api-webapp.tf
@@ -101,7 +101,7 @@ resource "azurerm_private_endpoint" "api_private_endpoint" {
   name                = "pe-api-${var.tre_id}"
   resource_group_name = var.resource_group_name
   location            = var.location
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.subnet_ids["shared"]
 
   lifecycle { ignore_changes = [tags] }
 
@@ -120,7 +120,7 @@ resource "azurerm_private_endpoint" "api_private_endpoint" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "api-integrated-vnet" {
   app_service_id = azurerm_app_service.api.id
-  subnet_id      = var.web_app_subnet
+  subnet_id      = var.subnet_ids["web_app"]
 }
 
 resource "azurerm_monitor_diagnostic_setting" "webapp_api" {

--- a/templates/core/terraform/api-webapp/variables.tf
+++ b/templates/core/terraform/api-webapp/variables.tf
@@ -1,10 +1,8 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
-variable "web_app_subnet" {}
 variable "core_vnet" {}
-variable "shared_subnet" {}
-variable "app_gw_subnet" {}
+variable "subnet_ids" {}
 variable "app_insights_connection_string" {}
 variable "app_insights_instrumentation_key" {}
 variable "log_analytics_workspace_id" {}

--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -37,7 +37,7 @@ resource "azurerm_application_gateway" "agw" {
   # Internal subnet for gateway backend.
   gateway_ip_configuration {
     name      = "gateway-ip-configuration"
-    subnet_id = var.app_gw_subnet
+    subnet_id = var.subnet_ids["app_gw"]
   }
 
   # HTTP Port

--- a/templates/core/terraform/appgateway/staticweb.tf
+++ b/templates/core/terraform/appgateway/staticweb.tf
@@ -38,7 +38,7 @@ resource "azurerm_private_endpoint" "webpe" {
   name                = "pe-web-${local.staticweb_storage_name}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.subnet_ids["shared"]
 
   lifecycle { ignore_changes = [tags] }
 

--- a/templates/core/terraform/appgateway/variables.tf
+++ b/templates/core/terraform/appgateway/variables.tf
@@ -2,8 +2,7 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
-variable "app_gw_subnet" {}
-variable "shared_subnet" {}
+variable "subnet_ids" {}
 variable "api_fqdn" {}
 variable "keyvault_id" {}
 variable "static_web_dns_zone_id" {}

--- a/templates/core/terraform/azure-monitor/azure-monitor.tf
+++ b/templates/core/terraform/azure-monitor/azure-monitor.tf
@@ -87,7 +87,7 @@ resource "azurerm_private_endpoint" "azure_monitor_private_endpoint" {
   name                = "pe-ampls-${var.tre_id}"
   resource_group_name = var.resource_group_name
   location            = var.location
-  subnet_id           = var.shared_subnet_id
+  subnet_id           = var.subnet_id
 
   lifecycle { ignore_changes = [tags] }
 

--- a/templates/core/terraform/azure-monitor/variables.tf
+++ b/templates/core/terraform/azure-monitor/variables.tf
@@ -1,7 +1,7 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
-variable "shared_subnet_id" {}
+variable "subnet_id" {}
 variable "azure_monitor_dns_zone_id" {}
 variable "azure_monitor_oms_opinsights_dns_zone_id" {}
 variable "azure_monitor_ods_opinsights_dns_zone_id" {}

--- a/templates/core/terraform/bastion/bastion.tf
+++ b/templates/core/terraform/bastion/bastion.tf
@@ -15,7 +15,7 @@ resource "azurerm_bastion_host" "bastion" {
 
   ip_configuration {
     name                 = "configuration"
-    subnet_id            = var.bastion_subnet
+    subnet_id            = var.subnet_id
     public_ip_address_id = azurerm_public_ip.bastion.id
   }
 

--- a/templates/core/terraform/bastion/variables.tf
+++ b/templates/core/terraform/bastion/variables.tf
@@ -1,4 +1,4 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
-variable "bastion_subnet" {}
+variable "subnet_id" {}

--- a/templates/core/terraform/keyvault/keyvault.tf
+++ b/templates/core/terraform/keyvault/keyvault.tf
@@ -41,7 +41,7 @@ resource "azurerm_private_endpoint" "kvpe" {
   name                = "pe-kv-${var.tre_id}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.subnet_id
 
   lifecycle { ignore_changes = [tags] }
 

--- a/templates/core/terraform/keyvault/variables.tf
+++ b/templates/core/terraform/keyvault/variables.tf
@@ -2,7 +2,7 @@ variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
 variable "core_vnet" {}
-variable "shared_subnet" {}
+variable "subnet_id" {}
 variable "tenant_id" {}
 variable "managed_identity_tenant_id" {}
 variable "managed_identity_object_id" {}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -36,7 +36,7 @@ module "azure_monitor" {
   tre_id                                   = var.tre_id
   location                                 = var.location
   resource_group_name                      = azurerm_resource_group.core.name
-  shared_subnet_id                         = module.network.shared_subnet_id
+  subnet_id                                = module.network.subnet_ids["shared"]
   azure_monitor_dns_zone_id                = module.network.azure_monitor_dns_zone_id
   azure_monitor_oms_opinsights_dns_zone_id = module.network.azure_monitor_oms_opinsights_dns_zone_id
   azure_monitor_ods_opinsights_dns_zone_id = module.network.azure_monitor_ods_opinsights_dns_zone_id
@@ -57,7 +57,7 @@ module "storage" {
   tre_id              = var.tre_id
   location            = var.location
   resource_group_name = azurerm_resource_group.core.name
-  shared_subnet       = module.network.shared_subnet_id
+  subnet_id           = module.network.subnet_ids["shared"]
   core_vnet           = module.network.core_vnet_id
 
   depends_on = [
@@ -70,8 +70,7 @@ module "appgateway" {
   tre_id                 = var.tre_id
   location               = var.location
   resource_group_name    = azurerm_resource_group.core.name
-  app_gw_subnet          = module.network.app_gw_subnet_id
-  shared_subnet          = module.network.shared_subnet_id
+  subnet_ids             = module.network.subnet_ids
   api_fqdn               = module.api-webapp.api_fqdn
   keyvault_id            = module.keyvault.keyvault_id
   static_web_dns_zone_id = module.network.static_web_dns_zone_id
@@ -93,10 +92,8 @@ module "api-webapp" {
   tre_id                                     = var.tre_id
   location                                   = var.location
   resource_group_name                        = azurerm_resource_group.core.name
-  web_app_subnet                             = module.network.web_app_subnet_id
-  shared_subnet                              = module.network.shared_subnet_id
-  app_gw_subnet                              = module.network.app_gw_subnet_id
   core_vnet                                  = module.network.core_vnet_id
+  subnet_ids                                 = module.network.subnet_ids
   app_insights_connection_string             = module.azure_monitor.app_insights_connection_string
   app_insights_instrumentation_key           = module.azure_monitor.app_insights_instrumentation_key
   log_analytics_workspace_id                 = module.azure_monitor.log_analytics_workspace_id
@@ -132,7 +129,7 @@ module "resource_processor_vmss_porter" {
   resource_group_name                             = azurerm_resource_group.core.name
   acr_id                                          = data.azurerm_container_registry.mgmt_acr.id
   app_insights_connection_string                  = module.azure_monitor.app_insights_connection_string
-  resource_processor_subnet_id                    = module.network.resource_processor_subnet_id
+  subnet_id                                       = module.network.subnet_ids["resource_processor"]
   docker_registry_server                          = var.docker_registry_server
   resource_processor_vmss_porter_image_repository = var.resource_processor_vmss_porter_image_repository
   service_bus_namespace_id                        = module.servicebus.id
@@ -151,12 +148,12 @@ module "resource_processor_vmss_porter" {
 }
 
 module "servicebus" {
-  source                       = "./servicebus"
-  tre_id                       = var.tre_id
-  location                     = var.location
-  resource_group_name          = azurerm_resource_group.core.name
-  core_vnet                    = module.network.core_vnet_id
-  resource_processor_subnet_id = module.network.resource_processor_subnet_id
+  source              = "./servicebus"
+  tre_id              = var.tre_id
+  location            = var.location
+  resource_group_name = azurerm_resource_group.core.name
+  core_vnet           = module.network.core_vnet_id
+  subnet_id           = module.network.subnet_ids["resource_processor"]
 }
 
 module "keyvault" {
@@ -164,8 +161,8 @@ module "keyvault" {
   tre_id                     = var.tre_id
   location                   = var.location
   resource_group_name        = azurerm_resource_group.core.name
-  shared_subnet              = module.network.shared_subnet_id
   core_vnet                  = module.network.core_vnet_id
+  subnet_id                  = module.network.subnet_ids["shared"]
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   managed_identity_tenant_id = module.identity.managed_identity.tenant_id
   managed_identity_object_id = module.identity.managed_identity.principal_id
@@ -195,10 +192,7 @@ module "routetable" {
   tre_id                       = var.tre_id
   location                     = var.location
   resource_group_name          = azurerm_resource_group.core.name
-  shared_subnet_id             = module.network.shared_subnet_id
-  resource_processor_subnet_id = module.network.resource_processor_subnet_id
-  web_app_subnet_id            = module.network.web_app_subnet_id
-  app_gw_subnet_id             = module.network.app_gw_subnet_id
+  subnet_ids                   = module.network.subnet_ids
   firewall_private_ip_address  = module.firewall.firewall_private_ip_address
 }
 
@@ -207,7 +201,7 @@ module "state-store" {
   tre_id              = var.tre_id
   location            = var.location
   resource_group_name = azurerm_resource_group.core.name
-  shared_subnet       = module.network.shared_subnet_id
+  subnet_id           = module.network.subnet_ids["shared"]
   core_vnet           = module.network.core_vnet_id
 }
 
@@ -216,7 +210,7 @@ module "bastion" {
   tre_id              = var.tre_id
   location            = var.location
   resource_group_name = azurerm_resource_group.core.name
-  bastion_subnet      = module.network.bastion_subnet_id
+  subnet_id           = module.network.subnet_ids["bastion"]
 }
 
 module "jumpbox" {
@@ -224,7 +218,7 @@ module "jumpbox" {
   tre_id              = var.tre_id
   location            = var.location
   resource_group_name = azurerm_resource_group.core.name
-  shared_subnet       = module.network.shared_subnet_id
+  subnet_id           = module.network.subnet_ids["shared"]
   keyvault_id         = module.keyvault.keyvault_id
   depends_on = [
     module.keyvault

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -188,12 +188,12 @@ module "firewall" {
 }
 
 module "routetable" {
-  source                       = "./routetable"
-  tre_id                       = var.tre_id
-  location                     = var.location
-  resource_group_name          = azurerm_resource_group.core.name
-  subnet_ids                   = module.network.subnet_ids
-  firewall_private_ip_address  = module.firewall.firewall_private_ip_address
+  source                      = "./routetable"
+  tre_id                      = var.tre_id
+  location                    = var.location
+  resource_group_name         = azurerm_resource_group.core.name
+  subnet_ids                  = module.network.subnet_ids
+  firewall_private_ip_address = module.firewall.firewall_private_ip_address
 }
 
 module "state-store" {

--- a/templates/core/terraform/network/output.tf
+++ b/templates/core/terraform/network/output.tf
@@ -2,28 +2,15 @@ output "core_vnet_id" {
   value = azurerm_virtual_network.core.id
 }
 
-output "bastion_subnet_id" {
-  value = azurerm_subnet.bastion.id
-}
-
-output "azure_firewall_subnet_id" {
-  value = azurerm_subnet.azure_firewall.id
-}
-
-output "app_gw_subnet_id" {
-  value = azurerm_subnet.app_gw.id
-}
-
-output "web_app_subnet_id" {
-  value = azurerm_subnet.web_app.id
-}
-
-output "shared_subnet_id" {
-  value = azurerm_subnet.shared.id
-}
-
-output "resource_processor_subnet_id" {
-  value = azurerm_subnet.resource_processor.id
+output subnet_ids {
+  value = {
+    "bastion" = azurerm_subnet.bastion.id
+    "azure_firewall" = azurerm_subnet.azure_firewall.id
+    "app_gw" = azurerm_subnet.app_gw.id
+    "web_app" = azurerm_subnet.web_app.id
+    "shared" = azurerm_subnet.shared.id
+    "resource_processor" = azurerm_subnet.resource_processor.id
+  }
 }
 
 output "azure_monitor_dns_zone_id" {

--- a/templates/core/terraform/network/output.tf
+++ b/templates/core/terraform/network/output.tf
@@ -2,13 +2,13 @@ output "core_vnet_id" {
   value = azurerm_virtual_network.core.id
 }
 
-output subnet_ids {
+output "subnet_ids" {
   value = {
-    "bastion" = azurerm_subnet.bastion.id
-    "azure_firewall" = azurerm_subnet.azure_firewall.id
-    "app_gw" = azurerm_subnet.app_gw.id
-    "web_app" = azurerm_subnet.web_app.id
-    "shared" = azurerm_subnet.shared.id
+    "bastion"            = azurerm_subnet.bastion.id
+    "azure_firewall"     = azurerm_subnet.azure_firewall.id
+    "app_gw"             = azurerm_subnet.app_gw.id
+    "web_app"            = azurerm_subnet.web_app.id
+    "shared"             = azurerm_subnet.shared.id
     "resource_processor" = azurerm_subnet.resource_processor.id
   }
 }

--- a/templates/core/terraform/resource_processor/vmss_porter/main.tf
+++ b/templates/core/terraform/resource_processor/vmss_porter/main.tf
@@ -101,7 +101,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "vm_linux" {
     ip_configuration {
       name      = "internal"
       primary   = true
-      subnet_id = var.resource_processor_subnet_id
+      subnet_id = var.subnet_id
     }
   }
 

--- a/templates/core/terraform/resource_processor/vmss_porter/variables.tf
+++ b/templates/core/terraform/resource_processor/vmss_porter/variables.tf
@@ -2,7 +2,7 @@ variable "tre_id" {}
 variable "location" {}
 variable "acr_id" {}
 variable "resource_group_name" {}
-variable "resource_processor_subnet_id" {}
+variable "subnet_id" {}
 variable "resource_processor_vmss_porter_image_repository" {}
 variable "docker_registry_server" {}
 variable "service_bus_namespace_id" {}

--- a/templates/core/terraform/routetable/routetable.tf
+++ b/templates/core/terraform/routetable/routetable.tf
@@ -15,16 +15,16 @@ resource "azurerm_route_table" "rt" {
 }
 
 resource "azurerm_subnet_route_table_association" "rt_shared_subnet_association" {
-  subnet_id      = var.shared_subnet_id
+  subnet_id      = var.subnet_ids["shared"]
   route_table_id = azurerm_route_table.rt.id
 }
 
 resource "azurerm_subnet_route_table_association" "rt_resource_processor_subnet_association" {
-  subnet_id      = var.resource_processor_subnet_id
+  subnet_id      = var.subnet_ids["resource_processor"]
   route_table_id = azurerm_route_table.rt.id
 }
 
 resource "azurerm_subnet_route_table_association" "rt_web_app_subnet_association" {
-  subnet_id      = var.web_app_subnet_id
+  subnet_id      = var.subnet_ids["web_app"]
   route_table_id = azurerm_route_table.rt.id
 }

--- a/templates/core/terraform/routetable/variables.tf
+++ b/templates/core/terraform/routetable/variables.tf
@@ -2,7 +2,4 @@ variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
 variable "firewall_private_ip_address" {}
-variable "shared_subnet_id" {}
-variable "resource_processor_subnet_id" {}
-variable "web_app_subnet_id" {}
-variable "app_gw_subnet_id" {}
+variable "subnet_ids" {}

--- a/templates/core/terraform/servicebus/servicebus.tf
+++ b/templates/core/terraform/servicebus/servicebus.tf
@@ -44,7 +44,7 @@ resource "azurerm_private_endpoint" "sbpe" {
   name                = "pe-sb-${var.tre_id}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.resource_processor_subnet_id
+  subnet_id           = var.subnet_id
 
   lifecycle { ignore_changes = [tags] }
 

--- a/templates/core/terraform/servicebus/variables.tf
+++ b/templates/core/terraform/servicebus/variables.tf
@@ -2,4 +2,4 @@ variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
 variable "core_vnet" {}
-variable "resource_processor_subnet_id" {}
+variable "subnet_id" {}

--- a/templates/core/terraform/state-store/statestore.tf
+++ b/templates/core/terraform/state-store/statestore.tf
@@ -55,7 +55,7 @@ resource "azurerm_private_endpoint" "sspe" {
   name                = "pe-ss-${var.tre_id}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.subnet_id
 
   lifecycle { ignore_changes = [tags] }
 

--- a/templates/core/terraform/state-store/variables.tf
+++ b/templates/core/terraform/state-store/variables.tf
@@ -1,5 +1,5 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
-variable "shared_subnet" {}
 variable "core_vnet" {}
+variable "subnet_id" {}

--- a/templates/core/terraform/storage/storage.tf
+++ b/templates/core/terraform/storage/storage.tf
@@ -23,7 +23,7 @@ resource "azurerm_private_endpoint" "blobpe" {
   name                = "pe-blob-${var.tre_id}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.subnet_id
 
   lifecycle { ignore_changes = [tags] }
 
@@ -49,7 +49,7 @@ resource "azurerm_private_endpoint" "filepe" {
   name                = "pe-file-${var.tre_id}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.subnet_id
 
   lifecycle { ignore_changes = [tags] }
 

--- a/templates/core/terraform/storage/variables.tf
+++ b/templates/core/terraform/storage/variables.tf
@@ -2,4 +2,4 @@ variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
 variable "core_vnet" {}
-variable "shared_subnet" {}
+variable "subnet_id" {}


### PR DESCRIPTION
Whilst looking at the subnets that are causing an intermittent error for the private endpoints, I reduced the amount of subnet id variables and put them in a single output list. This makes it easier to pass around multiple subnets.

#700 