### PR TITLE
#1309-Fix-DocumentationCorrectionsAndFormatting

### DIFF
--- a/docs/tre-admins/setup-instructions/deploying-azure-tre.md
+++ b/docs/tre-admins/setup-instructions/deploying-azure-tre.md
@@ -55,7 +55,7 @@ curl https://<azure_tre_fqdn>/api/health
 
 ### Using the API docs
 
-Open your browser and navigate to the `/api/docs` route of the API:  `https://<azure_tre_fqdn>/api/docs` and click *Try it out* on the operation of choice.
+Open your browser and navigate to the `/api/docs` route of the API:  `https://<azure_tre_fqdn>/api/docs` and click `Try it out` on the operation of choice.
 
 ![Swagger UI](../../assets/quickstart_swaggerui.png)
 

--- a/docs/tre-admins/setup-instructions/installing-base-workspace.md
+++ b/docs/tre-admins/setup-instructions/installing-base-workspace.md
@@ -11,14 +11,14 @@
 
     Copy the resulting JSON payload.
 
-!!! info
-    If you're using Codespaces, you may encounter a `Permission denied` issue with the Docker daemon. To fix this, run `sudo bash ./devops/scripts/set_docker_sock_permission.sh` from the root of the repository, then retry the make command.
+    !!! info
+        If you're using Codespaces, you may encounter a `Permission denied` issue with the Docker daemon. To fix this, run `sudo bash ./devops/scripts/set_docker_sock_permission.sh` from the root of the repository, then retry the make command.
 
 1. Navigate to the Swagger UI at `https://<azure_tre_fqdn>/api/docs`
 
 1. Log into the Swagger UI by clicking `Authorize`, then `Authorize` again. You will be redirected to the login page.
 
-1. Once logged in. Click `Try it out` on the `POST` `/api/workspace-templates` operation:
+1. Once logged in, click `Try it out` on the `POST` `/api/workspace-templates` operation:
 
     ![Post Workspace Template](../../assets/post-template.png)
 

