### PR TITLE
Remove access token

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -138,11 +138,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Install yq
         run: |
           sudo wget -O /usr/local/bin/yq \

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -20,6 +20,7 @@ env:
   USE_ENV_VARS_NOT_FILES: true
   DOCKER_BUILDKIT: 1
   TF_INPUT: 0 # interactive is off
+  TF_IN_AUTOMATION: 1 # Headless
 
 jobs:
   deploy_tre:
@@ -43,11 +44,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v1
         with:
@@ -56,7 +52,6 @@ jobs:
       - name: Deploy TRE
         shell: bash
         env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
           ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
           ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
@@ -274,10 +269,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
       - name: Deallocate Resources
         shell: bash
         env:

--- a/.github/workflows/lets_encrypt.yml
+++ b/.github/workflows/lets_encrypt.yml
@@ -14,6 +14,7 @@ concurrency: letsencrypt
 env:
   USE_ENV_VARS_NOT_FILES: true
   TF_INPUT: 0 # interactive is off
+  TF_IN_AUTOMATION: 1 # Run in headless mode
 
 jobs:
   renew_letsencrypt_certs:
@@ -23,11 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v1
@@ -42,7 +38,6 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           TF_VAR_tre_id: ${{ secrets.TRE_ID }}
           TF_VAR_terraform_state_container_name:
             ${{ secrets.TF_STATE_CONTAINER }}

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ porter-build:
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_env.sh ${DIR}/.env \
+	&& . ./devops/scripts/set_docker_sock_permission.sh \
 	&& cd ${DIR} && porter build --debug
 
 porter-install:

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ build-and-register-bundle: porter-build
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& cd ${DIR} \
-	&& ${ROOTPATH}/devops/scripts/build_and_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL} --access-token $${TOKEN}
+	&& ${ROOTPATH}/devops/scripts/build_and_register_bundle.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL}
 
 register-bundle-payload:
 	echo -e "\n\e[34m»»» 🧩 \e[96mPublishing ${DIR} bundle\e[0m..." \

--- a/devops/scripts/build_and_register_bundle.sh
+++ b/devops/scripts/build_and_register_bundle.sh
@@ -12,7 +12,6 @@ function usage() {
         -c, --current:        Make this the currently deployed version of this template
         -i, --insecure:       Bypass SSL certificate checks
         -u, --tre_url:        URL for the TRE (required for automatic registration)
-        -a, --access-token    Azure access token to automatically post to the API (required for automatic registration)
 USAGE
     exit 1
 }
@@ -54,10 +53,6 @@ while [ "$1" != "" ]; do
         ;;
     -i| --insecure)
         insecure=1
-        ;;
-    -a | --access-token)
-        shift
-        access_token=$1
         ;;
     *)
         usage

--- a/docs/tre-admins/setup-instructions/workflows.md
+++ b/docs/tre-admins/setup-instructions/workflows.md
@@ -48,13 +48,16 @@ Before you can run the `deploy_tre.yml` pipeline there are some one-time configu
   ```
 
   !!! caution
-      Save the JSON output locally - as you will need it later for the `AZURE_CREDENTIALS` secret
+      Save the JSON output locally - as you will need it later for setting secrets in the build
 
-1. Configure the AZURE_CREDENTIALS repository secret
+1. Configure the repository secrets. These values will be in the JSON file from the previous step.
 
   | <div style="width: 230px">Secret name</div> | Description |
   | ----------- | ----------- |
-  | `AZURE_CREDENTIALS` | The JSON output from the previous step |
+  | `ARM_SUBSCRIPTION_ID` | The Azure subscription to deploy to  |
+  | `ARM_TENANT_ID` | The Azure tenant to deploy to  |
+  | `ARM_CLIENT_ID` | The Azure Client Id (user)  |
+  | `ARM_CLIENT_SECRET` | The Azure Client Secret (password)  |
 
 ### Decide on a TRE ID and Azure resources location
 


### PR DESCRIPTION
# PR for issue
#1206 

## What is being addressed
- When we are building porter from docker-from-docker we need to set the socket up correctly
- When we build-and-register the bundles we do not ask for the TOKEN, instead we get it from the auth service
- We no longer need to log into Azure in the pipeline as the CheckDependencies does this for us

