### PR TITLE
Build and publish porter automatically from a make target

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -154,28 +154,7 @@ jobs:
           set -o pipefail
           set -o nounset
 
-          # test that porter is able to build the bundle
-          make porter-build DIR=${{ matrix.BUNDLE_DIR }}
-
-          TEMPLATE_NAME=$(yq eval '.name' ${{ matrix.BUNDLE_DIR }}/porter.yaml)
-
-          case "${BUNDLE_TYPE}" in
-            ("workspace") TRE_GET_PATH="api/workspace-templates" ;;
-            ("workspace_service") TRE_GET_PATH="api/workspace-service-templates" ;;
-          esac
-
-          export TOKEN=$(curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password&resource=${RESOURCE}&client_id=${CLIENT_ID}&username=${USERNAME}&password=${PASSWORD}&scope=default)" https://login.microsoftonline.com/${AUTH_TENANT_ID}/oauth2/token | jq -r '.access_token')
-
-          make register-bundle DIR=${{ matrix.BUNDLE_DIR }}
-
-          # Check that the template got registered
-          STATUS_CODE=$(curl -X "GET" "${TRE_URL}/${TRE_GET_PATH}/${TEMPLATE_NAME}" -H "accept: application/json" -H "Authorization: Bearer ${TOKEN}" -k -s -w "%{http_code}" -o /dev/null)
-
-          if [[ ${STATUS_CODE} != 200 ]]
-          then
-            echo "::warning ::Template API check for ${BUNDLE_TYPE} ${TEMPLATE_NAME} returned http status: ${STATUS_CODE}"
-            exit 1
-          fi
+          make build-and-register-bundle DIR=${{ matrix.BUNDLE_DIR }}
 
   e2e_tests:
     name: "Run E2E Tests"

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,13 @@ register-bundle:
 	&& cd ${DIR} \
 	&& ${ROOTPATH}/devops/scripts/publish_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL} --access-token $${TOKEN}
 
+build-and-register-bundle: porter-build
+	echo -e "\n\e[34m»»» 🧩 \e[96mPublishing ${DIR} bundle\e[0m..." \
+	&& ./devops/scripts/check_dependencies.sh porter \
+	&& . ./devops/scripts/load_env.sh ./devops/.env \
+	&& cd ${DIR} \
+	&& ${ROOTPATH}/devops/scripts/build_and_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL} --access-token $${TOKEN}
+
 register-bundle-payload:
 	echo -e "\n\e[34m»»» 🧩 \e[96mPublishing ${DIR} bundle\e[0m..." \
 	&& ./devops/scripts/check_dependencies.sh porter \

--- a/devops/scripts/build_and_register_bundle.sh
+++ b/devops/scripts/build_and_register_bundle.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+
+function usage() {
+    cat <<USAGE
+
+    Usage: $0 [-u --tre_url]  [-c --current] [-i --insecure]
+
+    Options:
+        -r, --acr-name        Azure Container Registry Name
+        -t, --bundle-type     Bundle type, workspace or workspace_service
+        -c, --current:        Make this the currently deployed version of this template
+        -i, --insecure:       Bypass SSL certificate checks
+        -u, --tre_url:        URL for the TRE (required for automatic registration)
+        -a, --access-token    Azure access token to automatically post to the API (required for automatic registration)
+USAGE
+    exit 1
+}
+
+# if no arguments are provided, return usage function
+if [ $# -eq 0 ]; then
+    usage # run usage function
+fi
+
+current="false"
+
+while [ "$1" != "" ]; do
+    case $1 in
+    -u | --tre_url)
+        shift
+        tre_url=$1
+        ;;
+    -r | --acr-name)
+        shift
+        acr_name=$1
+        ;;
+    -t | --bundle-type)
+        shift
+        case $1 in
+        workspace)
+        ;;
+        workspace_service)
+        ;;
+        user_resource)
+        ;;
+        *)
+            echo "Bundle type must be workspace, workspace_service or user_resource, not $1"
+            exit 1
+        esac
+        bundle_type=$1
+        ;;
+    -c| --current)
+        current="true"
+        ;;
+    -i| --insecure)
+        insecure=1
+        ;;
+    -a | --access-token)
+        shift
+        access_token=$1
+        ;;
+    *)
+        usage
+        ;;
+    esac
+    shift # remove the current value for `$1` and use the next
+done
+
+if [[ -z ${bundle_type+x} ]]; then
+    echo -e "No bundle type provided\n"
+    usage
+fi
+
+# This script assumes that it is being run in the BUNDLE_DIR so we can take the
+# current working directory
+BUNDLE_DIR="$(pwd)"
+TEMPLATE_NAME=$(yq eval '.name' ${BUNDLE_DIR}/porter.yaml)
+
+case "${bundle_type}" in
+  ("workspace") TRE_GET_PATH="api/workspace-templates" ;;
+  ("workspace_service") TRE_GET_PATH="api/workspace-service-templates" ;;
+esac
+
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d \
+  "grant_type=password&resource=${TF_VAR_api_client_id}&client_id=${CLIENT_ID}&username=${USERNAME}&password=${PASSWORD}&scope=default)" \
+  https://login.microsoftonline.com/${TF_VAR_aad_tenant_id}/oauth2/token | jq -r '.access_token'
+


### PR DESCRIPTION
# PR for issue
#1175

## What is being addressed
Amending the Actions workflow to reduce inline script to make it easier to move to the dev container. There is now a new target `make build-and-register-bundle` which builds the porter bundles, retrieves the token from the api, posts the json to the endpoint and checks that it has been registered.

## How is this addressed

![image](https://user-images.githubusercontent.com/6254153/151264134-100c6e08-c8d1-480d-9078-dea98cdd24c6.png)
The bundles all successfully register
