### PR TITLE
Tidy-up work for pr-comment-bot

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -4,10 +4,6 @@ name: Deploy Azure TRE Resuable
 on:
   workflow_call:
     inputs:
-      prRepo:
-        description: Name of the repo GitHub repo containing the ref (as org/repo)
-        type: string
-        required: false
       prRef:
         description: The git ref to checkout
         type: string
@@ -90,7 +86,6 @@ jobs:
         run: |
           echo "Inputs"
           echo "======"
-          echo "prRepo    : ${{ inputs.prRepo }}"
           echo "prRef     : ${{ inputs.prRef }}"
           echo "prRHeadSha: ${{ inputs.prHeadSha }}"
           echo "ciGitRef  : ${{ inputs.ciGitRef }}"
@@ -101,7 +96,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Set up Docker BuildKit
@@ -190,7 +184,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Docker build
@@ -220,7 +213,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Deploy TRE Core
@@ -388,7 +380,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Publish bundle
@@ -423,7 +414,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Docker build
@@ -470,7 +460,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
       - name: Register bundle
         uses: ./.github/actions/devcontainer_run_command
@@ -506,7 +495,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Run E2E Tests (Smoke)
@@ -571,7 +559,6 @@ jobs:
           persist-credentials: false
           # if the following values are missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
-          repository: ${{ inputs.prRepo }}
           ref: ${{ inputs.prRef }}
 
       - name: Run E2E Tests (Extended)

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -74,10 +74,12 @@ jobs:
 
             //
             // Determine what action to take
+            // Only use the first line of the comment to allow remainder of the body for other comments/notes
             //
             const commentBody = context.payload.comment.body;
+            const commentFirstLine = commentBody.split("\n")[0];
             let command = "none";
-            switch (commentBody.trim()){
+            switch (commentFirstLine.trim()){
               case "/test":
                 command = "run-tests";
               case "/test-force-approve":

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -148,7 +148,10 @@ jobs:
       # Get PR commit details for running tests
       - id: get_pr_details
         name: Get PR details
-        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'test-force-approve' || steps.check_command.outputs.result == 'test-destroy-env' }}
+        if: |
+          ${{ steps.check_command.outputs.result == 'run-tests'
+              || steps.check_command.outputs.result == 'test-force-approve'
+              || steps.check_command.outputs.result == 'test-destroy-env' }}
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.event.repository.full_name }}
@@ -199,7 +202,10 @@ jobs:
 
       # Check if the PR build/test needs to run
       - name: Checkout
-        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'test-force-approve' || steps.check_command.outputs.result == 'test-destroy-env' }}
+        if: |
+          ${{ steps.check_command.outputs.result == 'run-tests'
+              || steps.check_command.outputs.result == 'test-force-approve'
+              || steps.check_command.outputs.result == 'test-destroy-env' }}
         uses: actions/checkout@v2
         with:
           # repository: ${{ steps.get_pr_details.outputs.prRepo }}
@@ -220,7 +226,10 @@ jobs:
       # If we don't run the actual deploy (below) we won't receive a check-run status,
       # and will have to send it "manually"
       - name: Bypass E2E check-runs status
-        if: ${{ (steps.check_command.outputs.result == 'run-tests' && steps.filter.outputs.not-md == 'false') || steps.check_command.outputs.result == 'test-force-approve' }}
+        if: |
+          ${{ (steps.check_command.outputs.result == 'run-tests'
+                && steps.filter.outputs.not-md == 'false'
+              ) || steps.check_command.outputs.result == 'test-force-approve' }}
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -267,7 +276,9 @@ jobs:
   run_test:
     # Run the tests with the re-usable workflow
     needs: [pr_comment]
-    if: ${{ needs.pr_comment.outputs.command == 'run-tests' && needs.pr_comment.outputs.not-md == 'true' }}
+    if: |
+      ${{ needs.pr_comment.outputs.command == 'run-tests'
+          && needs.pr_comment.outputs.not-md == 'true' }}
     name: Deploy PR
     uses: ./.github/workflows/deploy_tre_reusable.yml
     with:

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check_command.outputs.result }}
-      prRepo: ${{ steps.get_pr_details.outputs.prRepo }}
       prRef: ${{ steps.get_pr_details.outputs.prRef }}
       prHeadSha: ${{ steps.get_pr_details.outputs.prHeadSha }}
       refid: ${{ steps.get_pr_details.outputs.refid }}
