### PR TITLE
Disable make tre-start and make tre-stop in Github action unitl issue #1165 is fixed

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -85,7 +85,8 @@ jobs:
           make all
 
           az extension add --name azure-firewall
-          make tre-start
+          # TODO: enable this once the bug https://github.com/microsoft/AzureTRE/issues/1165 is fixed
+          # make tre-start
 
       - name: Notify dedicated teams channel
         uses: sachinkundu/ms-teams-notification@1.4

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -289,4 +289,5 @@ jobs:
             TRE_ID: "${{secrets.TRE_ID}}"
           run: |
             az extension add --name azure-firewall
-            make tre-stop
+            # TODO: enable this once the bug https://github.com/microsoft/AzureTRE/issues/1165 is fixed
+            # make tre-stop


### PR DESCRIPTION
# PR for issue https://github.com/microsoft/AzureTRE/issues/1165

## What is being addressed

Temporarily disable `make tre-start` and `make tre-stop` commands in Github Actions until bug https://github.com/microsoft/AzureTRE/issues/1165 is fixed.

## How is this addressed

- Commented out corresponding lines in workflow definition
- Provided comment on why the lines are commented out 
