### PR TITLE
Gitea, Nexus: Move variable inputs to data and locals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,7 @@
-# These settings are for any web project
+# Default all files to have unix eols, so Windows does not break them
+* text eol=lf
 
-# Handle line endings automatically for files detected as text
-# and leave all files detected as binary untouched.
-* text=auto
-
-# Force the following filetypes to have unix eols, so Windows does not break them
-*.* text eol=lf
-
-# Windows forced line-endings
-/.idea/* text eol=crlf
-
-#
-## These files are binary and should be left untouched
-#
-
+# These files are binary and should be left untouched
 # (binary is a macro for -text -diff)
 *.png binary
 *.jpg binary

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -246,12 +246,12 @@ module "jumpbox" {
 }
 
 module "gitea" {
-  count                                         = var.deploy_gitea == true ? 1 : 0
-  source                                        = "../../shared_services/gitea/terraform"
-  tre_id                                        = var.tre_id
-  location                                      = var.location
-  acr_name                                      = data.azurerm_container_registry.mgmt_acr.name
-  mgmt_resource_group_name                      = var.mgmt_resource_group_name
+  count                    = var.deploy_gitea == true ? 1 : 0
+  source                   = "../../shared_services/gitea/terraform"
+  tre_id                   = var.tre_id
+  location                 = var.location
+  acr_name                 = data.azurerm_container_registry.mgmt_acr.name
+  mgmt_resource_group_name = var.mgmt_resource_group_name
 
   depends_on = [
     module.network,
@@ -262,10 +262,10 @@ module "gitea" {
 }
 
 module "nexus" {
-  count                                         = var.deploy_nexus == true ? 1 : 0
-  source                                        = "../../shared_services/sonatype-nexus/terraform"
-  tre_id                                        = var.tre_id
-  location                                      = var.location
+  count    = var.deploy_nexus == true ? 1 : 0
+  source   = "../../shared_services/sonatype-nexus/terraform"
+  tre_id   = var.tre_id
+  location = var.location
 
   depends_on = [
     module.network,

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -250,21 +250,8 @@ module "gitea" {
   source                                        = "../../shared_services/gitea/terraform"
   tre_id                                        = var.tre_id
   location                                      = var.location
-  docker_registry_server                        = data.azurerm_container_registry.mgmt_acr.login_server
-  acr_id                                        = data.azurerm_container_registry.mgmt_acr.id
-  keyvault_id                                   = module.keyvault.keyvault_id
-  storage_account_name                          = module.storage.storage_account_name
-  storage_account_primary_access_key            = module.storage.storage_account_access_key
-  shared_subnet_id                              = module.network.shared_subnet_id
-  web_app_subnet_id                             = module.network.web_app_subnet_id
-  private_dns_zone_azurewebsites_id             = module.network.private_dns_zone_azurewebsites_id
-  private_dns_zone_mysql_id                     = module.network.private_dns_zone_mysql_id
-  log_analytics_workspace_id                    = module.azure_monitor.log_analytics_workspace_id
-  core_app_service_plan_id                      = module.api-webapp.core_app_service_plan_id
-  core_application_insights_instrumentation_key = module.azure_monitor.app_insights_instrumentation_key
-  firewall_name                                 = module.firewall.firewall_name
-  firewall_resource_group_name                  = module.firewall.firewall_resource_group_name
-  web_app_subnet_address_prefixes               = module.network.web_app_subnet_address_prefixes
+  acr_name                                      = data.azurerm_container_registry.mgmt_acr.name
+  mgmt_resource_group_name                      = var.mgmt_resource_group_name
 
   depends_on = [
     module.network,
@@ -279,17 +266,6 @@ module "nexus" {
   source                                        = "../../shared_services/sonatype-nexus/terraform"
   tre_id                                        = var.tre_id
   location                                      = var.location
-  storage_account_name                          = module.storage.storage_account_name
-  storage_account_primary_access_key            = module.storage.storage_account_access_key
-  shared_subnet_id                              = module.network.shared_subnet_id
-  web_app_subnet_id                             = module.network.web_app_subnet_id
-  private_dns_zone_azurewebsites_id             = module.network.private_dns_zone_azurewebsites_id
-  log_analytics_workspace_id                    = module.azure_monitor.log_analytics_workspace_id
-  core_app_service_plan_id                      = module.api-webapp.core_app_service_plan_id
-  core_application_insights_instrumentation_key = module.azure_monitor.app_insights_instrumentation_key
-  firewall_name                                 = module.firewall.firewall_name
-  firewall_resource_group_name                  = module.firewall.firewall_resource_group_name
-  web_app_subnet_address_prefixes               = module.network.web_app_subnet_address_prefixes
 
   depends_on = [
     module.network,

--- a/templates/shared_services/gitea/terraform/firewall.tf
+++ b/templates/shared_services/gitea/terraform/firewall.tf
@@ -1,7 +1,7 @@
 resource "azurerm_firewall_application_rule_collection" "web_app_subnet_gitea" {
   name                = "arc-web_app_subnet_gitea"
-  azure_firewall_name = var.firewall_name
-  resource_group_name = var.firewall_resource_group_name
+  azure_firewall_name = data.azurerm_firewall.fw.name
+  resource_group_name = data.azurerm_firewall.fw.resource_group_name
   priority            = 103
   action              = "Allow"
 
@@ -17,6 +17,8 @@ resource "azurerm_firewall_application_rule_collection" "web_app_subnet_gitea" {
     }
 
     target_fqdns     = local.gitea_allowed_fqdns_list
-    source_addresses = var.web_app_subnet_address_prefixes
+    source_addresses = data.azurerm_subnet.web_app.address_prefixes
+
   }
 }
+

--- a/templates/shared_services/gitea/terraform/firewall.tf
+++ b/templates/shared_services/gitea/terraform/firewall.tf
@@ -18,7 +18,5 @@ resource "azurerm_firewall_application_rule_collection" "web_app_subnet_gitea" {
 
     target_fqdns     = local.gitea_allowed_fqdns_list
     source_addresses = data.azurerm_subnet.web_app.address_prefixes
-
   }
 }
-

--- a/templates/shared_services/gitea/terraform/gitea-webapp.tf
+++ b/templates/shared_services/gitea/terraform/gitea-webapp.tf
@@ -20,11 +20,11 @@ resource "azurerm_app_service" "gitea" {
   name                = local.webapp_name
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  app_service_plan_id = var.core_app_service_plan_id
+  app_service_plan_id = data.azurerm_app_service_plan.core.id
   https_only          = true
 
   app_settings = {
-    APPINSIGHTS_INSTRUMENTATIONKEY      = var.core_application_insights_instrumentation_key
+    APPINSIGHTS_INSTRUMENTATIONKEY      = data.azurerm_application_insights.core.instrumentation_key
     WEBSITES_PORT                       = "3000"
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
 
@@ -57,7 +57,7 @@ resource "azurerm_app_service" "gitea" {
   }
 
   site_config {
-    linux_fx_version                     = "DOCKER|${var.docker_registry_server}/microsoft/azuretre/gitea:${local.version}"
+    linux_fx_version                     = "DOCKER|${data.azurerm_container_registry.mgmt_acr.login_server}/microsoft/azuretre/gitea:${local.version}"
     remote_debugging_enabled             = false
     scm_use_main_ip_restriction          = true
     acr_use_managed_identity_credentials = true
@@ -86,9 +86,9 @@ resource "azurerm_app_service" "gitea" {
   storage_account {
     name         = "gitea-data"
     type         = "AzureFiles"
-    account_name = var.storage_account_name
+    account_name = data.azurerm_storage_account.gitea.name
 
-    access_key = var.storage_account_primary_access_key
+    access_key = data.azurerm_storage_account.gitea.primary_access_key
     share_name = azurerm_storage_share.gitea.name
 
     mount_path = "/data"
@@ -116,7 +116,7 @@ resource "azurerm_private_endpoint" "gitea_private_endpoint" {
   name                = "pe-${local.webapp_name}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  subnet_id           = var.shared_subnet_id
+  subnet_id           = data.azurerm_subnet.shared.id
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.gitea.id
@@ -127,7 +127,7 @@ resource "azurerm_private_endpoint" "gitea_private_endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.azurewebsites.net"
-    private_dns_zone_ids = [var.private_dns_zone_azurewebsites_id]
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.azurewebsites.id]
   }
 
   lifecycle { ignore_changes = [tags] }
@@ -135,13 +135,13 @@ resource "azurerm_private_endpoint" "gitea_private_endpoint" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "gitea-integrated-vnet" {
   app_service_id = azurerm_app_service.gitea.id
-  subnet_id      = var.web_app_subnet_id
+  subnet_id      = data.azurerm_subnet.web_app.id
 }
 
 resource "azurerm_monitor_diagnostic_setting" "webapp_gitea" {
   name                       = "diag-${var.tre_id}"
   target_resource_id         = azurerm_app_service.gitea.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.tre.id
 
   log {
     category = "AppServiceHTTPLogs"
@@ -234,7 +234,7 @@ resource "azurerm_monitor_diagnostic_setting" "webapp_gitea" {
 }
 
 resource "azurerm_key_vault_access_policy" "gitea_policy" {
-  key_vault_id = var.keyvault_id
+  key_vault_id = data.azurerm_key_vault.keyvault.id
   tenant_id    = azurerm_user_assigned_identity.gitea_id.tenant_id
   object_id    = azurerm_user_assigned_identity.gitea_id.principal_id
 
@@ -244,7 +244,7 @@ resource "azurerm_key_vault_access_policy" "gitea_policy" {
 resource "azurerm_key_vault_secret" "gitea_password" {
   name         = "${local.webapp_name}-admin-password"
   value        = random_password.gitea_passwd.result
-  key_vault_id = var.keyvault_id
+  key_vault_id = data.azurerm_key_vault.keyvault.id
 
   depends_on = [
     azurerm_key_vault_access_policy.gitea_policy
@@ -253,12 +253,12 @@ resource "azurerm_key_vault_secret" "gitea_password" {
 
 resource "azurerm_storage_share" "gitea" {
   name                 = "gitea-data"
-  storage_account_name = var.storage_account_name
+  storage_account_name = data.azurerm_storage_account.gitea.name
   quota                = var.gitea_storage_limit
 }
 
 resource "azurerm_role_assignment" "gitea_acrpull_role" {
-  scope                = var.acr_id
+  scope                = data.azurerm_container_registry.mgmt_acr.id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.gitea_id.principal_id
 }
@@ -266,6 +266,9 @@ resource "azurerm_role_assignment" "gitea_acrpull_role" {
 # unfortunately we have to tell the webapp to use the user-assigned identity when accessing key-vault, no direct tf way.
 resource "null_resource" "webapp_vault_access_identity" {
   provisioner "local-exec" {
-    command = "az rest --method PATCH --uri \"${azurerm_app_service.gitea.id}?api-version=2021-01-01\" --body \"{'properties':{'keyVaultReferenceIdentity':'${azurerm_user_assigned_identity.gitea_id.id}'}}\""
+    command = <<EOT
+      az login --service-principal --username ${var.arm_client_id} --password ${var.arm_client_secret} --tenant ${var.arm_tenant_id}
+      az rest --method PATCH --uri "${azurerm_app_service.gitea.id}?api-version=2021-01-01" --body "{'properties':{'keyVaultReferenceIdentity':'${azurerm_user_assigned_identity.gitea_id.id}'}}"
+    EOT
   }
 }

--- a/templates/shared_services/gitea/terraform/gitea-webapp.tf
+++ b/templates/shared_services/gitea/terraform/gitea-webapp.tf
@@ -267,7 +267,6 @@ resource "azurerm_role_assignment" "gitea_acrpull_role" {
 resource "null_resource" "webapp_vault_access_identity" {
   provisioner "local-exec" {
     command = <<EOT
-      az login --service-principal --username ${var.arm_client_id} --password ${var.arm_client_secret} --tenant ${var.arm_tenant_id}
       az rest --method PATCH --uri "${azurerm_app_service.gitea.id}?api-version=2021-01-01" --body "{'properties':{'keyVaultReferenceIdentity':'${azurerm_user_assigned_identity.gitea_id.id}'}}"
     EOT
   }

--- a/templates/shared_services/gitea/terraform/locals.tf
+++ b/templates/shared_services/gitea/terraform/locals.tf
@@ -2,6 +2,9 @@ locals {
   core_vnet                = "vnet-${var.tre_id}"
   core_resource_group_name = "rg-${var.tre_id}"
   webapp_name              = "gitea-${var.tre_id}"
+  firewall_name            = "fw-${var.tre_id}"
+  storage_account_name     = "stg${var.tre_id}"
+  keyvault_name            = "kv-${var.tre_id}"
   version                  = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
   gitea_allowed_fqdns_list = distinct(compact(split(",", replace(var.gitea_allowed_fqdns, " ", ""))))
 }

--- a/templates/shared_services/gitea/terraform/mysql.tf
+++ b/templates/shared_services/gitea/terraform/mysql.tf
@@ -38,7 +38,7 @@ resource "azurerm_private_endpoint" "private-endpoint" {
   name                = "pe-${azurerm_mysql_server.gitea.name}"
   location            = var.location
   resource_group_name = local.core_resource_group_name
-  subnet_id           = var.shared_subnet_id
+  subnet_id           = data.azurerm_subnet.shared.id
 
   private_service_connection {
     private_connection_resource_id = azurerm_mysql_server.gitea.id
@@ -49,7 +49,7 @@ resource "azurerm_private_endpoint" "private-endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.mysql.database.azure.com"
-    private_dns_zone_ids = [var.private_dns_zone_mysql_id]
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.mysql.id]
   }
 
   lifecycle { ignore_changes = [tags] }
@@ -58,7 +58,7 @@ resource "azurerm_private_endpoint" "private-endpoint" {
 resource "azurerm_key_vault_secret" "db_password" {
   name         = "${azurerm_mysql_server.gitea.name}-password"
   value        = random_password.password.result
-  key_vault_id = var.keyvault_id
+  key_vault_id = data.azurerm_key_vault.keyvault.id
 
   depends_on = [
     azurerm_key_vault_access_policy.gitea_policy

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -8,52 +8,10 @@ variable "location" {
   description = "Azure location (region) for deployment of core TRE services"
 }
 
-variable "docker_registry_server" {
+variable "gitea_allowed_fqdns" {
   type        = string
-  description = "Docker registry server"
-}
-
-variable "keyvault_id" {
-  type = string
-}
-
-variable "acr_id" {
-  type = string
-}
-
-variable "storage_account_name" {
-  type        = string
-  description = "The name of the storage account to use"
-}
-
-variable "storage_account_primary_access_key" {
-  type        = string
-  description = "The Primary Access Key for the storage account"
-}
-
-variable "shared_subnet_id" {
-  type        = string
-  description = "The ID of the shared subnet in which to create a private endpoint"
-}
-
-variable "web_app_subnet_id" {
-  type        = string
-  description = "The ID of the Web App subnet to connect to"
-}
-
-variable "web_app_subnet_address_prefixes" {
-  type        = list(string)
-  description = "List of address prefixes for the Web App subnet"
-}
-
-variable "private_dns_zone_azurewebsites_id" {
-  type        = string
-  description = "The ID of the private DNS zone to use for the private endpoint"
-}
-
-variable "private_dns_zone_mysql_id" {
-  type        = string
-  description = "The ID of the private DNS zone for MySQL"
+  description = "comma seperated string of allowed FQDNs for Gitea"
+  default     = "github.com, www.github.com, api.github.com, git-lfs.github.com, *githubusercontent.com"
 }
 
 variable "gitea_storage_limit" {
@@ -62,33 +20,27 @@ variable "gitea_storage_limit" {
   default     = 1024
 }
 
-variable "log_analytics_workspace_id" {
+variable "mgmt_resource_group_name" {
   type        = string
-  description = "ID of the Log Analytics workspace for TRE"
+  description = "Resource group name for TRE management"
 }
 
-variable "core_app_service_plan_id" {
+variable "acr_name" {
   type        = string
-  description = "Name of the App Service plan"
+  description = "Name of Azure Container Registry"
 }
 
-variable "core_application_insights_instrumentation_key" {
+variable "arm_tenant_id" {
   type        = string
-  description = "Instrumentation key for the Core Application Insights"
+  description = "ARM_TENANT_ID for the user / service principal that is installing Gitea"
 }
 
-variable "gitea_allowed_fqdns" {
+variable "arm_client_id" {
   type        = string
-  description = "comma seperated string of allowed FQDNs for Gitea"
-  default     = "github.com, www.github.com, api.github.com, git-lfs.github.com, *githubusercontent.com"
+  description = "ARM_CLIENT_ID for the user / service principal that is installing Gitea"
 }
 
-variable "firewall_name" {
+variable "arm_client_secret" {
   type        = string
-  description = "Name of the firewall to connect to"
-}
-
-variable "firewall_resource_group_name" {
-  type        = string
-  description = "Name of the resource group containing the firewall resource"
+  description = "ARM_CLIENT_SECRET for the user / service principal that is installing Gitea"
 }

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -29,18 +29,3 @@ variable "acr_name" {
   type        = string
   description = "Name of Azure Container Registry"
 }
-
-variable "arm_tenant_id" {
-  type        = string
-  description = "ARM_TENANT_ID for the user / service principal that is installing Gitea"
-}
-
-variable "arm_client_id" {
-  type        = string
-  description = "ARM_CLIENT_ID for the user / service principal that is installing Gitea"
-}
-
-variable "arm_client_secret" {
-  type        = string
-  description = "ARM_CLIENT_SECRET for the user / service principal that is installing Gitea"
-}

--- a/templates/shared_services/sonatype-nexus/terraform/data.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/data.tf
@@ -18,6 +18,11 @@ data "azurerm_virtual_network" "core" {
   resource_group_name = local.core_resource_group_name
 }
 
+data "azurerm_storage_account" "nexus" {
+  name                = local.storage_account_name
+  resource_group_name = local.core_resource_group_name
+}
+
 data "azurerm_subnet" "shared" {
   resource_group_name  = local.core_resource_group_name
   virtual_network_name = local.core_vnet
@@ -25,9 +30,9 @@ data "azurerm_subnet" "shared" {
 }
 
 data "azurerm_subnet" "web_app" {
-  resource_group_name  = local.core_resource_group_name
-  virtual_network_name = local.core_vnet
   name                 = "WebAppSubnet"
+  virtual_network_name = "vnet-${var.tre_id}"
+  resource_group_name  = local.core_resource_group_name
 }
 
 data "azurerm_firewall" "fw" {
@@ -35,31 +40,7 @@ data "azurerm_firewall" "fw" {
   resource_group_name = local.core_resource_group_name
 }
 
-data "azurerm_private_dns_zone" "mysql" {
-  name                = "privatelink.mysql.database.azure.com"
-  resource_group_name = local.core_resource_group_name
-}
-
 data "azurerm_private_dns_zone" "azurewebsites" {
   name                = "privatelink.azurewebsites.net"
-  resource_group_name = local.core_resource_group_name
-}
-
-data "azurerm_storage_account" "gitea" {
-  name                = local.storage_account_name
-  resource_group_name = local.core_resource_group_name
-}
-
-data "local_file" "version" {
-  filename = "${path.module}/../version.txt"
-}
-
-data "azurerm_container_registry" "mgmt_acr" {
-  name                = var.acr_name
-  resource_group_name = var.mgmt_resource_group_name
-}
-
-data "azurerm_key_vault" "keyvault" {
-  name                = local.keyvault_name
   resource_group_name = local.core_resource_group_name
 }

--- a/templates/shared_services/sonatype-nexus/terraform/firewall.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/firewall.tf
@@ -18,6 +18,5 @@ resource "azurerm_firewall_application_rule_collection" "web_app_subnet_nexus" {
 
     target_fqdns     = local.nexus_allowed_fqdns_list
     source_addresses = data.azurerm_subnet.web_app.address_prefixes
-
   }
 }

--- a/templates/shared_services/sonatype-nexus/terraform/firewall.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/firewall.tf
@@ -1,7 +1,7 @@
 resource "azurerm_firewall_application_rule_collection" "web_app_subnet_nexus" {
   name                = "arc-web_app_subnet_nexus"
-  azure_firewall_name = var.firewall_name
-  resource_group_name = var.firewall_resource_group_name
+  azure_firewall_name = data.azurerm_firewall.fw.name
+  resource_group_name = data.azurerm_firewall.fw.resource_group_name
   priority            = 104
   action              = "Allow"
 
@@ -17,6 +17,7 @@ resource "azurerm_firewall_application_rule_collection" "web_app_subnet_nexus" {
     }
 
     target_fqdns     = local.nexus_allowed_fqdns_list
-    source_addresses = var.web_app_subnet_address_prefixes
+    source_addresses = data.azurerm_subnet.web_app.address_prefixes
+
   }
 }

--- a/templates/shared_services/sonatype-nexus/terraform/locals.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
   core_vnet                = "vnet-${var.tre_id}"
   core_resource_group_name = "rg-${var.tre_id}"
+  firewall_name            = "fw-${var.tre_id}"
+  storage_account_name     = "stg${var.tre_id}"
   nexus_allowed_fqdns_list = distinct(compact(split(",", replace(var.nexus_allowed_fqdns, " ", ""))))
-
 }

--- a/templates/shared_services/sonatype-nexus/terraform/variables.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/variables.tf
@@ -8,69 +8,14 @@ variable "location" {
   description = "Azure location (region) for deployment of core TRE services"
 }
 
-variable "storage_account_name" {
-  type        = string
-  description = "The name of the storage account to use"
-}
-
-variable "storage_account_primary_access_key" {
-  type        = string
-  description = "The Primary Access Key for the storage account"
-}
-
 variable "nexus_storage_limit" {
   type        = number
   description = "Space allocated in GB for the Nexus data in Azure Files Share"
   default     = 1024
 }
 
-variable "shared_subnet_id" {
-  type        = string
-  description = "The ID of the shared subnet in which to create a private endpoint"
-}
-
-variable "web_app_subnet_id" {
-  type        = string
-  description = "The ID of the web app subnet to connect to"
-}
-
-variable "private_dns_zone_azurewebsites_id" {
-  type        = string
-  description = "The ID of the private DNS zone to use for the private endpoint"
-}
-
-variable "log_analytics_workspace_id" {
-  type        = string
-  description = "ID of the Log Analytics workspace for TRE"
-}
-
-variable "core_app_service_plan_id" {
-  type        = string
-  description = "Name of the App Service plan"
-}
-
-variable "core_application_insights_instrumentation_key" {
-  type        = string
-  description = "Instrumentation key for the Core Application Insights"
-}
-
 variable "nexus_allowed_fqdns" {
   type        = string
   description = "comma seperated string of allowed FQDNs for Nexus"
   default     = "*pypi.org"
-}
-
-variable "firewall_name" {
-  type        = string
-  description = "Name of the firewall to connect to"
-}
-
-variable "firewall_resource_group_name" {
-  type        = string
-  description = "Name of the firewall to connect to"
-}
-
-variable "web_app_subnet_address_prefixes" {
-  type        = list(string)
-  description = "List of address prefixes for the Web App subnet"
 }

--- a/templates/shared_services/sonatype-nexus/terraform/webapp.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/webapp.tf
@@ -199,7 +199,7 @@ resource "null_resource" "upload_nexus_props" {
       --name etc --share-name  ${azurerm_storage_share.nexus.name} \
       --account-name ${data.azurerm_storage_account.nexus.name} \
       --account-key ${data.azurerm_storage_account.nexus.primary_access_key} && \
-      az storage file upload --source /cnab/app/nexus.properties \
+      az storage file upload --source ../../shared_services/sonatype-nexus/nexus.properties \
       --path etc --share-name  ${azurerm_storage_share.nexus.name} \
       --account-name ${data.azurerm_storage_account.nexus.name} \
       --account-key ${data.azurerm_storage_account.nexus.primary_access_key}

--- a/templates/shared_services/sonatype-nexus/terraform/webapp.tf
+++ b/templates/shared_services/sonatype-nexus/terraform/webapp.tf
@@ -2,11 +2,11 @@ resource "azurerm_app_service" "nexus" {
   name                = "nexus-${var.tre_id}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  app_service_plan_id = var.core_app_service_plan_id
+  app_service_plan_id = data.azurerm_app_service_plan.core.id
   https_only          = true
 
   app_settings = {
-    APPINSIGHTS_INSTRUMENTATIONKEY      = var.core_application_insights_instrumentation_key
+    APPINSIGHTS_INSTRUMENTATIONKEY      = data.azurerm_application_insights.core.instrumentation_key
     WEBSITES_PORT                       = "8081" # nexus web-ui listens here
     WEBSITES_CONTAINER_START_TIME_LIMIT = "900"  # nexus takes a while to start-up
     WEBSITE_VNET_ROUTE_ALL              = 1
@@ -38,9 +38,9 @@ resource "azurerm_app_service" "nexus" {
   storage_account {
     name         = "nexus-data"
     type         = "AzureFiles"
-    account_name = var.storage_account_name
+    account_name = data.azurerm_storage_account.nexus.name
 
-    access_key = var.storage_account_primary_access_key
+    access_key = data.azurerm_storage_account.nexus.primary_access_key
     share_name = azurerm_storage_share.nexus.name
     mount_path = "/nexus-data"
   }
@@ -68,7 +68,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
   name                = "pe-nexus-${var.tre_id}"
   resource_group_name = local.core_resource_group_name
   location            = var.location
-  subnet_id           = var.shared_subnet_id
+  subnet_id           = data.azurerm_subnet.shared.id
 
   private_service_connection {
     private_connection_resource_id = azurerm_app_service.nexus.id
@@ -79,7 +79,7 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
 
   private_dns_zone_group {
     name                 = "privatelink.azurewebsites.net"
-    private_dns_zone_ids = [var.private_dns_zone_azurewebsites_id]
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.azurewebsites.id]
   }
 
   lifecycle { ignore_changes = [tags] }
@@ -87,13 +87,13 @@ resource "azurerm_private_endpoint" "nexus_private_endpoint" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "nexus-integrated-vnet" {
   app_service_id = azurerm_app_service.nexus.id
-  subnet_id      = var.web_app_subnet_id
+  subnet_id      = data.azurerm_subnet.web_app.id
 }
 
 resource "azurerm_monitor_diagnostic_setting" "nexus" {
   name                       = "diag-${var.tre_id}"
   target_resource_id         = azurerm_app_service.nexus.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.tre.id
 
   log {
     category = "AppServiceHTTPLogs"
@@ -187,7 +187,7 @@ resource "azurerm_monitor_diagnostic_setting" "nexus" {
 
 resource "azurerm_storage_share" "nexus" {
   name                 = "nexus-data"
-  storage_account_name = var.storage_account_name
+  storage_account_name = data.azurerm_storage_account.nexus.name
   quota                = var.nexus_storage_limit
 }
 
@@ -197,12 +197,12 @@ resource "null_resource" "upload_nexus_props" {
     command = <<EOT
       az storage directory create \
       --name etc --share-name  ${azurerm_storage_share.nexus.name} \
-      --account-name ${var.storage_account_name} \
-      --account-key ${var.storage_account_primary_access_key} && \
-      az storage file upload --source ../../shared_services/sonatype-nexus/nexus.properties \
+      --account-name ${data.azurerm_storage_account.nexus.name} \
+      --account-key ${data.azurerm_storage_account.nexus.primary_access_key} && \
+      az storage file upload --source /cnab/app/nexus.properties \
       --path etc --share-name  ${azurerm_storage_share.nexus.name} \
-      --account-name ${var.storage_account_name} \
-      --account-key ${var.storage_account_primary_access_key}
+      --account-name ${data.azurerm_storage_account.nexus.name} \
+      --account-key ${data.azurerm_storage_account.nexus.primary_access_key}
       EOT
   }
 


### PR DESCRIPTION
# PR for issue https://github.com/microsoft/AzureTRE/issues/1177
# NOTE: this PR is base for https://github.com/tanya-borisova/AzureTRE/pull/1 

## What is being addressed

In order to prepare extraction of Gitea and Nexus to Porter bundles, `variable` inputs need to be changed to `data` inputs, to simplify configuration of the Porter bundles. 

## How is this addressed

- Most variables are moved back to data inputs
- **NOTE**: Some of the parameters are hardcoded in `locals` (e.g. `firewall_name`, `storage_name`, etc). I considered passing them as env variables first, but our env configuration is already fairly complicated. Happy to discuss this point though. 