### PR TITLE
Delete failed E2E workspaces in the cleanup workflow/script

### DIFF
--- a/.github/workflows/clean_validation_envs.yml
+++ b/.github/workflows/clean_validation_envs.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Run clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAIN_TRE_ID: ${{ secrets.TRE_ID }}
           BRANCH_LAST_ACTIVITY_IN_HOURS: 4
         run: devops/scripts/clean_ci_validation_envs.sh

--- a/devops/scripts/clean_ci_validation_envs.sh
+++ b/devops/scripts/clean_ci_validation_envs.sh
@@ -66,12 +66,13 @@ while read -r rg_name rg_ref_name; do
 done
 
 # check if any workflows run on the main branch
+# to prevent us deleting a workspace for which an E2E (on main) is currently running
 if [ $(gh api "https://api.github.com/repos/microsoft/AzureTRE/actions/runs?branch=main&status=in_progress" --jq ".total_count") == 0 ]
 then
   # if not, we can delete old workspace resource groups that were left due to errors.
   az group list --query "[?starts_with(name, 'rg-${MAIN_TRE_ID}-')].name" -o tsv |
   while read -r rg_name; do
     echo "Deleting resource gorup: ${rg_name}"
-    # az group delete --yes --no-wait --name ${rg_name}
+    az group delete --yes --no-wait --name ${rg_name}
   done
 fi

--- a/devops/scripts/clean_ci_validation_envs.sh
+++ b/devops/scripts/clean_ci_validation_envs.sh
@@ -64,3 +64,14 @@ while read -r rg_name rg_ref_name; do
     fi
   fi
 done
+
+# check if any workflows run on the main branch
+if [ $(gh api "https://api.github.com/repos/microsoft/AzureTRE/actions/runs?branch=main&status=in_progress" --jq ".total_count") == 0 ]
+then
+  # if not, we can delete old workspace resource groups that were left due to errors.
+  az group list --query "[?starts_with(name, 'rg-${MAIN_TRE_ID}-')].name" -o tsv |
+  while read -r rg_name; do
+    echo "Deleting resource gorup: ${rg_name}"
+    # az group delete --yes --no-wait --name ${rg_name}
+  done
+fi

--- a/devops/scripts/clean_ci_validation_envs.sh
+++ b/devops/scripts/clean_ci_validation_envs.sh
@@ -72,7 +72,7 @@ then
   # if not, we can delete old workspace resource groups that were left due to errors.
   az group list --query "[?starts_with(name, 'rg-${MAIN_TRE_ID}-')].name" -o tsv |
   while read -r rg_name; do
-    echo "Deleting resource gorup: ${rg_name}"
+    echo "Deleting resource group: ${rg_name}"
     az group delete --yes --no-wait --name ${rg_name}
   done
 fi


### PR DESCRIPTION
Fixes #1144 

## What is being addressed

Failures in the E2E tests running on main can leave behind workspaces.

## How is this addressed

- Add a delete activity to the cleanup script and workflow that removes workspace resource groups associates with the environment of the main branch.
This will run only if there're no other workflow is currently running on the main branch. Although the pr_bot workflow always run under the main context, it's not that much of a problem if the delete action will only run every once in a while (like at night)
An example: https://github.com/microsoft/AzureTRE/runs/5446762221?check_suite_focus=true

PR deploy test were skipped because they don't test this workflow/script.