### PR TITLE
Fix missing subscription variable in action

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -171,6 +171,7 @@ runs:
           -e TF_VAR_aad_tenant_id \
           -e TF_VAR_api_client_id \
           -e TF_VAR_api_client_secret \
+          -e TF_VAR_arm_subscription_id="${{ inputs.ARM_SUBSCRIPTION_ID }}" \
           -e TF_VAR_swagger_ui_client_id \
           -e TF_VAR_core_address_space \
           -e TF_VAR_tre_address_space \

--- a/templates/core/terraform/azure-monitor/app_insights.json
+++ b/templates/core/terraform/azure-monitor/app_insights.json
@@ -53,11 +53,11 @@
   "outputs": {
     "instrumentationKey": {
       "value": "[reference(resourceId('microsoft.insights/components', parameters('app_insights_name')), '2020-02-02').InstrumentationKey]",
-      "type": "string"
+      "type": "String"
     },
     "connectionString": {
       "value": "[reference(resourceId('microsoft.insights/components', parameters('app_insights_name')), '2020-02-02').ConnectionString]",
-      "type": "string"
+      "type": "String"
     }
   }
 }


### PR DESCRIPTION
## What is being addressed

1. devcontainer action didn't have the arm_subscription_id variable as a TF one (caused replacing owner role resource)
2. azure monitor arm template had outputs with type "**s**tring" that TF kept replacing to "**S**tring"