### PR TITLE
CICD deployments with a reusable workflow

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -18,27 +18,51 @@ on:
 concurrency: "${{ github.workflow }}-${{ github.ref }}"
 
 jobs:
-  prepare:
+  run-deploy-tre-main:
+    name: "Run deploy main"
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy_tre_reusable.yml
+    secrets:
+      AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
+      ACR_NAME: ${{ secrets.ACR_NAME }}
+      ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+      ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+      API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
+      API_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET }}
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      CORE_ADDRESS_SPACE: ${{ secrets.CORE_ADDRESS_SPACE }}
+      LOCATION: ${{ secrets.LOCATION }}
+      MGMT_RESOURCE_GROUP: ${{ secrets.MGMT_RESOURCE_GROUP }}
+      MS_TEAMS_WEBHOOK_URI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+      STATE_STORAGE_ACCOUNT_NAME: ${{ secrets.STATE_STORAGE_ACCOUNT_NAME }}
+      SWAGGER_UI_CLIENT_ID: ${{ secrets.SWAGGER_UI_CLIENT_ID }}
+      TEST_APP_ID: ${{ secrets.TEST_APP_ID }}
+      TEST_USER_NAME: ${{ secrets.TEST_USER_NAME }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+      TEST_WORKSPACE_APP_ID: ${{ secrets.TEST_WORKSPACE_APP_ID }}
+      TF_STATE_CONTAINER: ${{ secrets.TF_STATE_CONTAINER }}
+      TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
+      TRE_ID: ${{ secrets.TRE_ID }}
+
+  prepare-not-main:
     name: Preparation
     runs-on: ubuntu-latest
     # The conditions below define the desired behaviour of the deployment
     # workflow:
-    #   1. The workflow must NOT be triggered automatically by an opened
-    #     pull request
-    #   2. It should be possible to manually trigger the workflow for PRs
-    #     originating from forks (using "safe to test" label)
-    #   3. The workflow must run when scheduled, pushed (i.e., merge) or
+    #   1. NOT for the main branch
+    #   2. When a PR is labeled correctly
+    #   3. The workflow run when pushed (update on PR branch) or
     #     manually triggered
     if: |
-      github.event.name == 'schedule'
-      || github.event_name == 'push'
+      github.ref != 'refs/heads/main' && (
+      github.event_name == 'push'
       || github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'safe to test')
+      || contains(github.event.pull_request.labels.*.name, 'safe to test'))
     outputs:
-      RUN_TRE_ID: ${{ github.ref == 'refs/heads/main' && secrets.TRE_ID || format('tre{0}', steps.run-id.outputs.refid) }}
-      RUN_ACR_NAME: ${{ github.ref == 'refs/heads/main' && secrets.ACR_NAME || format('tre{0}', steps.run-id.outputs.refid) }}
-      RUN_STATE_STORAGE_ACCOUNT_NAME: ${{ github.ref == 'refs/heads/main' && secrets.STATE_STORAGE_ACCOUNT_NAME || format('tre{0}mgmt', steps.run-id.outputs.refid) }}
-      RUN_MGMT_RESOURCE_GROUP: ${{ github.ref == 'refs/heads/main' && secrets.MGMT_RESOURCE_GROUP || format('rg-tre{0}-mgmt', steps.run-id.outputs.refid) }}
+      refid: ${{ steps.run-id.outputs.refid }}
     steps:
       - id: run-id
         name: Get run id
@@ -51,321 +75,32 @@ jobs:
           echo "using id of: ${REFID} for GitHub Ref: ${GITHUB_REF}"
           echo "::set-output name=refid::${REFID}"
 
