### PR TITLE
Add config to save dev container bash history to the mounted volume

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,3 +68,9 @@ RUN wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/
   && chmod +x /usr/local/bin/yq
 
 USER $USERNAME
+
+# Save command line history 
+RUN echo "export HISTFILE=$HOME/commandhistory/.bash_history" >> "$HOME/.bashrc" \
+    && echo "export PROMPT_COMMAND='history -a'" >> "$HOME/.bashrc" \
+    && mkdir -p $HOME/commandhistory \
+    && touch $HOME/commandhistory/.bash_history


### PR DESCRIPTION
This change persists bash history across dev container rebuilds.

The `commandhistory` volume was mounted in `devcontainer.json`, but the container wasn't configured to use it for bash history.