### PR TITLE
Install YQ in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,4 +64,7 @@ RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requ
 COPY ./.devcontainer/scripts/azure-cli.sh /tmp/
 RUN /tmp/azure-cli.sh
 
+RUN wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.13.0/yq_linux_amd64 \
+  && chmod +x /usr/local/bin/yq
+
 USER $USERNAME


### PR DESCRIPTION
# PR for issue
Issue #1175

## What is being addressed
We install YQ in the GH Actions pipeline, this needs to be in the DevContainer for use across CI engines.

## How is this addressed
Adding a new layer to the DevContainer

Once this is in, it will assist me completing Story #1175 