### PR TITLE
Remove access token as we retrieve it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ build-and-register-bundle: porter-build
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& cd ${DIR} \
-	&& ${ROOTPATH}/devops/scripts/build_and_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL} --access-token $${TOKEN}
+	&& ${ROOTPATH}/devops/scripts/build_and_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL}
 
 register-bundle-payload:
 	echo -e "\n\e[34m»»» 🧩 \e[96mPublishing ${DIR} bundle\e[0m..." \

--- a/devops/scripts/build_and_register_bundle.sh
+++ b/devops/scripts/build_and_register_bundle.sh
@@ -12,7 +12,6 @@ function usage() {
         -c, --current:        Make this the currently deployed version of this template
         -i, --insecure:       Bypass SSL certificate checks
         -u, --tre_url:        URL for the TRE (required for automatic registration)
-        -a, --access-token    Azure access token to automatically post to the API (required for automatic registration)
 USAGE
     exit 1
 }
@@ -54,10 +53,6 @@ while [ "$1" != "" ]; do
         ;;
     -i| --insecure)
         insecure=1
-        ;;
-    -a | --access-token)
-        shift
-        access_token=$1
         ;;
     *)
         usage


### PR DESCRIPTION
We previously passed in the TOKEN to the register bundles and this should have been retrieved from the auth service