### PR TITLE
Diagnostic settings support only sync deletion 

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -84,7 +84,7 @@ while read -r resource_id; do
       az monitor diagnostic-settings list --resource ${resource_id} --query "value[].name" -o tsv 2> /dev/null |
       while read -r diag_name; do
         echo "Deleting ${diag_name} on ${resource_id}"
-        az monitor diagnostic-settings delete --resource ${resource_id} --name ${diag_name} ${no_wait_option}
+        az monitor diagnostic-settings delete --resource ${resource_id} --name ${diag_name}
       done
   fi
 done


### PR DESCRIPTION
## What is being addressed

In PR #1387 I have included an async option to delete diagnostic settings, but that's unsupported. So removing it...