### PR TITLE
Fix Typo in Base Template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ bundle-publish:
 	$(call target_title, "Publishing ${DIR} bundle with Porter") \
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/set_docker_sock_permission.sh \
 	&& az acr login --name $${ACR_NAME}	\
 	&& cd ${DIR} \
@@ -259,6 +260,7 @@ bundle-register:
 	$(call target_title, "Registering ${DIR} bundle") \
 	&& ./devops/scripts/check_dependencies.sh porter \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& az acr login --name $${ACR_NAME}	\
 	&& cd ${DIR} \
 	&& ${ROOTPATH}/devops/scripts/register_bundle_with_api.sh --acr-name $${ACR_NAME} --bundle-type $${BUNDLE_TYPE} --current --insecure --tre_url $${TRE_URL} --verify

--- a/templates/workspaces/base/template_schema.json
+++ b/templates/workspaces/base/template_schema.json
@@ -10,7 +10,7 @@
       "shared_storage_quota": {
         "$id": "#/properties/shared_storage_quota",
         "type": "integer",
-        "title": "Shared Storage Quota'",
+        "title": "Shared Storage Quota",
         "description": "Quota (in GB) to set for the VM Shared Storage."
       }
     }


### PR DESCRIPTION
This fixes the build issue in `main`

A single quote breaks the way that CURL is called in `register_bundle_with_api.sh`. The same quote does not break the Swagger docs endpoint.

Because the automation route isn't tested by developers this wasn't seen locally. In fact, the changes to the makefile included in this PR are needed to allow testing locally.

The PR which allowed this to slip in fell foul of the fact that `/test` was testing `main`, not the PR branch.