### PR TITLE
Enable tre stop/start

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -103,7 +103,10 @@ inputs:
     description: "Indicates if the API endpoint has valid TLS certificate and if we validate it during E2E."
     required: false
     default: "true"
-
+  TF_VAR_debug:
+    description: "A value indicating if the system should be deployed in debug mode."
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -190,5 +193,6 @@ runs:
           -e IS_API_SECURED \
           -e TF_VAR_ci_git_ref="${{ github.ref }}" \
           -e DOCKER_BUILDKIT \
+          -e TF_VAR_debug=${{ inputs.TF_VAR_debug }} \
           '${{ inputs.ACTIONS_ACR_URI }}tredev:${{ inputs.ACTIONS_DEVCONTAINER_TAG }}' \
         bash -c "${{ inputs.COMMAND }}"

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -225,6 +225,7 @@ jobs:
           TF_VAR_swagger_ui_client_id: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
           TF_VAR_api_client_id: "${{ secrets.API_CLIENT_ID }}"
           TF_VAR_api_client_secret: "${{ secrets.API_CLIENT_SECRET }}"
+          TF_VAR_debug: "${{ github.ref == 'refs/heads/main' && false || true }}"
 
       - name: Notify dedicated teams channel
         uses: sachinkundu/ms-teams-notification@1.4

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ push-gitea-image:
 push-guacamole-image:
 	$(call push_image,"guac-server","./templates/workspace_services/guacamole/version.txt")
 
-tre-deploy:
+tre-deploy: tre-start
 	$(call target_title, "Deploying TRE") \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./templates/core/.env \

--- a/devops/scripts/control_tre.sh
+++ b/devops/scripts/control_tre.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+if [[ -z ${TRE_ID:-} ]]; then
+    echo "TRE_ID environment variable must be set."
+    exit 1
+fi
+
+# if we don't have a firewall, no need to continue this script.
+# most likely this is an automated execution before calling make tre-deploy
+if [[ $(az network firewall list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='fw-${TRE_ID}'] | length(@)") == 0 ]]; then
+  echo "TRE resource group or firewall don't exits. Exiting..."
+  exit 0
+fi
 
 if [[ "$1" == *"start"* ]]; then
   CURRENT_PUBLIC_IP=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].publicIpAddress" -o tsv)

--- a/templates/core/terraform/firewall/firewall.tf
+++ b/templates/core/terraform/firewall/firewall.tf
@@ -23,6 +23,7 @@ resource "azurerm_firewall" "fw" {
 }
 
 resource "azurerm_management_lock" "fw" {
+  count      = var.debug ? 0 : 1
   name       = azurerm_firewall.fw.name
   scope      = azurerm_firewall.fw.id
   lock_level = "CanNotDelete"
@@ -30,9 +31,11 @@ resource "azurerm_management_lock" "fw" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "firewall" {
-  name                       = "diagnostics-firewall-${var.tre_id}"
-  target_resource_id         = azurerm_firewall.fw.id
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  name                           = "diagnostics-firewall-${var.tre_id}"
+  target_resource_id             = azurerm_firewall.fw.id
+  log_analytics_workspace_id     = var.log_analytics_workspace_id
+  log_analytics_destination_type = "Dedicated"
+
   log {
     category = "AzureFirewallApplicationRule"
     enabled  = true

--- a/templates/core/terraform/firewall/variables.tf
+++ b/templates/core/terraform/firewall/variables.tf
@@ -33,3 +33,8 @@ variable "web_app_subnet" {
   })
   description = "The ID of the web app subnet"
 }
+
+variable "debug" {
+  type    = bool
+  default = false
+}

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -99,6 +99,7 @@ module "firewall" {
   location                   = var.location
   resource_group_name        = azurerm_resource_group.core.name
   log_analytics_workspace_id = module.azure_monitor.log_analytics_workspace_id
+  debug                      = var.debug
 
   shared_subnet = {
     id               = module.network.shared_subnet_id


### PR DESCRIPTION
## What is being addressed

This PR is partially resolves the problems described in #1165 and enables the system to stop and start the TRE to conserve costs, but **only** when deployed in debug mode.
This [test](https://github.com/microsoft/AzureTRE/runs/5214057060?check_suite_focus=true#step:3:326) shows a TRE that was previously stopped and brought up within the run.

## How is this addressed

- All locks are disabled in debug mode
- make tre-deploy calls tre-start before executing Terraform
- control_tre scripts checks if a TRE exists before doing anything. This is to a new tre deployment which can happen since tre-start is called before tre-deploy
- Change the type of firewall diagnostics settings to save Terraform redundant changes.
