### PR TITLE
Register AAD workspace - developer experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
       "justMyCode": false,
       "console": "integratedTerminal",
       "envFile": "${workspaceFolder}/templates/core/tre.env",
+      "preLaunchTask": "Copy_env_file_for_debug",
       "cwd": "${workspaceFolder}/api_app"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Copy_env_file_for_debug",
+      "command": "cp --force /workspaces/AzureTRE/templates/core/.env /workspaces/AzureTRE/api_app/.env",
+      "type": "shell"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
   "tasks": [
     {
       "label": "Copy_env_file_for_debug",
-      "command": "cp --force /workspaces/AzureTRE/templates/core/.env /workspaces/AzureTRE/api_app/.env",
+      "command": "cp --force ${workspaceFolder}/templates/core/.env ${workspaceFolder}/api_app/.env",
       "type": "shell"
     }
   ]

--- a/Makefile
+++ b/Makefile
@@ -259,3 +259,12 @@ setup-local-debugging:
 	&& pushd ./templates/core/terraform/ > /dev/null && . ./outputs.sh && popd > /dev/null \
 	&& . ./devops/scripts/load_env.sh ./templates/core/tre.env \
 	&& . ./devops/scripts/setup_local_api_debugging.sh
+
+register-aad-workspace:
+	echo -e "\n\e[34m»»» 🧩 \e[96mSetting up the ability to debug the API\e[0m..." \
+	&& . ./devops/scripts/check_dependencies.sh nodocker \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
+	&& pushd ./templates/core/terraform/ > /dev/null && . ./outputs.sh && popd > /dev/null \
+	&& . ./devops/scripts/load_env.sh ./templates/core/tre.env \
+	&& . ./devops/scripts/register-aad-workspace.sh
+

--- a/devops/scripts/register-aad-workspace.sh
+++ b/devops/scripts/register-aad-workspace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-: ${AAD_TENANT_ID?"You have not set you AAD_TENANT_ID in ./templates/core/.env"}
+: ${AAD_TENANT_ID?"You have not set your AAD_TENANT_ID in ./templates/core/.env"}
 
 LOGGED_IN_TENANT_ID=$(az account show --query tenantId -o tsv)
 CHANGED_TENANT=0

--- a/devops/scripts/register-aad-workspace.sh
+++ b/devops/scripts/register-aad-workspace.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+: ${AAD_TENANT_ID?"You have not set you AAD_TENANT_ID in ./templates/core/.env"}
+
+LOGGED_IN_TENANT_ID=$(az account show --query tenantId -o tsv)
+
+if [ "${LOGGED_IN_TENANT_ID}" != "${AAD_TENANT_ID}" ]; then
+  echo "Attempting to sign you onto ${AAD_TENANT_ID} to add an App Registration"
+
+  # First we need to login to the AAD tenant (as it could be different to the subscription tenant)
+  az login --tenant ${AAD_TENANT_ID} --allow-no-subscriptions
+fi
+
+# Then register an App
+./scripts/aad-app-reg.sh \
+-n "${TRE_ID} - Workspace One" \
+-r "https://${TRE_ID}.${RESOURCE_LOCATION}.cloudapp.azure.com/api/docs/oauth2-redirect" \
+-w

--- a/devops/scripts/register-aad-workspace.sh
+++ b/devops/scripts/register-aad-workspace.sh
@@ -9,7 +9,7 @@ CHANGED_TENANT=0
 if [ "${LOGGED_IN_TENANT_ID}" != "${AAD_TENANT_ID}" ]; then
   echo "Attempting to sign you onto ${AAD_TENANT_ID} to add an App Registration."
 
-  # First we need to login to the AAD tenant (as it could be different to the subscription tenant)
+  # First we need to login to the AAD tenant (as it is different to the subscription tenant)
   az login --tenant ${AAD_TENANT_ID} --allow-no-subscriptions
   CHANGED_TENANT=1
 fi
@@ -23,6 +23,6 @@ fi
 if [ "${CHANGED_TENANT}" -ne 0 ]; then
   echo "Attempting to sign you back into ${LOGGED_IN_TENANT_ID}."
 
-  # First we need to login to the AAD tenant (as it could be different to the subscription tenant)
+  # Log back into the tenant the user started on.
   az login --tenant ${LOGGED_IN_TENANT_ID} --allow-no-subscriptions
 fi

--- a/devops/scripts/register-aad-workspace.sh
+++ b/devops/scripts/register-aad-workspace.sh
@@ -4,12 +4,14 @@ set -e
 : ${AAD_TENANT_ID?"You have not set you AAD_TENANT_ID in ./templates/core/.env"}
 
 LOGGED_IN_TENANT_ID=$(az account show --query tenantId -o tsv)
+CHANGED_TENANT=0
 
 if [ "${LOGGED_IN_TENANT_ID}" != "${AAD_TENANT_ID}" ]; then
-  echo "Attempting to sign you onto ${AAD_TENANT_ID} to add an App Registration"
+  echo "Attempting to sign you onto ${AAD_TENANT_ID} to add an App Registration."
 
   # First we need to login to the AAD tenant (as it could be different to the subscription tenant)
   az login --tenant ${AAD_TENANT_ID} --allow-no-subscriptions
