### PR TITLE
Fix for broken tf install in resource processor

### DIFF
--- a/resource_processor/scripts/terraform.sh
+++ b/resource_processor/scripts/terraform.sh
@@ -1,0 +1,23 @@
+#!/bin/bash 
+set -e
+
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" |
+  grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/'
+}
+
+VERSION=${1:-"$(get_latest_release hashicorp/terraform)"}
+INSTALL_DIR=${2:-"$HOME/.local/bin"}
+CMD=terraform
+NAME=Terraform
+
+echo -e "\e[34m»»» 📦 \e[32mInstalling \e[33m$NAME v$VERSION\e[0m ..."
+
+curl -sSL "https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip" -o /tmp/tf.zip
+unzip /tmp/tf.zip -d /tmp > /dev/null
+mkdir -p $INSTALL_DIR
+mv /tmp/terraform $INSTALL_DIR
+rm -f /tmp/tf.zip
+
+echo -e "\n\e[34m»»» 💾 \e[32mInstalled to: \e[33m$(which $CMD)"
+echo -e "\e[34m»»» 💡 \e[32mVersion details: \e[39m$($CMD --version)"

--- a/resource_processor/vmss_porter/Dockerfile
+++ b/resource_processor/vmss_porter/Dockerfile
@@ -13,10 +13,11 @@ RUN apt-get update \
     && apt-get update && apt-get -y install azure-cli=${AZURE_CLI_VERSION}
 
 # Install Terraform
-RUN apt-get update && apt-get install -y gnupg software-properties-common curl \
-    && curl -fsSL https://apt.releases.hashicorp.com/gpg |  apt-key add - \
-    && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
-    && apt-get update && apt-get install -y terraform
+ARG TERRAFORM_VERSION="1.0.5"
+COPY ./scripts/terraform.sh /tmp/
+RUN apt-get update \
+    && apt-get -y install unzip \
+    && bash /tmp/terraform.sh "${TERRAFORM_VERSION}" /usr/bin
 
 # Install Porter
 RUN export PORTER_HOME=/root/.porter && curl -L https://cdn.porter.sh/${PORTER_PERMALINK}/install-linux.sh | bash


### PR DESCRIPTION
# PR for issue

## What is being addressed

Fix for a bug #1171  where TF installation in resource processor image fails due to corrupt repository.

## How is this addressed

- Consolidated install method used for dev container and reused in resource processor image