### PR TITLE
Fix firewall check in control script 

### DIFF
--- a/devops/scripts/control_tre.sh
+++ b/devops/scripts/control_tre.sh
@@ -48,6 +48,7 @@ elif [[ "$1" == *"stop"* ]]; then
   fi
 
   if [[ $(az network application-gateway list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='agw-${TRE_ID}'&&operationalState=='Running'] | length(@)") != 0 ]]; then
+    echo "Stopping Application Gateway"
     az network application-gateway stop -g "rg-$TRE_ID" -n "agw-$TRE_ID"
   else
     echo "Application Gateway already stopped"

--- a/devops/scripts/control_tre.sh
+++ b/devops/scripts/control_tre.sh
@@ -9,44 +9,48 @@ if [[ -z ${TRE_ID:-} ]]; then
     exit 1
 fi
 
-az config set extension.use_dynamic_install=yes_without_prompt
-
-# if we don't have a firewall, no need to continue this script.
+# if the resource group doesn't exist, no need to continue this script.
 # most likely this is an automated execution before calling make tre-deploy.
-if [[ $(az network firewall list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='fw-${TRE_ID}'] | length(@)") == 0 ]]; then
-  echo "TRE resource group or firewall don't exits. Exiting..."
+if [[ $(az group list --query "[?name=='rg-${TRE_ID}'] | length(@)") == 0 ]]; then
+  echo "TRE resource group doesn't exits. Exiting..."
   exit 0
 fi
 
+az config set extension.use_dynamic_install=yes_without_prompt
+
 if [[ "$1" == *"start"* ]]; then
-  CURRENT_PUBLIC_IP=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].publicIpAddress" -o tsv)
-  if [ -z "$CURRENT_PUBLIC_IP" ]; then
-    echo -e "Starting Firewall - creating ip-config"
-    az network firewall ip-config create -f "fw-$TRE_ID" -g "rg-$TRE_ID" -n "fw-ip-configuration" --public-ip-address "pip-fw-$TRE_ID" --vnet-name "vnet-$TRE_ID" > /dev/null
-  else
-    echo -e "Firewall ip-config already exists"
+  if [[ $(az network firewall list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='fw-${TRE_ID}'] | length(@)") != 0 ]]; then
+    CURRENT_PUBLIC_IP=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].publicIpAddress" -o tsv)
+    if [ -z "$CURRENT_PUBLIC_IP" ]; then
+      echo "Starting Firewall - creating ip-config"
+      az network firewall ip-config create -f "fw-$TRE_ID" -g "rg-$TRE_ID" -n "fw-ip-configuration" --public-ip-address "pip-fw-$TRE_ID" --vnet-name "vnet-$TRE_ID" > /dev/null
+    else
+      echo "Firewall ip-config already exists"
+    fi
   fi
 
   if [[ $(az network application-gateway list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='agw-${TRE_ID}'&&operationalState=='Stopped'] | length(@)") != 0 ]]; then
-    echo -e "Starting Application Gateway\n"
+    echo "Starting Application Gateway"
     az network application-gateway start -g "rg-$TRE_ID" -n "agw-$TRE_ID"
   else
-    echo -e "Application Gateway already running"
+    echo "Application Gateway already running"
   fi
 elif [[ "$1" == *"stop"* ]]; then
-  IPCONFIG_NAME=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].name" -o tsv)
+  if [[ $(az network firewall list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='fw-${TRE_ID}'] | length(@)") != 0 ]]; then
+    IPCONFIG_NAME=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].name" -o tsv)
 
-  if [ -n "$IPCONFIG_NAME" ]; then
-    echo -e "Deleting Firewall ip-config: $IPCONFIG_NAME"
-    az network firewall ip-config delete -f "fw-$TRE_ID" -n "$IPCONFIG_NAME" -g "rg-$TRE_ID"
-  else
-    echo -e "No Firewall ip-config found"
+    if [ -n "$IPCONFIG_NAME" ]; then
+      echo "Deleting Firewall ip-config: $IPCONFIG_NAME"
+      az network firewall ip-config delete -f "fw-$TRE_ID" -n "$IPCONFIG_NAME" -g "rg-$TRE_ID"
+    else
+      echo "No Firewall ip-config found"
+    fi
   fi
 
   if [[ $(az network application-gateway list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='agw-${TRE_ID}'&&operationalState=='Running'] | length(@)") != 0 ]]; then
     az network application-gateway stop -g "rg-$TRE_ID" -n "agw-$TRE_ID"
   else
-    echo -e "Application Gateway already stopped"
+    echo "Application Gateway already stopped"
   fi
 fi
 


### PR DESCRIPTION
## What is being addressed

1. Control script should check for firewall existence before trying to access its settings
2. Destroy script now looks for diagnostic settings and deletes them before deleting the resource group. This is another step to allow reusing the same TREID