### PR TITLE
Fix debug reference in docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -4,6 +4,8 @@ name: Publish docs via Github Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'docs/**'
 
 jobs:
   build:

--- a/docs/tre-admins/environment-variables.md
+++ b/docs/tre-admins/environment-variables.md
@@ -16,7 +16,6 @@
 | `ARM_CLIENT_ID` | *Optional for manual deployment without logged-in credentials.* The client whose azure identity will be used to deploy the solution. |
 | `ARM_CLIENT_SECRET` | *Optional for manual deployment without logged-in credentials.* The password of the client defined in `ARM_CLIENT_ID`. |
 | `ARM_TENANT_ID` | *Optional for manual deployment. If not specified the `az cli` selected subscription will be used.* The AAD tenant of the client defined in `ARM_CLIENT_ID`. |
-| `DEBUG` | If set to "true" disables purge protection of keyvault. |
 
 ## For Azure TRE instance in `/templates/core/.env`
 
@@ -31,3 +30,5 @@
 | `API_CLIENT_SECRET` | Generated when following [pre-deployment steps](./setup-instructions/pre-deployment-steps.md) guide. Client secret of the "TRE API". |
 | `DEPLOY_GITEA` | If set to `false` disables deployment of the [Gitea shared service](../azure-tre-overview/shared-services/gitea.md). |
 | `DEPLOY_NEXUS` | If set to `false` disables deployment of the [Nexus shared service](../azure-tre-overview/shared-services/nexus.md). |
+| `KEYVAULT_PURGE_PROTECTION_ENABLED` | If set to `false` disables purge protection of keyvault. A Recommanded setting for developers. |
+| `STATEFUL_RESOURCES_LOCKED` | If set to `false` locks on stateful resources won't be created. A Recommanded setting for developers. |


### PR DESCRIPTION
Fixes #1332 

## What is being addressed

A recent change removed the "debug" environment variable in favor of more descriptive ones. This PR fixes the docs around it.
Plus, update the docs workflow to run only when a doc was changed