### PR TITLE
Update to collaborators API

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -93,17 +93,12 @@ jobs:
           echo "prRHeadSha: ${{ inputs.prHeadSha }}"
           echo "ciGitRef  : ${{ inputs.ciGitRef }}"
 
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -197,17 +192,12 @@ jobs:
           build-and-push-gitea]
 
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -242,17 +232,12 @@ jobs:
     needs: [build_core_images]
     environment: Dev
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -425,16 +410,12 @@ jobs:
              BUNDLE_DIR: "./templates/workspace_services/innereye"}
     environment: Dev
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -464,17 +445,12 @@ jobs:
         target: [build-and-push-guacamole]
 
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -526,20 +502,14 @@ jobs:
              BUNDLE_DIR: "./templates/workspace_services/innereye"}
     environment: Dev
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
-
       - name: Register bundle
         uses: ./.github/actions/devcontainer_run_command
         with:
@@ -568,17 +538,12 @@ jobs:
     environment: Dev
     needs: [register_bundles, build_additional_images]
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
@@ -660,17 +625,12 @@ jobs:
     environment: Dev
     needs: [register_bundles, build_additional_images]
     steps:
-      - name: Checkout (default)
-        if: ${{ inputs.prRepo == '' }} # if not running for a PR, checkout the default ref for the workflow run
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-
-      - name: Checkout (PR)
-        if: ${{ inputs.prRepo != '' }} # if running for a PR, checkout the PR commit
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
           repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -62,7 +62,7 @@ jobs:
     # only allow commands where:
     # - the comment is on a PR
     # - the commenting user has write permissions (i.e. is OWNER or COLLABORATOR)
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') }}
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check_command.outputs.result }}
@@ -80,6 +80,43 @@ jobs:
         with:
           result-encoding: string
           script: |
+            // Previously, we attempted to use github.event.comment.author_association to check for OWNER or COLLABORATOR
+            // Unfortunately, that always shows MEMBER if you are in the microsoft org and have that set to publicly visible
+            // (Can check via https://github.com/orgs/microsoft/people?query=<username>)
+
+            // https://docs.github.com/en/rest/reference/collaborators#check-if-a-user-is-a-repository-collaborator
+            const commentUsername = context.payload.comment.user.login;
+            const repoFullName = context.payload.repository.full_name;
+            const repoParts = repoFullName.split("/");
+            const repoOwner = repoParts[0];
+            const repoName = repoParts[1];
+
+            let userHasWriteAccess = false;
+            try {
+              console.log(`Checking if user "${commentUsername}" has write access to ${repoOwner}/${repoName} ...`)
+              const result = await github.request('GET /repos/{owner}/{repo}/collaborators/{username}', {
+                owner: repoOwner,
+                repo: repoName,
+                username: commentUsername
+              });
+              userHasWriteAccess = result.status === 204;
+              console.log("success")
+              console.log(result);
+            } catch (err) {
+              console.log("error")
+              console.log(err);
+              if (err.status === 404){
+                console.log("User not found in collaborators");
+              } else {
+                console.log(`Error checking if user has write access: ${err.status} (${err.response.data.message}) `)
+              }
+            }
+            console.log("User has write access: " + userHasWriteAccess);
+
+            if (!userHasWriteAccess) {
+              return "none"; // only allow actions for users with write access
+            }
+
             //
             // Determine what action to take
             //

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -253,6 +253,7 @@ jobs:
         if: ${{ steps.check_command.outputs.result == 'test-destroy-env' }}
         env:
           RG_NAME: ${{ format('rg-tre{0}-mgmt', steps.get_pr_details.outputs.refid) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying test environment... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"


### PR DESCRIPTION
- Convert to collaborators API for permission check (seems to work regardless of whether the user has the `microsoft` org publicly visible or not, unlike the `author_association`)
- Simplify checkout logic
- Add GITHUB_TOKEN to env destroy step