### PR TITLE
Move user check inside workflow step

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -28,7 +28,7 @@ jobs:
     # only allow commands where:
     # - the comment is on a PR
     # - the commenting user has write permissions (i.e. is OWNER or COLLABORATOR)
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') }}
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check_command.outputs.result }}
@@ -45,8 +45,43 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const commentBody = context.payload.comment.body;
+            //
+            // Check whether the user has write access to the repo
+            //
 
+            // https://docs.github.com/en/rest/reference/collaborators#check-if-a-user-is-a-repository-collaborator
+            const commentUsername = context.payload.comment.user.login;
+            const repoFullName = context.payload.repository.full_name;
+            const repoParts = repoFullName.split("/");
+            const repoOwner = repoParts[0];
+            const repoName = repoParts[1];
+
+            let userHasWriteAccess = false;
+            try {
+              console.log(`Checking if user "${commentUsername}" has write access...`)
+              const result = await github.request('GET /repos/{owner}/{repo}/collaborators/{username}', {
+                owner: repoOwner,
+                repo: repoName,
+                username: commentUsername
+              });
+              const userHasWriteAccess = result.status == 204;
+              console.log(result);
+            } catch (err) {
+              if (err.status !== 404){
+                console.log(`Error checking if user has write access: ${err.status} (${err.response.data.message}) `)
+              }
+            }
+            console.log("User has write access: " + userHasWriteAccess);
+
+            if (!userHasWriteAccess){
+              // only allow users with write access to run commands
+              return "none";
+            }
+
+            //
+            // Determine what action to take
+            //
+            const commentBody = context.payload.comment.body;
             switch (commentBody.trim()){
               case "/test":
                 return "run-tests";


### PR DESCRIPTION
More work towards #478 

The permission model for the repo isn't a simple owner/collaborator model, so the previous approach of checking the `github.event.comment.author_association` (and testing for `OWNER`/`COLLABORATOR`) doesn't work.

Instead, the check is moved from the job's `if` condition into the github-script action and calls the collaborators API as per https://docs.github.com/en/rest/reference/collaborators#check-if-a-user-is-a-repository-collaborator to test whether the user is a collaborator
