### PR TITLE
Fix private endpoints being replaced when haven't changed

### DIFF
--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -232,17 +232,17 @@ module "jumpbox" {
 }
 
 module "gitea" {
-  count                  = var.deploy_gitea == true ? 1 : 0
-  source                 = "../../shared_services/gitea/terraform"
-  tre_id                 = var.tre_id
-  location               = var.location
-  docker_registry_server = data.azurerm_container_registry.mgmt_acr.login_server
-  acr_id                 = data.azurerm_container_registry.mgmt_acr.id
-  keyvault_id            = module.keyvault.keyvault_id
-  storage_account_name   = module.storage.storage_account_name
-  shared_subnet          = module.network.shared_subnet_id
-  private_dns_zone_azurewebsites_id    = module.network.private_dns_zone_azurewebsites_id
-  private_dns_zone_mysql_id    = module.network.private_dns_zone_mysql_id
+  count                             = var.deploy_gitea == true ? 1 : 0
+  source                            = "../../shared_services/gitea/terraform"
+  tre_id                            = var.tre_id
+  location                          = var.location
+  docker_registry_server            = data.azurerm_container_registry.mgmt_acr.login_server
+  acr_id                            = data.azurerm_container_registry.mgmt_acr.id
+  keyvault_id                       = module.keyvault.keyvault_id
+  storage_account_name              = module.storage.storage_account_name
+  shared_subnet                     = module.network.shared_subnet_id
+  private_dns_zone_azurewebsites_id = module.network.private_dns_zone_azurewebsites_id
+  private_dns_zone_mysql_id         = module.network.private_dns_zone_mysql_id
 
   depends_on = [
     module.network,
@@ -252,14 +252,14 @@ module "gitea" {
 }
 
 module "nexus" {
-  count                = var.deploy_nexus == true ? 1 : 0
-  source               = "../../shared_services/sonatype-nexus/terraform"
-  tre_id               = var.tre_id
-  location             = var.location
-  storage_account_name = module.storage.storage_account_name
-  shared_subnet          = module.network.shared_subnet_id
-  web_app_subnet = module.network.web_app_subnet_id
-  private_dns_zone_azurewebsites_id    = module.network.private_dns_zone_azurewebsites_id
+  count                             = var.deploy_nexus == true ? 1 : 0
+  source                            = "../../shared_services/sonatype-nexus/terraform"
+  tre_id                            = var.tre_id
+  location                          = var.location
+  storage_account_name              = module.storage.storage_account_name
+  shared_subnet                     = module.network.shared_subnet_id
+  web_app_subnet                    = module.network.web_app_subnet_id
+  private_dns_zone_azurewebsites_id = module.network.private_dns_zone_azurewebsites_id
 
   depends_on = [
     module.network,

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -240,6 +240,9 @@ module "gitea" {
   acr_id                 = data.azurerm_container_registry.mgmt_acr.id
   keyvault_id            = module.keyvault.keyvault_id
   storage_account_name   = module.storage.storage_account_name
+  shared_subnet          = module.network.shared_subnet_id
+  private_dns_zone_azurewebsites_id    = module.network.private_dns_zone_azurewebsites_id
+  private_dns_zone_mysql_id    = module.network.private_dns_zone_mysql_id
 
   depends_on = [
     module.network,
@@ -254,6 +257,9 @@ module "nexus" {
   tre_id               = var.tre_id
   location             = var.location
   storage_account_name = module.storage.storage_account_name
+  shared_subnet          = module.network.shared_subnet_id
+  web_app_subnet = module.network.web_app_subnet_id
+  private_dns_zone_azurewebsites_id    = module.network.private_dns_zone_azurewebsites_id
 
   depends_on = [
     module.network,

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -240,7 +240,7 @@ module "gitea" {
   acr_id                            = data.azurerm_container_registry.mgmt_acr.id
   keyvault_id                       = module.keyvault.keyvault_id
   storage_account_name              = module.storage.storage_account_name
-  shared_subnet                     = module.network.shared_subnet_id
+  shared_subnet_id                  = module.network.shared_subnet_id
   private_dns_zone_azurewebsites_id = module.network.private_dns_zone_azurewebsites_id
   private_dns_zone_mysql_id         = module.network.private_dns_zone_mysql_id
 
@@ -257,8 +257,8 @@ module "nexus" {
   tre_id                            = var.tre_id
   location                          = var.location
   storage_account_name              = module.storage.storage_account_name
-  shared_subnet                     = module.network.shared_subnet_id
-  web_app_subnet                    = module.network.web_app_subnet_id
+  shared_subnet_id                  = module.network.shared_subnet_id
+  web_app_subnet_id                 = module.network.web_app_subnet_id
   private_dns_zone_azurewebsites_id = module.network.private_dns_zone_azurewebsites_id
 
   depends_on = [

--- a/templates/core/terraform/network/output.tf
+++ b/templates/core/terraform/network/output.tf
@@ -22,6 +22,14 @@ output "shared_subnet_id" {
   value = azurerm_subnet.shared.id
 }
 
+output "private_dns_zone_azurewebsites_id" {
+  value = azurerm_private_dns_zone.azurewebsites.id
+}
+
+output "private_dns_zone_mysql_id" {
+  value = azurerm_private_dns_zone.mysql.id
+}
+
 output "resource_processor_subnet_id" {
   value = azurerm_subnet.resource_processor.id
 }

--- a/templates/shared_services/gitea/terraform/data.tf
+++ b/templates/shared_services/gitea/terraform/data.tf
@@ -18,12 +18,6 @@ data "azurerm_virtual_network" "core" {
   resource_group_name = local.core_resource_group_name
 }
 
-data "azurerm_subnet" "shared" {
-  resource_group_name  = local.core_resource_group_name
-  virtual_network_name = local.core_vnet
-  name                 = "SharedSubnet"
-}
-
 data "azurerm_subnet" "web_app" {
   resource_group_name  = local.core_resource_group_name
   virtual_network_name = local.core_vnet
@@ -32,11 +26,6 @@ data "azurerm_subnet" "web_app" {
 
 data "azurerm_private_dns_zone" "mysql" {
   name                = "privatelink.mysql.database.azure.com"
-  resource_group_name = local.core_resource_group_name
-}
-
-data "azurerm_private_dns_zone" "azurewebsites" {
-  name                = "privatelink.azurewebsites.net"
   resource_group_name = local.core_resource_group_name
 }
 

--- a/templates/shared_services/gitea/terraform/gitea-webapp.tf
+++ b/templates/shared_services/gitea/terraform/gitea-webapp.tf
@@ -116,7 +116,7 @@ resource "azurerm_private_endpoint" "gitea_private_endpoint" {
   name                = "pe-${local.webapp_name}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  subnet_id           = data.azurerm_subnet.shared.id
+  subnet_id           = var.shared_subnet
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.gitea.id
@@ -127,7 +127,7 @@ resource "azurerm_private_endpoint" "gitea_private_endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.azurewebsites.net"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.azurewebsites.id]
+    private_dns_zone_ids = [var.private_dns_zone_azurewebsites_id]
   }
 
   lifecycle { ignore_changes = [tags] }

--- a/templates/shared_services/gitea/terraform/gitea-webapp.tf
+++ b/templates/shared_services/gitea/terraform/gitea-webapp.tf
@@ -116,7 +116,7 @@ resource "azurerm_private_endpoint" "gitea_private_endpoint" {
   name                = "pe-${local.webapp_name}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.shared_subnet_id
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.gitea.id

--- a/templates/shared_services/gitea/terraform/mysql.tf
+++ b/templates/shared_services/gitea/terraform/mysql.tf
@@ -38,7 +38,7 @@ resource "azurerm_private_endpoint" "private-endpoint" {
   name                = "pe-${azurerm_mysql_server.gitea.name}"
   location            = var.location
   resource_group_name = local.core_resource_group_name
-  subnet_id           = data.azurerm_subnet.shared.id
+  subnet_id           = var.shared_subnet
 
   private_service_connection {
     private_connection_resource_id = azurerm_mysql_server.gitea.id
@@ -49,7 +49,7 @@ resource "azurerm_private_endpoint" "private-endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.mysql.database.azure.com"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.mysql.id]
+    private_dns_zone_ids = [var.private_dns_zone_mysql_id]
   }
 
   lifecycle { ignore_changes = [tags] }

--- a/templates/shared_services/gitea/terraform/mysql.tf
+++ b/templates/shared_services/gitea/terraform/mysql.tf
@@ -38,7 +38,7 @@ resource "azurerm_private_endpoint" "private-endpoint" {
   name                = "pe-${azurerm_mysql_server.gitea.name}"
   location            = var.location
   resource_group_name = local.core_resource_group_name
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.shared_subnet_id
 
   private_service_connection {
     private_connection_resource_id = azurerm_mysql_server.gitea.id

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -26,7 +26,7 @@ variable "storage_account_name" {
   description = "The name of the storage account to use"
 }
 
-variable "shared_subnet" {
+variable "shared_subnet_id" {
   type        = string
   description = "The ID of the shared subnet in which to create a private endpoint"
 }

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -26,6 +26,21 @@ variable "storage_account_name" {
   description = "The name of the storage account to use"
 }
 
+variable "shared_subnet" {
+  type        = string
+  description = "The ID of the shared subnet in which to create a private endpoint"
+}
+
+variable "private_dns_zone_azurewebsites_id" {
+  type = string
+  description = "The ID of the private DNS zone to use for the private endpoint"
+}
+
+variable "private_dns_zone_mysql_id" {
+  type = string
+  description = "The ID of the private DNS zone for MySQL"
+}
+
 variable "gitea_storage_limit" {
   type        = number
   description = "Space allocated in GB for the Gitea data in Azure Files Share"

--- a/templates/shared_services/sonatype-nexus/terraform/data.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/data.tf
@@ -18,23 +18,6 @@ data "azurerm_virtual_network" "core" {
   resource_group_name = local.core_resource_group_name
 }
 
-data "azurerm_subnet" "shared" {
-  resource_group_name  = local.core_resource_group_name
-  virtual_network_name = local.core_vnet
-  name                 = "SharedSubnet"
-}
-
-data "azurerm_subnet" "web_app" {
-  resource_group_name  = local.core_resource_group_name
-  virtual_network_name = local.core_vnet
-  name                 = "WebAppSubnet"
-}
-
-data "azurerm_private_dns_zone" "azurewebsites" {
-  name                = "privatelink.azurewebsites.net"
-  resource_group_name = local.core_resource_group_name
-}
-
 data "azurerm_storage_account" "nexus" {
   name                = var.storage_account_name
   resource_group_name = local.core_resource_group_name

--- a/templates/shared_services/sonatype-nexus/terraform/variables.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/variables.tf
@@ -19,12 +19,12 @@ variable "nexus_storage_limit" {
   default     = 1024
 }
 
-variable "shared_subnet" {
+variable "shared_subnet_id" {
   type        = string
   description = "The ID of the shared subnet in which to create a private endpoint"
 }
 
-variable "web_app_subnet" {
+variable "web_app_subnet_id" {
   type        = string
   description = "The ID of the web app subnet to connect to"
 }

--- a/templates/shared_services/sonatype-nexus/terraform/variables.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/variables.tf
@@ -18,3 +18,18 @@ variable "nexus_storage_limit" {
   description = "Space allocated in GB for the Nexus data in Azure Files Share"
   default     = 1024
 }
+
+variable "shared_subnet" {
+  type        = string
+  description = "The ID of the shared subnet in which to create a private endpoint"
+}
+
+variable "web_app_subnet" {
+  type        = string
+  description = "The ID of the web app subnet to connect to"
+}
+
+variable "private_dns_zone_azurewebsites_id" {
+  type = string
+  description = "The ID of the private DNS zone to use for the private endpoint"
+}

--- a/templates/shared_services/sonatype-nexus/terraform/webapp.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/webapp.tf
@@ -68,7 +68,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
   name                = "pe-nexus-${var.tre_id}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  subnet_id           = var.shared_subnet
+  subnet_id           = var.shared_subnet_id
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.nexus.id
@@ -87,7 +87,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "nexus-integrated-vnet" {
   app_service_id = azurerm_app_service.nexus.id
-  subnet_id      = var.web_app_subnet
+  subnet_id      = var.web_app_subnet_id
 }
 
 resource "azurerm_monitor_diagnostic_setting" "nexus" {

--- a/templates/shared_services/sonatype-nexus/terraform/webapp.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/webapp.tf
@@ -68,7 +68,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
   name                = "pe-nexus-${var.tre_id}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  subnet_id           = data.azurerm_subnet.shared.id
+  subnet_id           = var.shared_subnet
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.nexus.id
@@ -79,7 +79,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.azurewebsites.net"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.azurewebsites.id]
+    private_dns_zone_ids = [var.private_dns_zone_azurewebsites_id]
   }
 
   lifecycle { ignore_changes = [tags] }
@@ -87,7 +87,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "nexus-integrated-vnet" {
   app_service_id = azurerm_app_service.nexus.id
-  subnet_id      = data.azurerm_subnet.web_app.id
+  subnet_id      = var.web_app_subnet
 }
 
 resource "azurerm_monitor_diagnostic_setting" "nexus" {


### PR DESCRIPTION
# PR for issue https://github.com/microsoft/AzureTRE/issues/700

## What is being addressed

Currently, when running `make tre-deploy` consequently multiple times, private endpoints for Gitea and Nexus will always be replaced even when they haven't changed.
This seems to be due to the fact that some arguments are passed in corresponding modules as [data arguments](https://www.terraform.io/language/data-sources) (as opposed to using [variables](https://www.terraform.io/language/values/variables)). 

## How is this addressed

- Subnet IDs, as well as private DNS zones, are now passed in as variables, and not as data arguments 
- Note that this PR **does not** fix the issue of updating `module.resource_processor_vmss_porter[0].azurerm_role_assignment.subscription_owner` (which, as far as I can see, is the only remaining resource that is also being replaced when unchanged: a separate PR will follow for this). 

I confirmed that now, after consequent runs of `make tre-deploy`, only the above mentioned subscription owner is changing.  