### PR TITLE
Use Docker BuildKit cache in builds when running via make

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -145,6 +145,7 @@ runs:
         TF_VAR_api_client_secret: "${{ inputs.TF_VAR_api_client_secret }}"
         TF_VAR_acr_name: ${{ inputs.ACR_NAME }}
         IS_API_SECURED: ${{ inputs.IS_API_SECURED }}
+        DOCKER_BUILDKIT: ${{ inputs.DOCKER_BUILDKIT }}
       run: |
         docker run --rm --mount \
           "type=bind,src=${{ github.workspace }},dst=/workspaces/tre" \
@@ -184,5 +185,6 @@ runs:
           -e TEST_WORKSPACE_APP_ID \
           -e IS_API_SECURED \
           -e TF_VAR_ci_git_ref="${{ github.ref }}" \
+          -e DOCKER_BUILDKIT \
           '${{ inputs.ACTIONS_ACR_NAME }}.azurecr.io/tredev:${{ inputs.ACTIONS_DEVCONTAINER_TAG }}' \
         bash -c "${{ inputs.COMMAND }}"

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -140,8 +140,9 @@ jobs:
           docker image push \
             ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/tredev:${{ secrets.ACTIONS_DEVCONTAINER_TAG }}
 
-  build_docker_images:
-    name: Build Docker Images
+  build_core_images:
+    # used to build images used by core infrastructure
+    name: Build Core Docker Images
     runs-on: ubuntu-latest
     needs: [deploy_management]
     environment: Dev
@@ -151,8 +152,7 @@ jobs:
         target: [
           build-and-push-api,
           build-and-push-resource-processor,
-          build-and-push-gitea,
-          build-and-push-guacamole]
+          build-and-push-gitea]
 
     steps:
       - name: Checkout
@@ -177,14 +177,14 @@ jobs:
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: "Make Images Failed"
+          notification-summary: "Make Core Images Failed"
           notification-color: dc3545
           timezone: Europe/Zurich
 
   deploy_tre:
     name: Deploy TRE
     runs-on: ubuntu-latest
-    needs: [build_docker_images]
+    needs: [build_core_images]
     environment: Dev
     steps:
       - name: Checkout
@@ -278,11 +278,49 @@ jobs:
           LOCATION: "${{ secrets.LOCATION }}"
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
 
+  build_additional_images:
+    # used to build images NOT used by core infrastructure
+    name: Build Additional Docker Images
+    runs-on: ubuntu-latest
+    needs: [deploy_management]
+    environment: Dev
+    strategy:
+      fail-fast: true
+      matrix:
+        target: [build-and-push-guacamole]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker build
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make ${{ matrix.target }}"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          ACR_NAME: ${{ secrets.ACR_NAME }}
+
+      - name: Notify dedicated teams channel
+        uses: sachinkundu/ms-teams-notification@1.4
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        with:
+          github-token: ${{ github.token }}
+          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          notification-summary: "Make Additional Images Failed"
+          notification-color: dc3545
+          timezone: Europe/Zurich
+
+
   e2e_tests:
     name: "Run E2E Tests"
     runs-on: ubuntu-latest
     environment: Dev
-    needs: [publish_and_register_bundles]
+    needs: [publish_and_register_bundles, build_additional_images]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -299,6 +299,7 @@ jobs:
           COMMAND: "make ${{ matrix.target }}"
           ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
           ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ACTIONS_DEVCONTAINER_TAG: ${{ secrets.ACTIONS_DEVCONTAINER_TAG }}
           ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
           ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
           ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"

--- a/Makefile
+++ b/Makefile
@@ -37,74 +37,61 @@ mgmt-destroy:
 	&& . ./devops/scripts/load_terraform_env.sh ./devops/.env \
 	&& cd ./devops/terraform && ./destroy.sh
 
