### PR TITLE
Setup debug experience for api development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,7 @@ terraform.rc
 **/http-client.private.env.json
 
 # vscode
-.vscode/
+.vscode/settings.json
 
 # node
 node_modules
@@ -200,3 +200,4 @@ templates/core/terraform/scripts/validation.txt
 templates/core/terraform/plan
 e2e_tests/pytest_e2e.xml
 e2e_tests/workspace_id.txt
+validation.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  "configurations": [
+    {
+      "name": "TRE API",
+      "type": "python",
+      "module": "uvicorn",
+      "request": "launch",
+      "args": [
+        "main:app",
+        "--reload",
+        "--host",
+        "::",
+        "--port",
+        "8000"
+      ],
+      "justMyCode": false,
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/templates/core/tre.env",
+      "cwd": "${workspaceFolder}/api_app"
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -251,3 +251,11 @@ test-e2e:
 	export WORKSPACE_SCOPE="api://${TEST_WORKSPACE_APP_ID}/user_impersonation" && \
 	cd e2e_tests && \
 	python -m pytest -m smoke --junit-xml pytest_e2e.xml
+
+setup-local-debugging:
+	echo -e "\n\e[34m»»» 🧩 \e[96mSetting up the ability to debug the API\e[0m..." \
+	&& . ./devops/scripts/check_dependencies.sh nodocker \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
+	&& pushd ./templates/core/terraform/ > /dev/null && . ./outputs.sh && popd > /dev/null \
+	&& . ./devops/scripts/load_env.sh ./templates/core/tre.env \
+	&& . ./devops/scripts/setup_local_api_debugging.sh

--- a/devops/scripts/setup_local_api_debugging.sh
+++ b/devops/scripts/setup_local_api_debugging.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+: ${TRE_ID?"You have not set you TRE_ID in ./templates/core/.env"}
+: ${RESOURCE_GROUP_NAME?"Check RESOURCE_GROUP_NAME is defined in ./templates/core/tre.env"}
+: ${SERVICE_BUS_RESOURCE_ID?"Check SERVICE_BUS_RESOURCE_ID is defined in ./templates/core/tre.env"}
+: ${STATE_STORE_RESOURCE_ID?"Check STATE_STORE_RESOURCE_ID is defined in ./templates/core/tre.env"}
+: ${COSMOSDB_ACCOUNT_NAME?"Check COSMOSDB_ACCOUNT_NAME is defined in ./templates/core/tre.env"}
+
+export SERVICE_BUS_NAMESPACE="sb-${TRE_ID}"
+IPADDR=$(curl ipecho.net/plain; echo)
+
+echo "Adding local IP Address to ${COSMOSDB_ACCOUNT_NAME}. This may take a while . . . "
+az cosmosdb update \
+  --name ${COSMOSDB_ACCOUNT_NAME} \
+  --resource-group ${RESOURCE_GROUP_NAME} \
+  --ip-range-filter ${IPADDR}
+
+echo "Adding local IP Address to ${SERVICE_BUS_NAMESPACE}."
+az servicebus namespace network-rule add \
+  --resource-group ${RESOURCE_GROUP_NAME} \
+  --namespace-name ${SERVICE_BUS_NAMESPACE} \
+  --ip-address ${IPADDR} \
+  --action Allow
+
+SERVICE_PRINCIPAL_SECRET=$(az ad sp create-for-rbac --name "${TRE_ID}_debug_spn" -o json)
+export SERVICE_PRINCIPAL_ID=$(echo "$SERVICE_PRINCIPAL_SECRET" | jq -r '.appId')
+export SERVICE_PRINCIPAL_SECRET=$(echo "$SERVICE_PRINCIPAL_SECRET" | jq -r '.password')
+
+az role assignment create \
+    --role "Azure Service Bus Data Sender" \
+    --assignee ${SERVICE_PRINCIPAL_ID} \
+    --scope ${SERVICE_BUS_RESOURCE_ID}
+
+az role assignment create \
+    --role "Azure Service Bus Data Receiver" \
+    --assignee ${SERVICE_PRINCIPAL_ID} \
+    --scope ${SERVICE_BUS_RESOURCE_ID}
+
+az role assignment create \
+    --role "Contributor" \
+    --assignee ${SERVICE_PRINCIPAL_ID} \
+    --scope ${STATE_STORE_RESOURCE_ID}
+
+echo "Adding secrets to /workspaces/AzureTRE/templates/core/tre.env"
+echo "AZURE_CLIENT_ID=${SERVICE_PRINCIPAL_ID}" >> ./templates/core/tre.env
+echo "AZURE_CLIENT_SECRET=${SERVICE_PRINCIPAL_SECRET}" >> ./templates/core/tre.env

--- a/devops/scripts/setup_local_api_debugging.sh
+++ b/devops/scripts/setup_local_api_debugging.sh
@@ -7,7 +7,7 @@ set -e
 : ${STATE_STORE_RESOURCE_ID?"Check STATE_STORE_RESOURCE_ID is defined in ./templates/core/tre.env"}
 : ${COSMOSDB_ACCOUNT_NAME?"Check COSMOSDB_ACCOUNT_NAME is defined in ./templates/core/tre.env"}
 
-export SERVICE_BUS_NAMESPACE="sb-${TRE_ID}"
+SERVICE_BUS_NAMESPACE="sb-${TRE_ID}"
 IPADDR=$(curl ipecho.net/plain; echo)
 
 echo "Adding local IP Address to ${COSMOSDB_ACCOUNT_NAME}. This may take a while . . . "

--- a/docs/tre-developers/api.md
+++ b/docs/tre-developers/api.md
@@ -53,7 +53,7 @@ az cosmosdb create -n $COSMOS_NAME -g $RESOURCE_GROUP --locations regionName=$LO
 az cosmosdb sql database create -a $COSMOS_NAME -g $RESOURCE_GROUP -n $COSMOS_DB_NAME
 ```
 
-[Create a service principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli) and assign it permissions to access Service Bus:
+[Create a service principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli) and assign it permissions to access Service Bus and Cosmos:
 
 ```bash
 az ad sp create-for-rbac --name <service principal name>
@@ -70,6 +70,11 @@ az role assignment create \
     --role "Azure Service Bus Data Receiver" \
     --assignee $SERVICE_PRINCIPAL_ID \
     --scope /subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.ServiceBus/namespaces/$SERVICE_BUS_NAMESPACE
+
+az role assignment create \
+    --role "Contributor" \
+    --assignee $SERVICE_PRINCIPAL_ID \
+    --scope /subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$COSMOS_NAME
 ```
 
 !!! caution

--- a/templates/core/terraform/json-to-env.sh
+++ b/templates/core/terraform/json-to-env.sh
@@ -10,6 +10,10 @@ jq -r '
             "env_var": "RESOURCE_GROUP_NAME"
         },
         {
+            "path": "core_resource_group_location",
+            "env_var": "RESOURCE_LOCATION"
+        },
+        {
             "path": "app_gateway_name",
             "env_var": "APPLICATION_GATEWAY"
         },
@@ -30,6 +34,14 @@ jq -r '
             "env_var": "SERVICE_BUS_RESOURCE_ID"
         },
         {
+            "path": "service_bus_workspace_queue",
+            "env_var": "SERVICE_BUS_RESOURCE_REQUEST_QUEUE"
+        },
+        {
+            "path": "service_bus_deployment_status_queue",
+            "env_var": "SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE"
+        },
+        {
             "path": "state_store_resource_id",
             "env_var": "STATE_STORE_RESOURCE_ID"
         },
@@ -40,6 +52,14 @@ jq -r '
         {
             "path": "state_store_endpoint",
             "env_var": "STATE_STORE_ENDPOINT"
+        },
+        {
+            "path": "app_insights_instrumentation_key",
+            "env_var": "APPINSIGHTS_INSTRUMENTATIONKEY"
+        },
+        {
+            "path": "app_insights_connection_string",
+            "env_var": "APPLICATIONINSIGHTS_CONNECTION_STRING"
         }
     ]
         as $env_vars_to_extract

--- a/templates/core/terraform/outputs.sh
+++ b/templates/core/terraform/outputs.sh
@@ -16,3 +16,16 @@ fi
 
 # Now create an .env file
 ./json-to-env.sh < ../tre_output.json > ../tre.env
+
+# Add a few extra values to the file to help us
+# These are mainly ENV_VARS that have been named differently
+echo "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE=sb-${TRE_ID}.servicebus.windows.net" >> ../tre.env
+# Add the ones from ./templates/core.env
+echo "AAD_TENANT_ID=${AAD_TENANT_ID}" >> ../tre.env
+echo "API_CLIENT_ID=${API_CLIENT_ID}" >> ../tre.env
+echo "API_CLIENT_SECRET=${API_CLIENT_SECRET}" >> ../tre.env
+echo "SWAGGER_UI_CLIENT_ID=${SWAGGER_UI_CLIENT_ID}" >> ../tre.env
+# These next ones from Check Dependencies
+echo "SUBSCRIPTION_ID=${SUB_ID}" >> ../tre.env
+echo "AZURE_SUBSCRIPTION_ID=${SUB_ID}" >> ../tre.env
+echo "AZURE_TENANT_ID=${TENANT_ID}" >> ../tre.env

--- a/templates/core/terraform/outputs.tf
+++ b/templates/core/terraform/outputs.tf
@@ -2,6 +2,10 @@ output "core_resource_group_name" {
   value = azurerm_resource_group.core.name
 }
 
+output "core_resource_group_location" {
+  value = azurerm_resource_group.core.location
+}
+
 output "log_analytics_name" {
   value = module.azure_monitor.log_analytics_workspace_name
 }
@@ -26,6 +30,14 @@ output "service_bus_resource_id" {
   value = module.servicebus.id
 }
 
+output "service_bus_workspace_queue" {
+  value = module.servicebus.workspacequeue
+}
+
+output "service_bus_deployment_status_queue" {
+  value = module.servicebus.service_bus_deployment_status_update_queue
+}
+
 output "state_store_resource_id" {
   value = module.state-store.id
 }
@@ -36,4 +48,14 @@ output "state_store_endpoint" {
 
 output "state_store_account_name" {
   value = module.state-store.cosmosdb_account_name
+}
+
+output "app_insights_instrumentation_key" {
+  value     = module.azure_monitor.app_insights_instrumentation_key
+  sensitive = true
+}
+
+output "app_insights_connection_string" {
+  value     = module.azure_monitor.app_insights_connection_string
+  sensitive = true
 }


### PR DESCRIPTION
## What is being addressed
This PR adds the capability to produce the necessary environment needed to debug the api locally.

## How is this addressed

- Build your environment with `make tre-deploy`. At this stage you should have a working infrastructure in Azure.
- Now run `make setup-local-debugging` and this will add your local ip address to cosmos and service bus and add your identity to the correct permissions to read/write to the queue and connect to Cosmos.
- Now go to vscode and inside your devcontainer you should be able to debug the "TRE API" from the launch.json. This will run the api locally and connect to a cloud TRE.
