### PR TITLE
Revert to author_association check

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -28,7 +28,7 @@ jobs:
     # only allow commands where:
     # - the comment is on a PR
     # - the commenting user has write permissions (i.e. is OWNER or COLLABORATOR)
-    if: ${{ github.event.issue.pull_request }}
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') }}
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check_command.outputs.result }}
@@ -45,42 +45,6 @@ jobs:
         with:
           result-encoding: string
           script: |
-            //
-            // Check whether the user has write access to the repo
-            //
-
-            // https://docs.github.com/en/rest/reference/collaborators#check-if-a-user-is-a-repository-collaborator
-            const commentUsername = context.payload.comment.user.login;
-            const repoFullName = context.payload.repository.full_name;
-            const repoParts = repoFullName.split("/");
-            const repoOwner = repoParts[0];
-            const repoName = repoParts[1];
-
-            let userHasWriteAccess = false;
-            try {
-              console.log(`Checking if user "${commentUsername}" has write access to ${repoOwner}/${repoName} ...`)
-              const result = await github.request('GET /repos/{owner}/{repo}/collaborators/{username}', {
-                owner: repoOwner,
-                repo: repoName,
-                username: commentUsername
-              });
-              const userHasWriteAccess = result.status === 204;
-              console.log(result);
-            } catch (err) {
-              console.log(err);
-              if (err.status === 404){
-                console.log("User not found in collaborators");
-              } else {
-                console.log(`Error checking if user has write access: ${err.status} (${err.response.data.message}) `)
-              }
-            }
-            console.log("User has write access: " + userHasWriteAccess);
-
-            if (!userHasWriteAccess){
-              // only allow users with write access to run commands
-              return "none";
-            }
-
             //
             // Determine what action to take
             //


### PR DESCRIPTION
Continued work on #478 

A previous PR moved from the `author_association` check to attempting to test for write access in the repo using the `/repos/{owner}/{repo}/collaborators/{username}` api ([docs](https://docs.github.com/en/rest/reference/collaborators#check-if-a-user-is-a-repository-collaborator)). While this worked well in a test repo, it failed here. The API always returned a 404, even for endpoints that were tested on a developer laptop with a PAT (the PAT required authorisation for the microsoft org).

After further investigation/testing, we tried adding my user directly to the collaborators (rather than as part of the group that is added) with the same permissions as it has in the group, and the `author_association` value suddenly started to identify me as a `COLLABORATOR`. During this test, the collaborators API also identified me as a collaborator.

This PR reverts to the `author_association` check as both options appear to have the same requirement and it is the simpler of the two options. The `author_association` check also allows the test to be part of the `if` condition on the workflow step, avoiding running the workflow when the condition isn't met, which saves workflow execution time.