+# A recipe for building images. Parameters:
+# 1. Image name suffix
+# 2. Version file path
+# 3. Docker file path
+# 4. Docoer context path
+# Example: $(call build_image,"api","./api_app/_version.py","api_app/Dockerfile","./api_app/")
+define build_image
+$(call target_title, "Building $(1) Image") \
+&& . ./devops/scripts/check_dependencies.sh \
+&& . ./devops/scripts/load_env.sh ./devops/.env \
+&& . ./devops/scripts/set_docker_sock_permission.sh \
+&& source <(grep = $(2) | sed 's/ *= */=/g') \
+&& az acr login -n $${ACR_NAME} \
+&& docker build -t ${FULL_IMAGE_NAME_PREFIX}/$(1):$${__version__} --build-arg BUILDKIT_INLINE_CACHE=1 \
+	--cache-from ${FULL_IMAGE_NAME_PREFIX}/$(1):$${__version__} -f $(3) $(4)
+endef
+
 build-api-image:
-	$(call target_title, "Building API Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./api_app/_version.py | sed 's/ *= */=/g') \
-	&& docker build -t "${FULL_IMAGE_NAME_PREFIX}/api:$${__version__}" ./api_app/
+	$(call build_image,"api","api_app/_version.py","api_app/Dockerfile","api_app/")
 
 build-resource-processor-vm-porter-image:
-	$(call target_title, "Building Resource Processor Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./resource_processor/version.txt | sed 's/ *= */=/g') \
-	&& docker build -t "${FULL_IMAGE_NAME_PREFIX}/resource-processor-vm-porter:$${__version__}" -f ./resource_processor/vmss_porter/Dockerfile ./resource_processor/
+	$(call build_image,"resource-processor-vm-porter","resource_processor/version.txt","resource_processor/vmss_porter/Dockerfile","resource_processor/")
 
 build-gitea-image:
-	$(call target_title, "Building Gitea Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./templates/shared_services/gitea/version.txt | sed 's/ *= */=/g') \
-	&& docker build -t "${FULL_IMAGE_NAME_PREFIX}/gitea:$${__version__}" -f ./templates/shared_services/gitea/Dockerfile .
+	$(call build_image,"gitea","templates/shared_services/gitea/version.txt","templates/shared_services/gitea/Dockerfile","templates/shared_services/gitea/")
 
 build-guacamole-image:
-	$(call target_title, "Building Guacamole Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./templates/workspace_services/guacamole/version.txt | sed 's/ *= */=/g') \
-	&& cd ./templates/workspace_services/guacamole/guacamole-server/ \
-	&& docker build -t "${FULL_IMAGE_NAME_PREFIX}/guac-server:$${__version__}" -f ./docker/Dockerfile .
+	$(call build_image,"guac-server","templates/workspace_services/guacamole/version.txt","templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile","templates/workspace_services/guacamole/guacamole-server")
 
-push-resource-processor-vm-porter-image:
-	$(call target_title, "Pushing Resource Processor Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./resource_processor/version.txt | sed 's/ *= */=/g') \
-	&& az acr login -n $${ACR_NAME} \
-	&& docker push "${FULL_IMAGE_NAME_PREFIX}/resource-processor-vm-porter:$${__version__}"
+
+# A recipe for pushing images. Parameters:
+# 1. Image name suffix
+# 2. Version file path
+# Example: $(call push_image,"api","./api_app/_version.py")
+define push_image
+$(call target_title, "Pushing $(1) Image") \
+&& . ./devops/scripts/check_dependencies.sh \
+&& . ./devops/scripts/load_env.sh ./devops/.env \
+&& . ./devops/scripts/set_docker_sock_permission.sh \
+&& source <(grep = $(2) | sed 's/ *= */=/g') \
+&& az acr login -n $${ACR_NAME} \
+&& docker push "${FULL_IMAGE_NAME_PREFIX}/$(1):$${__version__}"
+endef
 
 push-api-image:
-	$(call target_title, "Pushing API Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./api_app/_version.py | sed 's/ *= */=/g') \
-	&& az acr login -n $${ACR_NAME} \
-	&& docker push "${FULL_IMAGE_NAME_PREFIX}/api:$${__version__}"
+	$(call push_image,"api","./api_app/_version.py")
+
+push-resource-processor-vm-porter-image:
+	$(call push_image,"resource-processor-vm-porter","./resource_processor/version.txt")
 
 push-gitea-image:
-	$(call target_title, "Pushing Gitea Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./templates/shared_services/gitea/version.txt | sed 's/ *= */=/g') \
-	&& az acr login -n $${ACR_NAME} \
-	&& docker push "${FULL_IMAGE_NAME_PREFIX}/gitea:$${__version__}"
+	$(call push_image,"gitea","./templates/shared_services/gitea/version.txt")
 
 push-guacamole-image:
-	$(call target_title, "Pushing Guacamole Image") \
-	&& . ./devops/scripts/check_dependencies.sh \
-	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/set_docker_sock_permission.sh \
-	&& source <(grep = ./templates/workspace_services/guacamole/version.txt | sed 's/ *= */=/g') \
-	&& az acr login -n $${ACR_NAME} \
-	&& docker push "${FULL_IMAGE_NAME_PREFIX}/guac-server:$${__version__}"
+	$(call push_image,"guac-server","./templates/workspace_services/guacamole/version.txt")
 
 tre-deploy:
 	$(call target_title, "Deploying TRE") \
@@ -206,7 +193,7 @@ porter-uninstall:
 	&& cd ${DIR} && porter uninstall -p ./parameters.json --cred ./azure.json --debug
 
 porter-custom-action:
-	$(call target_title, "Deploying ${DIR} with Porter") \
+	$(call target_title, "Performing:${ACTION} ${DIR} with Porter") \
 	&& . ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
@@ -214,7 +201,7 @@ porter-custom-action:
 	&& cd ${DIR} && porter invoke --action ${ACTION} -p ./parameters.json --cred ./azure.json --debug
 
 porter-publish:
-	$(call target_title, "Publishing ${DIR} bundle") \
+	$(call target_title, "Publishing ${DIR} bundle with Porter") \
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& az acr login --name $${ACR_NAME}	\
@@ -222,7 +209,7 @@ porter-publish:
 	&& porter publish --registry "$${ACR_NAME}.azurecr.io" --debug
 
 register-bundle:
-	$(call target_title, "Publishing ${DIR} bundle") \
+	$(call target_title, "Registering ${DIR} bundle") \
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& cd ${DIR} \
@@ -236,7 +223,7 @@ build-and-register-bundle: porter-build
 	&& ${ROOTPATH}/devops/scripts/build_and_register_bundle.sh --acr-name ${ACR_NAME} --bundle-type ${BUNDLE_TYPE} --current --insecure --tre_url ${TRE_URL}
 
 register-bundle-payload:
-	$(call target_title, "Publishing ${DIR} bundle") \
+	$(call target_title, "Registering payload ${DIR} bundle") \
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
 	&& cd ${DIR} \
@@ -269,7 +256,7 @@ setup-local-debugging-api:
 	&& . ./devops/scripts/setup_local_api_debugging.sh
 
 register-aad-workspace:
-	echo -e "\n\e[34m»»» 🧩 \e[96mSetting up the ability to debug the API\e[0m..." \
+	$(call target_title,"Registering AAD Workspace") \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& pushd ./templates/core/terraform/ > /dev/null && . ./outputs.sh && popd > /dev/null \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ mgmt-destroy:
 # 1. Image name suffix
 # 2. Version file path
 # 3. Docker file path
-# 4. Docoer context path
+# 4. Docker context path
 # Example: $(call build_image,"api","./api_app/_version.py","api_app/Dockerfile","./api_app/")
 define build_image
 $(call target_title, "Building $(1) Image") \


### PR DESCRIPTION
# Fixes #1271 

## What is being addressed

Docker buildkit isn't used when the CI builds images through the devcontainer and caching isn't possible.

## How is this addressed

- Pass the DOCKER_BUILDKIT value from the action to the docker run command so that it will be available inside the devcontainer for all other docker operations
- Create a make recipe for building and publishing images
- Create & use buildkit cache layers when building images via make
- Move Guacamole image build to a later stage as core deployments doesn't need to wait for it
