### PR TITLE
Save terraform plan to a unique file, add a script to compare them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+*tfplan*
 
 # Ignore CLI configuration files
 .terraformrc

--- a/templates/core/terraform/compare_plans.sh
+++ b/templates/core/terraform/compare_plans.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+function usage() {
+    cat <<USAGE
+
+    Usage: $0 [--left <plan_file> ]  [ --right <plan_file> ]
+
+    Options:
+        --left   First tfplan file to compare
+        --right  Second tfplan file to compare
+USAGE
+    exit 1
+}
+
+# if no arguments are provided, return usage function
+if [ $# -eq 0 ]; then
+    usage # run usage function
+fi
+
+current="false"
+
+while [ "$1" != "" ]; do
+    case $1 in
+    --left)
+        shift
+        left_tfplan=$1
+        ;;
+    --right)
+        shift
+        right_tfplan=$1
+        ;;
+    *)
+        usage
+        ;;
+    esac
+    shift # remove the current value for `$1` and use the next
+done
+
+
+if [[ -z ${left_tfplan} || -z ${right_tfplan} ]]; then
+    echo -e "Not enough files provided to compare\n"
+    usage
+fi
+
+echo "Comparing ${left_tfplan} to ${right_tfplan}..."
+
+
+function plan_change() {
+  terraform show -json $1 | jq -r '.resource_changes[] | select(.change.actions[] | contains("no-op") or contains("read") | not)' > "$1_filtered.json"
+}
+
+plan_change ${left_tfplan}
+plan_change ${right_tfplan}
+
+diff <(jq --sort-keys . ${left_tfplan}_filtered.json) <(jq --sort-keys . ${right_tfplan}_filtered.json)

--- a/templates/core/terraform/compare_plans.sh
+++ b/templates/core/terraform/compare_plans.sh
@@ -1,47 +1,14 @@
 #!/bin/bash
 set -e
 
-function usage() {
-    cat <<USAGE
-
-    Usage: $0 [--left <plan_file> ]  [ --right <plan_file> ]
-
-    Options:
-        --left   First tfplan file to compare
-        --right  Second tfplan file to compare
-USAGE
-    exit 1
-}
-
 # if no arguments are provided, return usage function
-if [ $# -eq 0 ]; then
-    usage # run usage function
+if [[ $# -ne 2 || -z $1 || -z $2 ]]; then
+    echo "Usage: $0 <left_plan_file> <right_plan_file>"
+    exit 1
 fi
 
-current="false"
-
-while [ "$1" != "" ]; do
-    case $1 in
-    --left)
-        shift
-        left_tfplan=$1
-        ;;
-    --right)
-        shift
-        right_tfplan=$1
-        ;;
-    *)
-        usage
-        ;;
-    esac
-    shift # remove the current value for `$1` and use the next
-done
-
-
-if [[ -z ${left_tfplan} || -z ${right_tfplan} ]]; then
-    echo -e "Not enough files provided to compare\n"
-    usage
-fi
+left_tfplan=$1
+right_tfplan=$2
 
 echo "Comparing ${left_tfplan} to ${right_tfplan}..."
 

--- a/templates/core/terraform/deploy.sh
+++ b/templates/core/terraform/deploy.sh
@@ -2,8 +2,12 @@ export TF_VAR_docker_registry_server="$TF_VAR_acr_name.azurecr.io"
 export TF_VAR_docker_registry_username=$TF_VAR_acr_name
 export TF_VAR_docker_registry_password=$(az acr credential show --name ${TF_VAR_acr_name} --query passwords[0].value -o tsv | sed 's/"//g')
 
+PLAN_FILE="tfplan$$"
+LOG_FILE="tmp$$.log"
+
 ../../../devops/scripts/terraform_wrapper.sh -g $TF_VAR_mgmt_resource_group_name \
                                             -s $TF_VAR_mgmt_storage_account_name \
                                             -n $TF_VAR_terraform_state_container_name \
                                             -k ${TF_VAR_tre_id} \
-                                            -c "terraform plan -out plan && terraform apply -input=false -auto-approve plan"
+                                            -l ${LOG_FILE} \
+                                            -c "terraform plan -out ${PLAN_FILE} && terraform apply -input=false -auto-approve ${PLAN_FILE}"


### PR DESCRIPTION
## What is being addressed

Currently, output of `terraform plan` command is saved to a file named `plan`.
This makes it harder to debug the difference of its content over time (e.g. https://github.com/microsoft/AzureTRE/issues/700) 

## How is this addressed

- Adding a unique prefix to saved Terraform plan files
- Add a script to compare previously saved Terraform plan files

Example of output:

![image](https://user-images.githubusercontent.com/52954123/149992257-41c5fec8-4eac-49f2-a762-da30c4b1c562.png)