+  CHANGED_TENANT=1
 fi
 
 # Then register an App
@@ -17,3 +19,10 @@ fi
 -n "${TRE_ID} - Workspace One" \
 -r "https://${TRE_ID}.${RESOURCE_LOCATION}.cloudapp.azure.com/api/docs/oauth2-redirect" \
 -w
+
+if [ "${CHANGED_TENANT}" -ne 0 ]; then
+  echo "Attempting to sign you back into ${LOGGED_IN_TENANT_ID}."
+
+  # First we need to login to the AAD tenant (as it could be different to the subscription tenant)
+  az login --tenant ${LOGGED_IN_TENANT_ID} --allow-no-subscriptions
+fi

--- a/docs/tre-admins/setup-instructions/installing-base-workspace.md
+++ b/docs/tre-admins/setup-instructions/installing-base-workspace.md
@@ -37,7 +37,7 @@ As explained in the [auth guide](../auth.md), every workspace has a correspondin
 
 Running the script will report `WORKSPACE_API_CLIENT_ID` for the generated app which needs to be used in the POST body below.
 
-Go to ``azure_tre_fqdn/docs`` and use POST /api/workspaces with the sample body to create a base workspace.
+Go to `https://<azure_tre_fqdn>/api/docs` and use POST /api/workspaces with the sample body to create a base workspace.
 
 ```json
 {
@@ -45,7 +45,7 @@ Go to ``azure_tre_fqdn/docs`` and use POST /api/workspaces with the sample body 
   "properties": {
     "display_name": "manual-from-swagger",
     "description": "workspace for team X",
-    "app_id": "workspace app id created above"
+    "app_id": "WORKSPACE_API_CLIENT_ID"
   }
 }
 ```

--- a/templates/core/terraform/keyvault/keyvault.tf
+++ b/templates/core/terraform/keyvault/keyvault.tf
@@ -16,9 +16,9 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   tenant_id    = data.azurerm_client_config.deployer.tenant_id
   object_id    = data.azurerm_client_config.deployer.object_id
 
-  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete"]
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover"]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Purge", "Recover"]
-  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge"]
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover"]
   storage_permissions     = ["Get", "List", "Update", "Delete"]
 }
 

--- a/templates/core/terraform/keyvault/keyvault.tf
+++ b/templates/core/terraform/keyvault/keyvault.tf
@@ -16,9 +16,9 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   tenant_id    = data.azurerm_client_config.deployer.tenant_id
   object_id    = data.azurerm_client_config.deployer.object_id
 
-  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", "Recover"]
+  key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete"]
   secret_permissions      = ["Get", "List", "Set", "Delete", "Purge", "Recover"]
-  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge", "Recover"]
+  certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Purge"]
   storage_permissions     = ["Get", "List", "Update", "Delete"]
 }
 

--- a/templates/core/terraform/outputs.sh
+++ b/templates/core/terraform/outputs.sh
@@ -21,6 +21,7 @@ fi
 # These are mainly ENV_VARS that have been named differently
 echo "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE=sb-${TRE_ID}.servicebus.windows.net" >> ../tre.env
 # Add the ones from ./templates/core.env
+echo "TRE_ID=${TRE_ID}" >> ../tre.env
 echo "AAD_TENANT_ID=${AAD_TENANT_ID}" >> ../tre.env
 echo "API_CLIENT_ID=${API_CLIENT_ID}" >> ../tre.env
 echo "API_CLIENT_SECRET=${API_CLIENT_SECRET}" >> ../tre.env

--- a/templates/core/terraform/outputs.sh
+++ b/templates/core/terraform/outputs.sh
@@ -20,12 +20,6 @@ fi
 # Add a few extra values to the file to help us
 # These are mainly ENV_VARS that have been named differently
 echo "SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE=sb-${TRE_ID}.servicebus.windows.net" >> ../tre.env
-# Add the ones from ./templates/core.env
-echo "TRE_ID=${TRE_ID}" >> ../tre.env
-echo "AAD_TENANT_ID=${AAD_TENANT_ID}" >> ../tre.env
-echo "API_CLIENT_ID=${API_CLIENT_ID}" >> ../tre.env
-echo "API_CLIENT_SECRET=${API_CLIENT_SECRET}" >> ../tre.env
-echo "SWAGGER_UI_CLIENT_ID=${SWAGGER_UI_CLIENT_ID}" >> ../tre.env
 # These next ones from Check Dependencies
 echo "SUBSCRIPTION_ID=${SUB_ID}" >> ../tre.env
 echo "AZURE_SUBSCRIPTION_ID=${SUB_ID}" >> ../tre.env


### PR DESCRIPTION
## What is being addressed

- New `make register-aad-workspace` which will log you into the AAD_TENANT_ID and register an AAD app for your workspace and then log you back into the tenant you were on
- Updated the developer experience so that it copies the `templates\core\.env` file to your api_app when launching debug so that you have to copy less keys/values around. This has also meant I have to write less to templates/core/tre.env as this should be the values that have come from your deployment.
