### PR TITLE
CI checks core image version update

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -16,11 +16,6 @@ jobs:
   docker_build:
     name: Build images
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository
-      || github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'safe to test')
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,12 +27,36 @@ jobs:
           filters: |
             api:
               - 'api_app/**/*'
+            api_version:
+              - 'api_app/_version.py'
             resource_processor:
               - 'resource_processor/**/*'
+            resource_processor_version:
+              - 'resource_processor/version.txt'
             guacamole_server:
               - 'templates/workspace_services/guacamole/guacamole-server/**/*'
+            guacamole_server_version:
+              - 'templates/workspace_services/guacamole/version.txt'
             gitea:
               - 'templates/shared_services/gitea/**/*'
+            gitea_version:
+              - 'templates/shared_services/gitea/version.txt'
+
+      - name: "Stale version: api"
+        if: ${{ steps.filter.outputs.api == 'true' && steps.filter.outputs.api_version == 'false' }}
+        run: echo "::error::Code update without version change" && exit 1
+
+      - name: "Stale version: resource_processor"
+        if: ${{ steps.filter.outputs.resource_processor == 'true' && steps.filter.outputs.resource_processor_version == 'false' }}
+        run: echo "::error::Code update without version change" && exit 1
+
+      - name: "Stale version: guacamole_server"
+        if: ${{ steps.filter.outputs.guacamole_server == 'true' && steps.filter.outputs.guacamole_server_version == 'false' }}
+        run: echo "::error::Code update without version change" && exit 1
+
+      - name: "Stale version: gitea"
+        if: ${{ steps.filter.outputs.gitea == 'true' && steps.filter.outputs.gitea_version == 'false' }}
+        run: echo "::error::Code update without version change" && exit 1
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
Fixes #1359 

## What is being addressed

We tag core images with a value from a version file. If the application is updated but the version file isn't, then it might cause failures after the merge to main. 
The reason is that in PR validation we deploy a new environment, but on main we use a preexisting one. If the version file isn't change then the existing container running in the environment won't get replaced and that can produce errors in the E2E tests.

## How is this addressed

- Add a check in the CI that will enforce updating the version file when the respective application is updated. This only tests that the file was updated (git method) and not the actual number.
You can see a run result here: https://github.com/microsoft/AzureTRE/runs/5286484296?check_suite_focus=true
- An additional change is to remove the job conditions as we can run this workflow for any PR and not just native (non-fork) or with the label.