### PR TITLE
Fixing missing Resource Group

### DIFF
--- a/templates/core/terraform/json-to-env.sh
+++ b/templates/core/terraform/json-to-env.sh
@@ -7,7 +7,7 @@ jq -r '
     [
         {
             "path": "core_resource_group_name",
-            "env_var": "RESOURCE_GROUP"
+            "env_var": "RESOURCE_GROUP_NAME"
         },
         {
             "path": "app_gateway_name",
@@ -24,6 +24,22 @@ jq -r '
         {
             "path": "azure_tre_fqdn",
             "env_var": "FQDN"
+        },
+        {
+            "path": "service_bus_resource_id",
+            "env_var": "SERVICE_BUS_RESOURCE_ID"
+        },
+        {
+            "path": "state_store_resource_id",
+            "env_var": "STATE_STORE_RESOURCE_ID"
+        },
+        {
+            "path": "state_store_account_name",
+            "env_var": "COSMOSDB_ACCOUNT_NAME"
+        },
+        {
+            "path": "state_store_endpoint",
+            "env_var": "STATE_STORE_ENDPOINT"
         }
     ]
         as $env_vars_to_extract

--- a/templates/core/terraform/keyvault/keyvault.tf
+++ b/templates/core/terraform/keyvault/keyvault.tf
@@ -8,7 +8,7 @@ resource "azurerm_key_vault" "kv" {
   sku_name                 = "standard"
   purge_protection_enabled = var.debug == "true" ? false : true
 
-  lifecycle { ignore_changes = [tags] }
+  lifecycle { ignore_changes = [access_policy, tags] }
 }
 
 resource "azurerm_key_vault_access_policy" "deployer" {
@@ -19,7 +19,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover"]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Purge", "Recover"]
   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover"]
-  storage_permissions     = ["Get", "List", "Update", "Delete"]
+  storage_permissions     = ["Get", "List", "Update", "Delete", "Recover"]
 }
 
 resource "azurerm_key_vault_access_policy" "managed_identity" {

--- a/templates/core/terraform/keyvault/keyvault.tf
+++ b/templates/core/terraform/keyvault/keyvault.tf
@@ -19,7 +19,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover"]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Purge", "Recover"]
   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover"]
-  storage_permissions     = ["Get", "List", "Update", "Delete", "Recover"]
+  storage_permissions     = ["Get", "List", "Update", "Delete"]
 }
 
 resource "azurerm_key_vault_access_policy" "managed_identity" {

--- a/templates/core/terraform/outputs.tf
+++ b/templates/core/terraform/outputs.tf
@@ -21,3 +21,19 @@ output "static_web_storage" {
 output "keyvault_name" {
   value = module.keyvault.keyvault_name
 }
+
+output "service_bus_resource_id" {
+  value = module.servicebus.id
+}
+
+output "state_store_resource_id" {
+  value = module.state-store.id
+}
+
+output "state_store_endpoint" {
+  value = module.state-store.endpoint
+}
+
+output "state_store_account_name" {
+  value = module.state-store.cosmosdb_account_name
+}

--- a/templates/core/terraform/scripts/letsencrypt.sh
+++ b/templates/core/terraform/scripts/letsencrypt.sh
@@ -13,7 +13,10 @@ IPADDR=$(curl ipecho.net/plain; echo)
 # The storage account is protected by network rules
 # The rules need to be temporarily lifted so that the index.html file, if required, and certificate can be uploaded
 echo "Creating network rule on storage account ${STORAGE_ACCOUNT} for $IPADDR"
-az storage account network-rule add --account-name "${STORAGE_ACCOUNT}" --ip-address $IPADDR
+az storage account network-rule add \
+  --account-name "${STORAGE_ACCOUNT}" \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --ip-address $IPADDR
 echo "Waiting for network rule to take effect"
 sleep 30s
 echo "Created network rule on storage account"
@@ -89,13 +92,13 @@ if [[ -n ${KEYVAULT} ]]; then
         | jq -r '.sid')
 
     az network application-gateway ssl-cert update \
-        --resource-group "${RESOURCE_GROUP}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
         --gateway-name "${APPLICATION_GATEWAY}" \
         --name 'cert-primary' \
         --key-vault-secret-id "${sid}"
 else
     az network application-gateway ssl-cert update \
-        --resource-group "${RESOURCE_GROUP}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
         --gateway-name "${APPLICATION_GATEWAY}" \
         --name 'letsencrypt' \
         --cert-file "${CERT_DIR}/aci.pfx" \
@@ -103,5 +106,8 @@ else
 fi
 
 echo "Removing network rule on storage account"
-az storage account network-rule remove --account-name ${STORAGE_ACCOUNT} --ip-address ${IPADDR}
+az storage account network-rule remove \
+  --account-name ${STORAGE_ACCOUNT} \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --ip-address ${IPADDR}
 echo "Removed network rule on storage account"

--- a/templates/core/terraform/scripts/upload_static_web.sh
+++ b/templates/core/terraform/scripts/upload_static_web.sh
@@ -13,7 +13,10 @@ IPADDR=$(curl ipecho.net/plain; echo)
 # The storage account is protected by network rules
 # The rules need to be temporarily lifted so that the index.html file, if required, and certificate can be uploaded
 echo "Creating network rule on storage account ${STORAGE_ACCOUNT} for $IPADDR"
-az storage account network-rule add --account-name "${STORAGE_ACCOUNT}" --ip-address $IPADDR
+az storage account network-rule add \
+  --account-name "${STORAGE_ACCOUNT}" \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --ip-address $IPADDR
 echo "Waiting for network rule to take effect"
 sleep 30s
 echo "Created network rule on storage account"
@@ -29,5 +32,8 @@ az storage blob upload-batch \
     --only-show-errors
 
 echo "Removing network rule on storage account"
-az storage account network-rule remove --account-name ${STORAGE_ACCOUNT} --ip-address ${IPADDR}
+az storage account network-rule remove \
+  --account-name ${STORAGE_ACCOUNT} \
+  --resource-group "${RESOURCE_GROUP_NAME}" \
+  --ip-address ${IPADDR}
 echo "Removed network rule on storage account"


### PR DESCRIPTION
# PR for issue 
#1233 

## What is being addressed
We were not explicitly setting the RESOURCE_GROUP_NAME in the letsencrypt and uploadstaticweb.sh

## How is this addressed
- I have also renamed the variable so that it can be re-used in other parts of the developer experience.
- There are also further ServiceBus outputs that are needed in scripts