### PR TITLE
Add test-destroy-env command

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -55,6 +55,8 @@ jobs:
                 return "run-tests";
               case "/test-force-approve":
                 return "test-force-approve";
+              case "/test-destroy-env":
+                return "test-destroy-env";
               case "/help":
                 return "show-help";
               default:
@@ -70,12 +72,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Showing help on PR ${PR_NUMBER}"
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Hello<br/><br/>You can use the following commands:<br/>    /test - run tests on a PR<br/>    /test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)<br/>    /help - show this help"
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "Hello<br/><br/>You can use the following commands:<br/>    /test - run tests on a PR<br/>    /test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)<br/>    /test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)    /help - show this help"
 
       # Get PR commit details for running tests
       - id: get_pr_details
         name: Get PR details
-        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'test-force-approve' }}
+        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'test-force-approve' || steps.check_command.outputs.result == 'test-destroy-env' }}
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.event.repository.full_name }}
@@ -157,6 +159,24 @@ jobs:
         run: |
           echo "Showing help on PR ${PR_NUMBER}"
           gh pr comment ${PR_NUMBER} --repo $REPO --body "Running tests: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+      # Perform az login for destroy env script to be able to run
+      - name: Azure Login
+        if: ${{ steps.check_command.outputs.result == 'test-destroy-env' }}
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      # Destroy validation deployment
+      - name: Run deployment cleanup
+        if: ${{ steps.check_command.outputs.result == 'test-destroy-env' }}
+        env:
+          RG_NAME: ${{ format('rg-tre{0}-mgmt', steps.get_pr_details.outputs.refid) }}
+        run: |
+          set -e
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying test environment... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          devops/scripts/destroy_env_no_terraform.sh --core-tre-rg ${RG_NAME}
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "Test environment destroy complete"
 
 
   run_test:


### PR DESCRIPTION
Building on the comment-based commands work for #478, this PR adds a `test-destroy-env` command to destroy a test validation environment for a PR 