### PR TITLE
Force LF line endings in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,7 @@
-# These settings are for any web project
+# Default all files to have unix eols, so Windows does not break them
+* text eol=lf
 
-# Handle line endings automatically for files detected as text
-# and leave all files detected as binary untouched.
-* text=auto
-
-# Force the following filetypes to have unix eols, so Windows does not break them
-*.* text eol=lf
-
-# Windows forced line-endings
-/.idea/* text eol=crlf
-
-#
-## These files are binary and should be left untouched
-#
-
+# These files are binary and should be left untouched
 # (binary is a macro for -text -diff)
 *.png binary
 *.jpg binary


### PR DESCRIPTION
# PR for issue #1213

## What is being addressed

Force all line endings to `lf` on checkout to avoid line endings being changed when checked out to Windows file systems.