### PR TITLE
A job to free disk space in Resource Processor

### DIFF
--- a/templates/core/terraform/resource_processor/vmss_porter/cloud-config.yaml
+++ b/templates/core/terraform/resource_processor/vmss_porter/cloud-config.yaml
@@ -39,6 +39,10 @@ write_files:
       ARM_TENANT_ID=${arm_tenant_id}
       ARM_USE_MSI=true
       APPLICATIONINSIGHTS_CONNECTION_STRING=${app_insights_connection_string}
+  # a weekly cron job to have docker free disk space
+  - path: /etc/cron.weekly/docker-prune
+    content: docker system prune -f
+    permissions: '0755'
 
 runcmd:
   - export DEBIAN_FRONTEND=noninteractive
@@ -47,4 +51,5 @@ runcmd:
   - docker run -d -v /var/run/docker.sock:/var/run/docker.sock
     --restart always --env-file .env
     --name resource_processor_vmss_porter1
+    --log-driver local
     ${docker_registry_server}/${resource_processor_vmss_porter_image_repository}:${resource_processor_vmss_porter_image_tag}


### PR DESCRIPTION
Fixes #1335 

## What is being addressed

The resource process disk space can run out after certain amount of time.

## How is this addressed

- Change docker logging driver to "local" which will automatically limit the size it can grow to. https://docs.docker.com/config/containers/logging/local/
- Add a weekly cron job that will do a `docker system prune` and free up space. On a stable system without many image changes this can increase the time needed to deploy bundles, which is why this is set for weekly and not daily.