--- a/docs/tre-admins/setup-instructions/installing-workspace-service-and-user-resource.md
+++ b/docs/tre-admins/setup-instructions/installing-workspace-service-and-user-resource.md
@@ -16,7 +16,7 @@ We will use the [Guacamole workspace service bundle](./tre-templates/workspace-s
 
 1. Log into the Swagger UI by clicking `Authorize`, then `Authorize` again. You will be redirected to the login page.
 
-1. Once logged in. Click `Try it out` on the `POST` `/api/workspace-service-templates` operation.
+1. Once logged in, click `Try it out` on the `POST` `/api/workspace-service-templates` operation.
 
 1. Paste the payload json generated earlier into the `Request body` field, then click `Execute`. Review the server response.
 
@@ -34,15 +34,17 @@ The Guacamole workspace service also has user resources, there are the VMs that 
 
     Copy the resulting JSON payload.
 
-1. Navigate to the Swagger UI at `https://<azure_tre_fqdn>/api/docs`. You should already be logged in.
+1. Navigate to the Swagger UI at `https://<azure_tre_fqdn>/api/docs`.
 
-Click `Try it out` on the `POST` `/api/user-resource-templates` operation.
+1. Log into the Swagger UI by clicking Authorize, then Authorize again. You will be redirected to the login page.
+
+1. Once logged in, click `Try it out` on the `POST` `/api/workspace-service-templates/<service_template_name>/user-resource-templates` operation.
 
 1. In the `service_template_name` field, paste the name of the workspace service template that you registered earlier - `tre-service-guacamole`.
 
 1. Paste the payload json generated earlier into the `Request body` field, then click `Execute`. Review the server response.
 
-1. To verify registration of the template do `GET` operation on `/api/user-resource-templates`. The name of the template should now be listed.
+1. To verify registration of the template do `GET` operation on `/api/workspace-service-templates/<service_template_name>/user-resource-templates`. The name of the template should now be listed.
 
 ## Creating a workspace service
 
@@ -50,33 +52,33 @@ Now that we have published and registered both workspace service and user resour
 
 1. Navigate to the Swagger UI at `https://<azure_tre_fqdn>/api/workspaces/<workspace_id>/docs` . Where `<workspace_id>` is the workspace ID of the workspace created in the previous step.
 
-!!! info
-    All routes are auth protected. Click the green **Authorize** button to receive a token for Swagger client.
+    !!! info
+        All routes are auth protected. Click the green **Authorize** button to receive a token for Swagger client.
 
 1. Log into the Swagger UI by clicking `Authorize`, then `Authorize` again. You will be redirected to the login page.
 
-!!! info
-    You need to log in with a user with assigned the WorkspaceOwner role in the app regsitration used when deploying your workspace.
+    !!! info
+        You need to log in with a user with assigned the WorkspaceOwner role in the app regsitration used when deploying your workspace.
 
-1. Once logged in. Click `Try it out` on the `POST` `/api/workspaces/<workspace_id>/workspace-services` operation.
+1. Once logged in, click `Try it out` on the `POST` `/api/workspaces/<workspace_id>/workspace-services` operation.
 
 1. Enter the workspace_id in the `workspace_id` field.
 
 1. Paste the following payload json into the `Request body` field, update `<WORKSPACE_API_CLIENT_ID>` with the client ID of the app registration for the base workspace you created previously, then click `Execute`. Review the server response.
 
-```json
-{
-  "templateName":"tre-service-guacamole",
-  "properties": {
-    "display_name":"Virtual Desktop",
-    "description":"Create virtual desktops for running research workloads",
-    "openid_client_id":"<WORKSPACE_API_CLIENT_ID>",
-    "is_exposed_externally":true,
-    "guac_disable_copy":true,
-    "guac_disable_paste":true
-  }
-}
-```
+    ```json
+    {
+      "templateName":"tre-service-guacamole",
+      "properties": {
+        "display_name":"Virtual Desktop",
+        "description":"Create virtual desktops for running research workloads",
+        "openid_client_id":"<WORKSPACE_API_CLIENT_ID>",
+        "is_exposed_externally":true,
+        "guac_disable_copy":true,
+        "guac_disable_paste":true
+      }
+    }
+    ```
 
 The API will return an `operation` object with a `Location` header to query the operation status, as well as the `resourceId` and `resourcePath` properties to query the resource under creation. Record this ID for later use.
 
@@ -99,18 +101,18 @@ Once the workspace service has been created, we can use the workspace API to cre
 
 1. Paste the following payload json into the `Request body` field, then click `Execute`. Review the server response.
 
-```json
-{
-  "templateName": "tre-service-guacamole-windowsvm",
-  "properties": {
-    "display_name": "My VM",
-    "description": "Will be using this VM for my research",
-    "os_image": "Server 2019 Data Science VM"
-  }
-}
-```
+    ```json
+    {
+      "templateName": "tre-service-guacamole-windowsvm",
+      "properties": {
+        "display_name": "My VM",
+        "description": "Will be using this VM for my research",
+        "os_image": "Server 2019 Data Science VM"
+      }
+    }
+    ```
 
-> Note: You can also specify "Windows 10" for a standard Windows 10 image
+    > Note: You can also specify "Windows 10" for a standard Windows 10 image
 
 The API will return an `operation` object with a `Location` header to query the operation status, as well as the `resourceId` and `resourcePath` properties to query the resource under creation.
 


### PR DESCRIPTION
# PR for 
[Documentation: Corrections and formatting issues #1309](https://github.com/microsoft/AzureTRE/issues/1309)

## What is being addressed
- [x] Incorrect numbering under `Publishing and registering the base workspace bundle` heading in https://microsoft.github.io/AzureTRE/tre-admins/setup-instructions/installing-base-workspace/
- [x] Incorrect numbering under `Publish and register a user resource template` heading in https://microsoft.github.io/AzureTRE/tre-admins/setup-instructions/installing-workspace-service-and-user-resource/
- [x] API operation not correct under `Publish and register a user resource template` heading in https://microsoft.github.io/AzureTRE/tre-admins/setup-instructions/installing-workspace-service-and-user-resource/. `/api/user-resource-templates` should be `/api/workspace-service-templates/<service_template_name>/user-resource-templates`
- [x] Incorrect numbering under `Creating a workspace service` heading in https://microsoft.github.io/AzureTRE/tre-admins/setup-instructions/installing-workspace-service-and-user-resource/
- [x] Codeblock and Note: missing indentation under `Creating a user resource` in https://microsoft.github.io/AzureTRE/tre-admins/setup-instructions/installing-workspace-service-and-user-resource/
- [x] Fix `Try it out` formatting on https://microsoft.github.io/AzureTRE/tre-admins/setup-instructions/deploying-azure-tre/

## How is this addressed
Applied various formatting fixes and fixed api operation