### PR TITLE
Fix extended tests results publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,7 +197,8 @@ templates/core/terraform/scripts/validation.txt
 templates/core/terraform/plan
 
 # Test results
-e2e_tests/pytest_e2e.xml
+e2e_tests/pytest_e2e_smoke.xml
+e2e_tests/pytest_e2e_extended.xml
 e2e_tests/workspace_id.txt
 pytest_api_unit.xml
 pytest_api_unit_failed

--- a/Makefile
+++ b/Makefile
@@ -238,14 +238,14 @@ test-e2e-smoke:
 	export SCOPE="api://${RESOURCE}/user_impersonation" && \
 	export WORKSPACE_SCOPE="api://${TEST_WORKSPACE_APP_ID}/user_impersonation" && \
 	cd e2e_tests && \
-	python -m pytest -m smoke --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e.xml
+	python -m pytest -m smoke --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_smoke.xml
 
 test-e2e-extended:
-	$(call target_title, "Running E2E smoke tests") && \
+	$(call target_title, "Running E2E extended tests") && \
 	export SCOPE="api://${RESOURCE}/user_impersonation" && \
 	export WORKSPACE_SCOPE="api://${TEST_WORKSPACE_APP_ID}/user_impersonation" && \
 	cd e2e_tests && \
-	python -m pytest -m extended --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e.xml
+	python -m pytest -m extended --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_extended.xml
 
 setup-local-debugging-api:
 	$(call target_title,"Setting up the ability to debug the API") \


### PR DESCRIPTION
Fixes #1344 

## What is being addressed

Bug fix: Smoke and Extended tests try to upload a result file which does not exists

## How is this addressed

- update make file to correct file name
