### PR TITLE
Fixes for pr_comment_bot

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -88,11 +88,14 @@ jobs:
         if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Set up Docker BuildKit
         uses: docker/setup-buildx-action@v1
+        with:
+          persist-credentials: false
 
       - name: Login to Container Registry
         uses: docker/login-action@v1
@@ -184,11 +187,14 @@ jobs:
       - name: Checkout (default)
         if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Checkout (PR)
         if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -226,11 +232,14 @@ jobs:
       - name: Checkout (default)
         if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Checkout (PR)
         if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -341,11 +350,14 @@ jobs:
       - name: Checkout (default)
         if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Checkout (PR)
         if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -397,8 +409,19 @@ jobs:
              BUNDLE_DIR: "./templates/workspace_services/innereye"}
     environment: Dev
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Register bundle
         uses: ./.github/actions/devcontainer_run_command
@@ -431,11 +454,14 @@ jobs:
       - name: Checkout (default)
         if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Checkout (PR)
         if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -506,11 +532,14 @@ jobs:
       - name: Checkout (default)
         if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Checkout (PR)
         if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -181,8 +181,16 @@ jobs:
           build-and-push-gitea]
 
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Docker build
         uses: ./.github/actions/devcontainer_run_command
@@ -215,8 +223,16 @@ jobs:
     needs: [build_core_images]
     environment: Dev
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Deploy Trusted Research Environment
         uses: ./.github/actions/devcontainer_run_command
@@ -285,8 +301,16 @@ jobs:
              BUNDLE_DIR: "./templates/workspace_services/innereye"}
     environment: Dev
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Publish bundle
         uses: ./.github/actions/devcontainer_run_command
@@ -314,8 +338,16 @@ jobs:
         target: [build-and-push-guacamole]
 
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Docker build
         uses: ./.github/actions/devcontainer_run_command
@@ -396,8 +428,16 @@ jobs:
     environment: Dev
     needs: [register_bundles, build_additional_images]
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Run E2E Tests (Smoke)
         uses: ./.github/actions/devcontainer_run_command
@@ -463,8 +503,16 @@ jobs:
     environment: Dev
     needs: [register_bundles, build_additional_images]
     steps:
-      - name: Checkout
+      - name: Checkout (default)
+        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
         uses: actions/checkout@v2
+
+      - name: Checkout (PR)
+        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
 
       - name: Run E2E Tests (Extended)
         uses: ./.github/actions/devcontainer_run_command

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -76,7 +76,10 @@ jobs:
         if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'force-approve' }}
         uses: actions/checkout@v2
         with:
+          repository: ${{ inputs.prRepo }}
+          ref: ${{ inputs.prRef }}
           persist-credentials: false
+
       - uses: dorny/paths-filter@v2
         id: filter
         if: ${{ steps.check_command.outputs.result == 'run-tests' }}


### PR DESCRIPTION
- Fixup checkout steps across jobs to ensure that all stages of the PR build are using the correct commit
- Add persist-credentials=false in re-usable workflow
- Set repo/ref on checkout for filter (attempt to fix `.md` filter on build)

(Part of #478)