### PR TITLE
Sort RGs before delete

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -109,7 +109,9 @@ else
 fi
 
 # this will find the mgmt, core resource groups as well as any workspace ones
-az group list --query "[?starts_with(name, '${core_tre_rg}')].[name]" -o tsv |
+# we are reverse-sorting to first delete the workspace groups (might not be
+# good enough because we use no-wait sometimes)
+az group list --query "[?starts_with(name, '${core_tre_rg}')].[name]" -o tsv | sort -r |
 while read -r rg_item; do
   echo "Deleting resource group: ${rg_item}"
   az group delete --resource-group "${rg_item}" --yes ${no_wait_option}


### PR DESCRIPTION
Fixes #1438 

## What is being addressed

Workspace group might have references to the routetable in the core resource group. The destroy script will first try to delete the core RG and that will fail in these situations.

## How is this addressed

- Reverse sort the resource groups so workspace ones (e.g. rg-treid-ws-12ab) will be deleted first