-  deploy_management:
-    name: Deploy Management
-    runs-on: ubuntu-latest
-    needs: [prepare]
-    environment: Dev
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Docker BuildKit
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io
-          username: ${{ secrets.ACTIONS_ACR_NAME }}
-          password: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-
-      - name: Build new devcontainer
-        shell: bash
-        env:
-            DOCKER_BUILDKIT: 1
-        run: |
-          set -e
-          USER_UID=$(id -u)
-          USER_GID=$(id -g)
-          docker build . \
-            -t 'tredev:latest' \
-            -f '.devcontainer/Dockerfile' \
-            --cache-from ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:latest \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --build-arg USER_UID="${USER_UID}" \
-            --build-arg USER_GID="${USER_GID}"
-          docker image tag tredev:latest ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:latest
-
-      - name: Deploy management
-        uses: ./.github/actions/devcontainer_run_command
-        with:
-          COMMAND: "make bootstrap && make mgmt-deploy"
-          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
-          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
-          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
-          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
-          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
-          TRE_ID: "${{ needs.prepare.outputs.RUN_TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
-          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          ACR_NAME: ${{ needs.prepare.outputs.RUN_ACR_NAME }}
-          TF_VAR_terraform_state_container_name:
-            ${{ secrets.TF_STATE_CONTAINER }}
-          TF_VAR_mgmt_resource_group_name: "${{ needs.prepare.outputs.RUN_MGMT_RESOURCE_GROUP }}"
-          TF_VAR_mgmt_storage_account_name:
-            ${{ needs.prepare.outputs.RUN_STATE_STORAGE_ACCOUNT_NAME }}
-          TF_VAR_core_address_space: ${{ secrets.CORE_ADDRESS_SPACE }}
-          TF_VAR_tre_address_space: ${{ secrets.TRE_ADDRESS_SPACE }}
-          TF_VAR_swagger_ui_client_id: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
-          TF_VAR_api_client_id: "${{ secrets.API_CLIENT_ID }}"
-          TF_VAR_api_client_secret: "${{ secrets.API_CLIENT_SECRET }}"
-
-      - name: Notify dedicated teams channel
-        uses: sachinkundu/ms-teams-notification@1.4
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        with:
-          github-token: ${{ github.token }}
-          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: "Deploy TRE Failed"
-          notification-color: dc3545
-          timezone: Europe/Zurich
-
-      - name: Push cached devcontainer
-        if: ${{ success() }}
-        shell: bash
-        run: |
-          set -e
-          docker image push ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:latest
-
-  build_docker_images:
-    name: Build Docker Images
-    runs-on: ubuntu-latest
-    needs: [prepare, deploy_management]
-    environment: Dev
-    strategy:
-      fail-fast: true
-      matrix:
-        target: [
-          build-and-push-api,
-          build-and-push-resource-processor,
-          build-and-push-gitea,
-          build-and-push-guacamole]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Docker build
-        uses: ./.github/actions/devcontainer_run_command
-        with:
-          COMMAND: "make ${{ matrix.target }}"
-          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
-          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
-          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
-          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
-          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          ACR_NAME: ${{ needs.prepare.outputs.RUN_ACR_NAME }}
-
-      - name: Notify dedicated teams channel
-        uses: sachinkundu/ms-teams-notification@1.4
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        with:
-          github-token: ${{ github.token }}
-          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: "Make Images Failed"
-          notification-color: dc3545
-          timezone: Europe/Zurich
-
-  deploy_tre:
-    name: Deploy TRE
-    runs-on: ubuntu-latest
-    needs: [prepare, build_docker_images]
-    environment: Dev
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Deploy Trusted Research Environment
-        uses: ./.github/actions/devcontainer_run_command
-        with:
-          COMMAND: "make tre-deploy"
-          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
-          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
-          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
-          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
-          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
-          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
-          TEST_USER_NAME: "${{ secrets.TEST_USER_NAME }}"
-          TEST_USER_PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
-          TEST_WORKSPACE_APP_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
-          TRE_ID: "${{ needs.prepare.outputs.RUN_TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
-          ACR_NAME: ${{ needs.prepare.outputs.RUN_ACR_NAME }}
-          TF_VAR_terraform_state_container_name:
-            ${{ secrets.TF_STATE_CONTAINER }}
-          TF_VAR_mgmt_resource_group_name: ${{ needs.prepare.outputs.RUN_MGMT_RESOURCE_GROUP }}
-          TF_VAR_mgmt_storage_account_name:
-            ${{ needs.prepare.outputs.RUN_STATE_STORAGE_ACCOUNT_NAME }}
-          TF_VAR_core_address_space: ${{ secrets.CORE_ADDRESS_SPACE }}
-          TF_VAR_tre_address_space: ${{ secrets.TRE_ADDRESS_SPACE }}
-          TF_VAR_swagger_ui_client_id: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
-          TF_VAR_api_client_id: "${{ secrets.API_CLIENT_ID }}"
-          TF_VAR_api_client_secret: "${{ secrets.API_CLIENT_SECRET }}"
-
-      - name: Notify dedicated teams channel
-        uses: sachinkundu/ms-teams-notification@1.4
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        with:
-          github-token: ${{ github.token }}
-          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: "Deploy TRE Failed"
-          notification-color: dc3545
-          timezone: Europe/Zurich
-
-  publish_and_register_bundles:
-    name: Register Bundles
-    runs-on: ubuntu-latest
-    needs: [prepare, deploy_tre]
-    strategy:
-      matrix:
-        include:
-        # bundles type can be inferred from the bundle
-        # dir (but this is more explicit)
-          - {BUNDLE_TYPE: "workspace",
-             BUNDLE_DIR: "./templates/workspaces/base"}
-          - {BUNDLE_TYPE: "workspace",
-             BUNDLE_DIR: "./templates/workspaces/innereye"}
-          - {BUNDLE_TYPE: "workspace_service",
-             BUNDLE_DIR: "./templates/workspace_services/guacamole"}
-          - {BUNDLE_TYPE: "workspace_service",
-             BUNDLE_DIR: "./templates/workspace_services/azureml"}
-          - {BUNDLE_TYPE: "workspace_service",
-             BUNDLE_DIR: "./templates/workspace_services/devtestlabs"}
-          - {BUNDLE_TYPE: "workspace_service",
-             BUNDLE_DIR: "./templates/workspace_services/innereye"}
-    environment: Dev
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Register bundles
-        uses: ./.github/actions/devcontainer_run_command
-        with:
-          COMMAND: "make build-and-register-bundle DIR=${{ matrix.BUNDLE_DIR }}"
-          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
-          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
-          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
-          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
-          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          ACR_NAME: ${{ needs.prepare.outputs.RUN_ACR_NAME }}
-          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
-          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
-          TEST_USER_NAME: "${{ secrets.TEST_USER_NAME }}"
-          TEST_USER_PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
-          TRE_ID: "${{ needs.prepare.outputs.RUN_TRE_ID }}"
-          LOCATION: "${{ secrets.LOCATION }}"
-          BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
-
-  e2e_tests:
-    name: "Run E2E Tests"
-    runs-on: ubuntu-latest
-    environment: Dev
-    if: |
-      github.event.name == 'schedule'
-      || github.event_name == 'push'
-      || github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'safe to test')
-    needs: [prepare, publish_and_register_bundles]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Run e2e Tests
-        uses: ./.github/actions/devcontainer_run_command
-        with:
-          COMMAND: "make test-e2e"
-          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
-          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
-          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
-          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
-          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
-          LOCATION: "${{ secrets.LOCATION }}"
-          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
-          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
-          TEST_USER_NAME: "${{ secrets.TEST_USER_NAME }}"
-          TEST_USER_PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
-          TEST_WORKSPACE_APP_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
-          TRE_ID: "${{ needs.prepare.outputs.RUN_TRE_ID }}"
-          IS_API_SECURED: "false"
-          # ${{ github.ref == 'refs/heads/main' }} # only the "main" env has valid TLS
-
-      - name: Notify dedicated teams channel
-        uses: sachinkundu/ms-teams-notification@1.4
-        if: ${{ failure() && github.ref == 'refs/heads/main'}}
-        continue-on-error: true
-        with:
-          github-token: ${{ github.token }}
-          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: "E2E Tests failed"
-          notification-color: dc3545
-          timezone: Europe/Zurich
-
-      # - name: Expose workspace id
-      #   shell: bash
-      #   if: always()
-      #   run: |
-      #     cd ${{ github.workspace }}/e2e_tests
-      #     wkspc_id=`cat workspace_id.txt`
-      #     echo "WORKSPACE_ID=$wkspc_id" >> $GITHUB_ENV
-
-      - name: Notify dedicated teams channel
-        uses: sachinkundu/ms-teams-notification@1.4
-        if: ${{ success() && github.ref == 'refs/heads/main' }}
-        continue-on-error: true
-        with:
-          github-token: ${{ github.token }}
-          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: "Deployment and tests passed successfully"
-          notification-color: 28a745
-          timezone: Europe/Zurich
-
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: E2E Test Results (Python ${{ matrix.python-version }})
-          path: "./e2e_tests/pytest_e2e.xml"
-
-      - name: Publish Test Results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          files: "./e2e_tests/pytest_e2e.xml"
-
-  tre_stop:
-    name: "Deallocate Resources"
-    runs-on: ubuntu-latest
-    environment: Dev
-    needs: [prepare, e2e_tests]
-    if: |
-      ${{
-      always() &&
-      github.event.name == 'schedule'
-      || github.event_name == 'push'
-      || github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'safe to test')
-      }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Deallocate Resources
-        shell: bash
-        env:
-          TRE_ID: "${{secrets.TRE_ID}}"
-        run: |
-          az extension add --name azure-firewall
-          # TODO: enable this once the bug
-          # https://github.com/microsoft/AzureTRE/issues/1165 is fixed
-          # make tre-stop
+  run-deploy-tre-not-main:
+    name: "Run deploy NOT main"
+    if: github.ref != 'refs/heads/main'
+    needs: [prepare-not-main]
+    uses: ./.github/workflows/deploy_tre_reusable.yml
+    secrets:
+      AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
+      ACR_NAME: ${{ format('tre{0}', needs.prepare-not-main.outputs.refid) }}
+      ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+      ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+      API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
+      API_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET }}
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      CORE_ADDRESS_SPACE: ${{ secrets.CORE_ADDRESS_SPACE }}
+      LOCATION: ${{ secrets.LOCATION }}
+      MGMT_RESOURCE_GROUP: ${{ format('rg-tre{0}-mgmt', needs.prepare-not-main.outputs.refid) }}
+      MS_TEAMS_WEBHOOK_URI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+      STATE_STORAGE_ACCOUNT_NAME: ${{ format('tre{0}mgmt', needs.prepare-not-main.outputs.refid) }}
+      SWAGGER_UI_CLIENT_ID: ${{ secrets.SWAGGER_UI_CLIENT_ID }}
+      TEST_APP_ID: ${{ secrets.TEST_APP_ID }}
+      TEST_USER_NAME: ${{ secrets.TEST_USER_NAME }}
+      TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+      TEST_WORKSPACE_APP_ID: ${{ secrets.TEST_WORKSPACE_APP_ID }}
+      TF_STATE_CONTAINER: ${{ secrets.TF_STATE_CONTAINER }}
+      TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
+      TRE_ID: ${{ format('tre{0}', needs.prepare-not-main.outputs.refid) }}

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -1,0 +1,370 @@
+---
+name: Deploy Azure TRE Resuable
+
+on:
+  workflow_call:
+    secrets:
+      AAD_TENANT_ID:
+        required: true
+      ACR_NAME:
+        required: true
+      ACTIONS_ACR_NAME:
+        required: true
+      ACTIONS_ACR_PASSWORD:
+        required: true
+      API_CLIENT_ID:
+        required: true
+      API_CLIENT_SECRET:
+        required: true
+      ARM_CLIENT_ID:
+        required: true
+      ARM_CLIENT_SECRET:
+        required: true
+      ARM_SUBSCRIPTION_ID:
+        required: true
+      ARM_TENANT_ID:
+        required: true
+      CORE_ADDRESS_SPACE:
+        required: true
+      LOCATION:
+        required: true
+      MGMT_RESOURCE_GROUP:
+        required: true
+      MS_TEAMS_WEBHOOK_URI:
+        required: true
+      STATE_STORAGE_ACCOUNT_NAME:
+        required: true
+      SWAGGER_UI_CLIENT_ID:
+        required: true
+      TEST_APP_ID:
+        required: true
+      TEST_USER_NAME:
+        required: true
+      TEST_USER_PASSWORD:
+        required: true
+      TEST_WORKSPACE_APP_ID:
+        required: true
+      TF_STATE_CONTAINER:
+        required: true
+      TRE_ADDRESS_SPACE:
+        required: true
+      TRE_ID:
+        required: true
+
+# This will prevent multiple runs of this entire workflow.
+# We should NOT cancel in progress runs as that can destabilize the environment.
+concurrency: "deploy-${{ github.ref }}"
+
+jobs:
+  deploy_management:
+    name: Deploy Management
+    runs-on: ubuntu-latest
+    environment: Dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker BuildKit
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io
+          username: ${{ secrets.ACTIONS_ACR_NAME }}
+          password: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+
+      - name: Build new devcontainer
+        shell: bash
+        env:
+            DOCKER_BUILDKIT: 1
+        run: |
+          set -e
+          USER_UID=$(id -u)
+          USER_GID=$(id -g)
+          docker build . \
+            -t 'tredev:latest' \
+            -f '.devcontainer/Dockerfile' \
+            --cache-from ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:latest \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg USER_UID="${USER_UID}" \
+            --build-arg USER_GID="${USER_GID}"
+          docker image tag tredev:latest ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:latest
+
+      - name: Deploy management
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make bootstrap && make mgmt-deploy"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          LOCATION: ${{ secrets.LOCATION }}
+          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          TF_VAR_terraform_state_container_name:
+            ${{ secrets.TF_STATE_CONTAINER }}
+          TF_VAR_mgmt_resource_group_name: "${{ secrets.MGMT_RESOURCE_GROUP }}"
+          TF_VAR_mgmt_storage_account_name:
+            ${{ secrets.STATE_STORAGE_ACCOUNT_NAME }}
+          TF_VAR_core_address_space: ${{ secrets.CORE_ADDRESS_SPACE }}
+          TF_VAR_tre_address_space: ${{ secrets.TRE_ADDRESS_SPACE }}
+          TF_VAR_swagger_ui_client_id: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
+          TF_VAR_api_client_id: "${{ secrets.API_CLIENT_ID }}"
+          TF_VAR_api_client_secret: "${{ secrets.API_CLIENT_SECRET }}"
+
+      - name: Notify dedicated teams channel
+        uses: sachinkundu/ms-teams-notification@1.4
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          notification-summary: "Deploy TRE Failed"
+          notification-color: dc3545
+          timezone: Europe/Zurich
+
+      - name: Push cached devcontainer
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          set -e
+          docker image push ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:latest
+
+  build_docker_images:
+    name: Build Docker Images
+    runs-on: ubuntu-latest
+    needs: [deploy_management]
+    environment: Dev
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [
+          build-and-push-api,
+          build-and-push-resource-processor,
+          build-and-push-gitea,
+          build-and-push-guacamole]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker build
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make ${{ matrix.target }}"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+
+      - name: Notify dedicated teams channel
+        uses: sachinkundu/ms-teams-notification@1.4
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          notification-summary: "Make Images Failed"
+          notification-color: dc3545
+          timezone: Europe/Zurich
+
+  deploy_tre:
+    name: Deploy TRE
+    runs-on: ubuntu-latest
+    needs: [build_docker_images]
+    environment: Dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy Trusted Research Environment
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make tre-deploy"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
+          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
+          TEST_USER_NAME: "${{ secrets.TEST_USER_NAME }}"
+          TEST_USER_PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
+          TEST_WORKSPACE_APP_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          LOCATION: ${{ secrets.LOCATION }}
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          TF_VAR_terraform_state_container_name:
+            ${{ secrets.TF_STATE_CONTAINER }}
+          TF_VAR_mgmt_resource_group_name: ${{ secrets.MGMT_RESOURCE_GROUP }}
+          TF_VAR_mgmt_storage_account_name:
+            ${{ secrets.STATE_STORAGE_ACCOUNT_NAME }}
+          TF_VAR_core_address_space: ${{ secrets.CORE_ADDRESS_SPACE }}
+          TF_VAR_tre_address_space: ${{ secrets.TRE_ADDRESS_SPACE }}
+          TF_VAR_swagger_ui_client_id: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
+          TF_VAR_api_client_id: "${{ secrets.API_CLIENT_ID }}"
+          TF_VAR_api_client_secret: "${{ secrets.API_CLIENT_SECRET }}"
+
+      - name: Notify dedicated teams channel
+        uses: sachinkundu/ms-teams-notification@1.4
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          notification-summary: "Deploy TRE Failed"
+          notification-color: dc3545
+          timezone: Europe/Zurich
+
+  publish_and_register_bundles:
+    name: Register Bundles
+    runs-on: ubuntu-latest
+    needs: [deploy_tre]
+    strategy:
+      matrix:
+        include:
+        # bundles type can be inferred from the bundle
+        # dir (but this is more explicit)
+          - {BUNDLE_TYPE: "workspace",
+             BUNDLE_DIR: "./templates/workspaces/base"}
+          - {BUNDLE_TYPE: "workspace",
+             BUNDLE_DIR: "./templates/workspaces/innereye"}
+          - {BUNDLE_TYPE: "workspace_service",
+             BUNDLE_DIR: "./templates/workspace_services/guacamole"}
+          - {BUNDLE_TYPE: "workspace_service",
+             BUNDLE_DIR: "./templates/workspace_services/azureml"}
+          - {BUNDLE_TYPE: "workspace_service",
+             BUNDLE_DIR: "./templates/workspace_services/devtestlabs"}
+          - {BUNDLE_TYPE: "workspace_service",
+             BUNDLE_DIR: "./templates/workspace_services/innereye"}
+    environment: Dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Register bundles
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make build-and-register-bundle DIR=${{ matrix.BUNDLE_DIR }}"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
+          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
+          TEST_USER_NAME: "${{ secrets.TEST_USER_NAME }}"
+          TEST_USER_PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          LOCATION: "${{ secrets.LOCATION }}"
+          BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
+
+  e2e_tests:
+    name: "Run E2E Tests"
+    runs-on: ubuntu-latest
+    environment: Dev
+    needs: [publish_and_register_bundles]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run e2e Tests
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make test-e2e"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          LOCATION: "${{ secrets.LOCATION }}"
+          RESOURCE: "${{ secrets.API_CLIENT_ID }}"
+          AUTH_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
+          TEST_USER_NAME: "${{ secrets.TEST_USER_NAME }}"
+          TEST_USER_PASSWORD: "${{ secrets.TEST_USER_PASSWORD }}"
+          TEST_WORKSPACE_APP_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          IS_API_SECURED: false # ${{ github.ref == 'refs/heads/main' }} # only the "main" env has valid TLS
+
+      - name: Notify dedicated teams channel
+        uses: sachinkundu/ms-teams-notification@1.4
+        if: ${{ failure() && github.ref == 'refs/heads/main'}}
+        continue-on-error: true
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          notification-summary: "E2E Tests failed"
+          notification-color: dc3545
+          timezone: Europe/Zurich
+
+      # - name: Expose workspace id
+      #   shell: bash
+      #   if: always()
+      #   run: |
+      #     cd ${{ github.workspace }}/e2e_tests
+      #     wkspc_id=`cat workspace_id.txt`
+      #     echo "WORKSPACE_ID=$wkspc_id" >> $GITHUB_ENV
+
+      - name: Notify dedicated teams channel
+        uses: sachinkundu/ms-teams-notification@1.4
+        if: ${{ success() && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          notification-summary: "Deployment and tests passed successfully"
+          notification-color: 28a745
+          timezone: Europe/Zurich
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: E2E Test Results (Python ${{ matrix.python-version }})
+          path: "./e2e_tests/pytest_e2e.xml"
+
+      - name: Publish Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "./e2e_tests/pytest_e2e.xml"
+
+  # Waiting for: https://github.com/microsoft/AzureTRE/issues/1165
+  # tre_stop:
+  #   name: "Deallocate Resources"
+  #   runs-on: ubuntu-latest
+  #   environment: Dev
+  #   needs: [e2e_tests]
+  #   if: |
+  #     ${{
+  #     always() &&
+  #     github.event.name == 'schedule'
+  #     || github.event_name == 'push'
+  #     || github.event_name == 'workflow_dispatch'
+  #     || contains(github.event.pull_request.labels.*.name, 'safe to test')
+  #     }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
+
+  #     - name: Deallocate Resources
+  #       shell: bash
+  #       env:
+  #         TRE_ID: "${{secrets.TRE_ID}}"
+  #       run: |
+  #         az extension add --name azure-firewall
+  #         # TODO: enable this once the bug
+  #         # https://github.com/microsoft/AzureTRE/issues/1165 is fixed
+  #         # make tre-stop

--- a/devops/scripts/clean_ci_validation_envs.sh
+++ b/devops/scripts/clean_ci_validation_envs.sh
@@ -34,7 +34,7 @@ while read -r rg_name rg_ref_name; do
   then
     # this rg originated from an external PR (i.e. a fork)
     pr_num=${rg_ref_name//[!0-9]/}
-    if [ $(echo ${open_prs} | jq -c "[ .[] | select( .number | contains(${pr_num})) ] | length") == 0]
+    if [ $(echo ${open_prs} | jq -c "[ .[] | select( .number | contains(${pr_num})) ] | length") == 0 ]
     then
       echo "PR ${pr_num} (derived from ref ${rg_ref_name}) is not open, and environment ${rg_name} can be deleted."
       deleteEnv ${rg_name}


### PR DESCRIPTION
# PR for issue

## What is being addressed

Deployment to azure uses secrets but depending on the source branch we might want to change the values used. For instance, the tre_id is predefined for the environment representing the main branch, but is dynamic in other cases.
Using conditional expressions with secrets to produce new values isn't possible (example below).
> RUN_TRE_ID: ${{ github.ref == 'refs/heads/main' && secrets.TRE_ID || format('tre{0}', steps.run-id.outputs.refid) }}

As a side note, this PR also fixes a problem with the deployment workflow not executing on schedule.

## How is this addressed

- Treat the entire deployment workflow as a reusable one and call it differently per the source branch we're deploying from. This way we could calculate new values without referencing any existing secrets and pass them along to the reusable workflow as a new secret.
