### PR TITLE
Add TRE_URL to .env.example file

### DIFF
--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -716,6 +716,9 @@ if [[ $createAutomationAccount -eq 1 ]]; then
 AUTOMATION_ADMIN_ACCOUNT_CLIENT_ID=${automationAppId}
 AUTOMATION_ADMIN_ACCOUNT_CLIENT_SECRET=${automationSpPassword}
 
+** Please copy this to /templates/core/.env and set it to be https://fqdn for your TRE **
+TRE_URL=__CHANGE_ME___
+
 ENV_VARS
 
 fi

--- a/templates/core/.env.sample
+++ b/templates/core/.env.sample
@@ -12,10 +12,10 @@ API_CLIENT_ID=__CHANGE_ME__
 API_CLIENT_SECRET=__CHANGE_ME__
 SWAGGER_UI_CLIENT_ID=__CHANGE_ME__
 
-# Automation accounts (e.g. bundle registration)
-AUTOMATION_ADMIN_ACCOUNT_CLIENT_ID=__CHANGE_ME__
-AUTOMATION_ADMIN_ACCOUNT_CLIENT_SECRET=__CHANGE_ME__
+# The following 3 environment variables are only required
+# if you want to automated bundle registration.
+# Change TRE_URL's location (e.g. westeurope) as appropriate
 
-# Bundle Registration via Automation needs to know TRE_URL.
-# Change the location (e.g. westeurope) as appropriate
-TRE_URL=https://${TRE_ID}.westeurope.cloudapp.azure.com
+# AUTOMATION_ADMIN_ACCOUNT_CLIENT_ID=__CHANGE_ME__
+# AUTOMATION_ADMIN_ACCOUNT_CLIENT_SECRET=__CHANGE_ME__
+# TRE_URL=https://${TRE_ID}.westeurope.cloudapp.azure.com

--- a/templates/core/.env.sample
+++ b/templates/core/.env.sample
@@ -15,3 +15,7 @@ SWAGGER_UI_CLIENT_ID=__CHANGE_ME__
 # Automation accounts (e.g. bundle registration)
 AUTOMATION_ADMIN_ACCOUNT_CLIENT_ID=__CHANGE_ME__
 AUTOMATION_ADMIN_ACCOUNT_CLIENT_SECRET=__CHANGE_ME__
+
+# Bundle Registration via Automation needs to know TRE_URL.
+# Change the location (e.g. westeurope) as appropriate
+TRE_URL=https://${TRE_ID}.westeurope.cloudapp.azure.com


### PR DESCRIPTION
Previous PR (#1441) added additional environment variables into the mix for `make bundle-register`

The result is that without the `TRE_URL` env var set you may see an error when you run `make bundle-register` in the situation where you have these two defined env vars...

```
AUTOMATION_ADMIN_ACCOUNT_CLIENT_ID
AUTOMATION_ADMIN_ACCOUNT_CLIENT_SECRET
```

You may see this error:

<img width="739" alt="image" src="https://user-images.githubusercontent.com/1524451/157478976-b02c1441-3cc4-41d3-8b4b-c4d527f0ab29.png">

This PR adds an addition environment variable into the `.env.example` file that the user needs to copy to the .env file within the `templates/core/` folder.

THIS IS FAR FROM PERFECT. We absolutely should create this env var ourselves, but after reviewing this for a while I realised that the .env file set up in the project is a bit messy (tracked in #1470)

For now, consider this PR as some sign-posting/documentation. 