@@ -114,12 +113,7 @@ jobs:
           REPO: ${{ github.event.repository.full_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Could look at moving this to GitHub Script action as well
-
-          echo "Getting PR repo..."
-          pr_owner=$(gh pr view $PR_NUMBER --repo $REPO --json headRepositoryOwner | jq -r .headRepositoryOwner.login)
-          pr_repo=$(gh pr view $PR_NUMBER --repo $REPO --json headRepository | jq -r .headRepository.name)
-          echo -e "\tPR from $pr_owner/$pr_repo"
+          # Leaving this as bash script as GitHub Script doesn't seem to support multiple output values
 
           echo "Getting PR ref..."
           ref=$(gh pr view $PR_NUMBER --repo $REPO --json commits | jq -r ".[] | last | .oid")
@@ -131,14 +125,12 @@ jobs:
 
           echo "Setting outputs"
           echo "::set-output name=prRef::${prMergeRef}"
-          echo "::set-output name=prRepo::${pr_owner}/${pr_repo}"
-          echo "Done"
 
           github_pr_ref="refs/pull/${PR_NUMBER}/merge"
           echo "::set-output name=ciGitRef::${github_pr_ref}"
 
           REFID=$(echo ${github_pr_ref} | shasum | cut -c1-8)
-          echo "using id of: ${REFID} for GitHub Ref: ${github_pr_ref}"
+          echo "using id of: ${REFID} for GitHub Ref: ${github_pr_ref} (RG base name)"
           echo "::set-output name=refid::${REFID}"
 
           # Get PR HEAD SHA for checks status
@@ -152,7 +144,6 @@ jobs:
           echo "PR Details"
           echo "=========="
           echo "prRef    : ${{ steps.get_pr_details.outputs.prRef }}"
-          echo "prRepo   : ${{ steps.get_pr_details.outputs.prRepo }}"
           echo "prHeadSha: ${{ steps.get_pr_details.outputs.prHeadSha }}"
           echo "refid    : ${{ steps.get_pr_details.outputs.refid }}"
           echo "ciGitRef : ${{ steps.get_pr_details.outputs.ciGitRef }}"
@@ -165,7 +156,6 @@ jobs:
               || steps.check_command.outputs.result == 'test-destroy-env' }}
         uses: actions/checkout@v2
         with:
-          # repository: ${{ steps.get_pr_details.outputs.prRepo }}
           ref: ${{ steps.get_pr_details.outputs.prRef }}
           persist-credentials: false
 
@@ -241,7 +231,6 @@ jobs:
     with:
       prRef: ${{ needs.pr_comment.outputs.prRef }}
       prHeadSha: ${{ needs.pr_comment.outputs.prHeadSha }}
-      # prRepo: ${{ needs.pr_comment.outputs.prRepo }}
       ciGitRef: ${{ needs.pr_comment.outputs.ciGitRef }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -8,51 +8,6 @@ on:
 
 jobs:
 
-  debug:
-    name: temp - debug
-    runs-on: ubuntu-latest
-    steps:
-      # Determine whether the comment is a command
-      - name: Echo payload info
-        run: |
-          echo "Debug...."
-          echo "github.event.issue.pull_request: ${{ github.event.issue.pull_request }}"
-          echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
-
-      - name: Check for user permissions
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            // https://docs.github.com/en/rest/reference/collaborators#check-if-a-user-is-a-repository-collaborator
-            const commentUsername = context.payload.comment.user.login;
-            const repoFullName = context.payload.repository.full_name;
-            const repoParts = repoFullName.split("/");
-            const repoOwner = repoParts[0];
-            const repoName = repoParts[1];
-
-            let userHasWriteAccess = false;
-            try {
-              console.log(`Checking if user "${commentUsername}" has write access to ${repoOwner}/${repoName} ...`)
-              const result = await github.request('GET /repos/{owner}/{repo}/collaborators/{username}', {
-                owner: repoOwner,
-                repo: repoName,
-                username: commentUsername
-              });
-              userHasWriteAccess = result.status === 204;
-              console.log("success")
-              console.log(result);
-            } catch (err) {
-              console.log("error")
-              console.log(err);
-              if (err.status === 404){
-                console.log("User not found in collaborators");
-              } else {
-                console.log(`Error checking if user has write access: ${err.status} (${err.response.data.message}) `)
-              }
-            }
-            console.log("User has write access: " + userHasWriteAccess);
-
   pr_comment:
     name: PR comment
     environment: Dev

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -204,7 +204,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          echo "Showing help on PR ${PR_NUMBER}"
+          echo "Adding comment with link to run on PR ${PR_NUMBER}"
           gh pr comment ${PR_NUMBER} --repo $REPO --body "Running tests: https://github.com/${REPO}/actions/runs/${RUN_ID}"
 
       # Perform az login for destroy env script to be able to run

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -114,6 +114,7 @@ jobs:
             console.log("User has write access: " + userHasWriteAccess);
 
             if (!userHasWriteAccess) {
+              console.log("Command: none [user doesn't have permission]");
               return "none"; // only allow actions for users with write access
             }
 
@@ -121,18 +122,19 @@ jobs:
             // Determine what action to take
             //
             const commentBody = context.payload.comment.body;
+            let command = "none";
             switch (commentBody.trim()){
               case "/test":
-                return "run-tests";
+                command = "run-tests";
               case "/test-force-approve":
-                return "test-force-approve";
+                command = "test-force-approve";
               case "/test-destroy-env":
-                return "test-destroy-env";
+                command = "test-destroy-env";
               case "/help":
-                return "show-help";
-              default:
-                return "none";
+                command = "show-help";
             }
+            console.log(`Command: ${command}`);
+            return command;
 
       # Add comment with help text in response to help command
       - name: Show Help


### PR DESCRIPTION
- Format `if` conditions to reduce long lines
- Log command decision
- Remove permission debug job
- Fixup log message
- Remove unused PR repo values
- Only check first line of comment for command (allows adding other comment, e.g. notes/justification for test-force-approve)

Tidying up for #478 (not final, i.e. future PR will continue this work)