### PR TITLE
Keyvault accessed only over Private Endpoint

### DIFF
--- a/templates/workspaces/base/terraform/keyvault.tf
+++ b/templates/workspaces/base/terraform/keyvault.tf
@@ -6,6 +6,11 @@ resource "azurerm_key_vault" "kv" {
   purge_protection_enabled = true
   tenant_id                = data.azurerm_client_config.current.tenant_id
 
+  network_acls {
+    bypass                     = "None"
+    default_action             = "Deny"
+  }
+
   lifecycle { ignore_changes = [tags] }
 }
 


### PR DESCRIPTION
This PR fixes #1047 

## What is being addressed
The Workspace keyvault can now only be accessed by Private Endpoint.

![image](https://user-images.githubusercontent.com/6254153/150326856-7c2a9c33-9107-4595-852a-542c8dd1268e.png)

## How is this addressed

- I have logged onto a Guacamole VM to test this