### PR TITLE
Fix: update `/test` builds to ensure PR code is tested

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -119,11 +119,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        persist-credentials: false
-
     - name: Login to Container Registry
       uses: docker/login-action@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ deploy-shared-services: firewall-install gitea-install nexus-install
 migrate-firewall-state: prepare-tf-state
 
 bootstrap:
+	echo "**** SL TEST - check that this is output ****"
 	$(call target_title, "Bootstrap Terraform") \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ deploy-shared-services: firewall-install gitea-install nexus-install
 migrate-firewall-state: prepare-tf-state
 
 bootstrap:
-	echo "**** SL TEST - check that this is output ****"
 	$(call target_title, "Bootstrap Terraform") \
 	&& . ./devops/scripts/check_dependencies.sh nodocker \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \


### PR DESCRIPTION
Remove the `checkout` step in devcontainer_run_command action as the parent jobs already include `checkout` steps (and target the ref for the PR)