### PR TITLE
Add steps for creating AAD tenant for dev environments

### DIFF
--- a/docs/tre-admins/setup-instructions/pre-deployment-steps.md
+++ b/docs/tre-admins/setup-instructions/pre-deployment-steps.md
@@ -56,14 +56,14 @@ Next, you will set the configuration variables for the specific Azure TRE instan
 
 1. Open the `/templates/core/.env.sample` file and then save it without the .sample extension. You should now have a file called `.env` located in the `/templates/core` folder.
 1. Set the first one of the variables, `TRE_ID`, which is the alphanumeric, with underscores and hyphens allowed, ID for the Azure TRE instance. The value will be used in various Azure resources, and **needs to be globally unique and less than 12 characters in length**. Use only lowercase letters. Choose wisely!
-1. Run the `/scripts/aad-app-reg.sh` script to create API and Swagger UI app registrations and their service principals. The details of the script are covered [app registration script](../auth.md#app-registration-script) section of the auth document. Below is a sample where `TRE_ID` has value `mytre` and the Azure location is `westeurope`:
+1. Run the `/scripts/aad-app-reg.sh` script to create API and Swagger UI app registrations and their service principals in Azure Active Directory. The details of the script are covered [app registration script](../auth.md#app-registration-script) section of the auth document. Below is a sample where `TRE_ID` has value `mytre` and the Azure location is `westeurope`:
 
   ```bash
   ./scripts/aad-app-reg.sh -n TRE -r https://mytre.westeurope.cloudapp.azure.com/api/docs/oauth2-redirect -a
   ```
 
   !!! note
-      The full functionality of the script requires directory admin privileges. You may need to contact your friendly AAD admin to complete this step. The app registrations can be created manually in Azure Portal too. For more information, see [Authentication and authorization](../auth.md).
+      The full functionality of the script requires directory admin privileges. You may need to contact your friendly Azure Active Directory admin to complete this step. The app registrations can be created manually in Azure Portal too. For more information, see [Authentication and authorization](../auth.md).<br/>If you don't have permissions and just want to create a development environment or explore TRE then you can create a separate Azure Active Directory tenant for this stage by [following the steps here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant) (note that you won't be able to use certain Active Directory integrated services in this configuration, so it is not recommended for production).
 
   With the output of the script, you can now provide the required auth related values for the following variables in the `/templates/core/.env` configuration file:
 

--- a/docs/tre-admins/setup-instructions/pre-deployment-steps.md
+++ b/docs/tre-admins/setup-instructions/pre-deployment-steps.md
@@ -63,7 +63,7 @@ Next, you will set the configuration variables for the specific Azure TRE instan
   ```
 
   !!! note
-      The full functionality of the script requires directory admin privileges. You may need to contact your friendly Azure Active Directory admin to complete this step. The app registrations can be created manually in Azure Portal too. For more information, see [Authentication and authorization](../auth.md).<br/>If you don't have permissions and just want to create a development environment or explore TRE then you can create a separate Azure Active Directory tenant for this stage by [following the steps here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant) (note that you won't be able to use certain Active Directory integrated services in this configuration, so it is not recommended for production).
+      The full functionality of the script requires directory admin privileges. You may need to contact your friendly Azure Active Directory admin to complete this step. The app registrations can be created manually in Azure Portal too. For more information, see [Authentication and authorization](../auth.md).<br/>If you don't have permissions and just want to create a development environment then skip this step and see the steps in the "Using a separate Azure Active Directory tenant) below.
 
   With the output of the script, you can now provide the required auth related values for the following variables in the `/templates/core/.env` configuration file:
 
@@ -90,6 +90,37 @@ API_CLIENT_ID=af6...dc
 API_CLIENT_SECRET=abc...12
 SWAGGER_UI_CLIENT_ID=d87...12
 ```
+
+### Using a separate Azure Active Directory tenant
+
+  !!! caution
+      This section is only relevant it you are setting up a separate Azure Active Directory tenant for use 
+      This is only recommended for development environments when you don't have the required permissions to create the necessary Azure Active Directory registrations.
+      Using a separate Azure Active Directory tenant will prevent you from using certain Azure Active Directory integrated services.
+      For production deployments, work with your Azure Active Directory administrator to perform the required registration
+
+1.  Create an Azure Active Directory tenant
+    To create a new Azure Active Directory tenant, [follow the steps here](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant) 
+
+1.  Sign in to the new tenant
+    Sign in to the new tenant by running the following command (substitute the ID of the tenant you just created)
+
+    ```bash
+    az login --tenant <tenant-id-here> --allow-no-subscriptions
+    ```
+
+1.  Run the `/scripts/aad-app-reg.sh` script to create API and Swagger UI app registrations and their service principals in Azure Active Directory. The details of the script are covered [app registration script](../auth.md#app-registration-script) section of the auth document. Below is a sample where `TRE_ID` has value `mytre` and the Azure location is `westeurope`:
+
+    ```bash
+    ./scripts/aad-app-reg.sh -n TRE -r https://mytre.westeurope.cloudapp.azure.com/api/docs/oauth2-redirect -a
+    ```
+  With the output of the script, you can now provide the required auth related values for the following variables in the `/templates/core/.env` configuration file as described above in the "Set environment configuration variables of the Azure TRE instance" section.
+
+1. Reset your `az` account to use the subscription you want to deploy resources into (`az list` will show the subscriptions you are signed into)
+   ```bash
+   az account set --subscription <name or id of subscription>
+   ```
+
 
 ## Add admin user
 

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -532,7 +532,7 @@ if [[ $workspace -eq 0 ]]; then
 
 Variables:
 
-AAD_TENANT_ID=$(az account show | jq -r '.tenantId')
+AAD_TENANT_ID=$(az account show --output json | jq -r '.tenantId')
 API_CLIENT_ID=${apiAppId}
 API_CLIENT_SECRET=${spPassword}
 SWAGGER_UI_CLIENT_ID=${swaggerAppId}
@@ -544,7 +544,7 @@ else
 
 Variables:
 
-AAD_TENANT_ID=$(az account show | jq -r '.tenantId')
+AAD_TENANT_ID=$(az account show --output json | jq -r '.tenantId')
 WORKSPACE_API_CLIENT_ID=${apiAppId}
 WORKSPACE_API_CLIENT_SECRET=${spPassword}
 


### PR DESCRIPTION
Adding a note to docs on how to create a separate AAD tenant, e.g. for working in a dev environment where you don't have permissions to create the AAD app

Closes #1185