### PR TITLE
Fix up typo in docs with bundle-register

### DIFF
--- a/docs/tre-admins/setup-instructions/installing-workspace-service-and-user-resource.md
+++ b/docs/tre-admins/setup-instructions/installing-workspace-service-and-user-resource.md
@@ -8,7 +8,7 @@ We will use the [Guacamole workspace service bundle](./tre-templates/workspace-s
 
     ```cmd
     make bundle-publish DIR=./templates/workspace_services/guacamole BUNDLE_TYPE=workspace_service
-    make bundle-register DIR=./templates/workspaces/guacamole BUNDLE_TYPE=workspace_service
+    make bundle-register DIR=./templates/workspace_services/guacamole BUNDLE_TYPE=workspace_service
     ```
 
     Copy the resulting JSON payload.


### PR DESCRIPTION
make bundle-register DIR=./templates/workspace_services/guacamole BUNDLE_TYPE=workspace_service

previous command had wrong path