### PR TITLE
Make uses destroy script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,9 +178,7 @@ tre-destroy:
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
-	&& . ./devops/scripts/load_terraform_env.sh ./devops/.env \
-	&& . ./devops/scripts/load_terraform_env.sh ./templates/core/.env \
-	&& cd ./templates/core/terraform/ && ./destroy.sh
+	&& . ./devops/scripts/destroy_env_no_terraform.sh
 
 terraform-deploy:
 	$(call target_title, "Deploying ${DIR} with Terraform") \

--- a/devops/scripts/control_tre.sh
+++ b/devops/scripts/control_tre.sh
@@ -56,11 +56,12 @@ elif [[ "$1" == *"stop"* ]]; then
 fi
 
 # Report final FW status
-PUBLIC_IP=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].publicIpAddress" -o tsv)
-if [ -n "$PUBLIC_IP" ]; then
-  FW_STATE="Running"
-else
-  FW_STATE="Stopped"
+FW_STATE="Stopped"
+if [[ $(az network firewall list --query "[?resourceGroup=='rg-${TRE_ID}'&&name=='fw-${TRE_ID}'] | length(@)") != 0 ]]; then
+  PUBLIC_IP=$(az network firewall ip-config list -f "fw-$TRE_ID" -g "rg-$TRE_ID" --query "[0].publicIpAddress" -o tsv)
+  if [ -n "$PUBLIC_IP" ]; then
+    FW_STATE="Running"
+  fi
 fi
 
 # Report final AGW status

--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -23,11 +23,6 @@ USAGE
     exit 1
 }
 
-# if no arguments are provided, return usage function
-if [ $# -eq 0 ]; then
-    usage # run usage function
-fi
-
 no_wait=false
 
 while [ "$1" != "" ]; do

--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -91,7 +91,7 @@ az resource list --resource-group ${core_tre_rg} --query '[].[id]' -o tsv | xarg
 
 # purge keyvault if possible (makes it possible to reuse the same tre_id later)
 # this has to be done before we delete the resource group since we don't wait for it to complete
-if [[ $(az keyvault list --resource-group ${core_tre_rg} --query '[?proterties.enablePurgeProtection==null] | length (@)') != 0 ]]; then
+if [[ $(az keyvault list --resource-group ${core_tre_rg} --query '[?properties.enablePurgeProtection==null] | length (@)') != 0 ]]; then
   tre_id=${core_tre_rg#"rg-"}
   keyvault_name="kv-${tre_id}"
 


### PR DESCRIPTION
Fixes #510, Fixes #1164

## What is being addressed
With the recent changes in how the CI destroy environments and the move of shared services outside of the core deployment, the current tre-destroy make target isn't able to handle some of the nuances.



## How is this addressed

The primary change is to wire the make target to the [destroy_env_no_terraform script](https://github.com/microsoft/AzureTRE/blob/main/devops/scripts/destroy_env_no_terraform.sh) which now performs the following activates:
1. Delete all locks
2. Delete all diagnostic settings for any resource in the core resource group (Terraform sometimes doesn't clean up this very well)
3. Delete the core keyvault
4. Purge the core keyvault if its purge protection is off (Terraform cannot do this)
5. Delete all resource groups that start with the same prefix as the core one, i.e. rg-TRE_ID. This results is all workspace RGs being deleted as well (Terraform cannot do this in a simple way)
