### PR TITLE
Implement start and stop actions for vm user resources

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -61,8 +61,15 @@ outputs:
       - install
   - name: hostname
     type: string
+    applyTo:
+      - install
+      - start
+      - stop
   - name: resource_group
     type: string
+    applyTo:
+      - start
+      - stop
   - name: connection_uri
     type: string
     applyTo:
@@ -99,7 +106,6 @@ install:
       outputs:
         - name: ip
         - name: hostname
-        - name: resource_group
         - name: connection_uri
 
 upgrade:
@@ -134,6 +140,28 @@ uninstall:
         key: "{{ bundle.parameters.id }}"
 
 start:
+  - terraform:
+      arguments:
+        - "output"
+      description: "Get VM hostname and rg from Terraform outputs"
+      backendConfig:
+        resource_group_name:
+          "{{ bundle.parameters.tfstate_resource_group_name }}"
+        storage_account_name:
+          "{{ bundle.parameters.tfstate_storage_account_name }}"
+        container_name: "{{ bundle.parameters.tfstate_container_name }}"
+        key: "{{ bundle.parameters.id }}"
+      outputs:
+        - name: hostname
+        - name: resource_group
+  - az:
+      description:
+        "Login to Azure"
+      arguments:
+        - login
+      flags:
+        identity:
+        username: "{{ bundle.credentials.azure_client_id }}"
   - az:
       description:
         "Start the VM"
@@ -145,9 +173,34 @@ start:
         resource-group: "{{ bundle.outputs.resource_group }}"
 
 stop:
-  - exec:
+  - terraform:
+      arguments:
+        - "output"
+      description: "Get VM hostname and rg from Terraform outputs"
+      backendConfig:
+        resource_group_name:
+          "{{ bundle.parameters.tfstate_resource_group_name }}"
+        storage_account_name:
+          "{{ bundle.parameters.tfstate_storage_account_name }}"
+        container_name: "{{ bundle.parameters.tfstate_container_name }}"
+        key: "{{ bundle.parameters.id }}"
+      outputs:
+        - name: hostname
+        - name: resource_group
+  - az:
+      description:
+        "Login to Azure"
+      arguments:
+        - login
+      flags:
+        identity:
+        username: "{{ bundle.credentials.azure_client_id }}"
+  - az:
       description:
         "Stop the VM"
-      command: echo
       arguments:
-        - "NotImplemented"
+        - vm
+        - stop
+      flags:
+        name: "{{ bundle.outputs.hostname }}"
+        resource-group: "{{ bundle.outputs.resource_group }}"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-service-guacamole-linuxvm
-version: 0.1.4
+version: 0.1.5
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -61,8 +61,8 @@ outputs:
       - install
   - name: hostname
     type: string
-    applyTo:
-      - install
+  - name: resource_group
+    type: string
   - name: connection_uri
     type: string
     applyTo:
@@ -72,6 +72,7 @@ mixins:
   - exec
   - terraform:
       clientVersion: 1.0.4
+  - az
 
 install:
   - terraform:
@@ -98,6 +99,7 @@ install:
       outputs:
         - name: ip
         - name: hostname
+        - name: resource_group
         - name: connection_uri
 
 upgrade:
@@ -132,12 +134,15 @@ uninstall:
         key: "{{ bundle.parameters.id }}"
 
 start:
-  - exec:
+  - az:
       description:
         "Start the VM"
-      command: echo
       arguments:
-        - "NotImplemented"
+        - vm
+        - start
+      flags:
+        name: "{{ bundle.outputs.hostname }}"
+        resource-group: "{{ bundle.outputs.resource_group }}"
 
 stop:
   - exec:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/main.tf
@@ -55,6 +55,10 @@ output "hostname" {
   value = azurerm_linux_virtual_machine.linuxvm.name
 }
 
+output "resource_group" {
+  value = data.azurerm_resource_group.ws.name
+}
+
 output "azure_resource_id" {
   value = azurerm_linux_virtual_machine.linuxvm.id
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-service-guacamole-windowsvm
-version: 0.1.4
+version: 0.1.5
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -63,6 +63,13 @@ outputs:
     type: string
     applyTo:
       - install
+      - start
+      - stop
+  - name: resource_group
+    type: string
+    applyTo:
+      - start
+      - stop
   - name: connection_uri
     type: string
     applyTo:
@@ -72,6 +79,7 @@ mixins:
   - exec
   - terraform:
       clientVersion: 1.0.4
+  - az
 
 install:
   - terraform:
@@ -132,17 +140,67 @@ uninstall:
         key: "{{ bundle.parameters.id }}"
 
 start:
-  - exec:
+  - terraform:
+      arguments:
+        - "output"
+      description: "Get VM hostname and rg from Terraform outputs"
+      backendConfig:
+        resource_group_name:
+          "{{ bundle.parameters.tfstate_resource_group_name }}"
+        storage_account_name:
+          "{{ bundle.parameters.tfstate_storage_account_name }}"
+        container_name: "{{ bundle.parameters.tfstate_container_name }}"
+        key: "{{ bundle.parameters.id }}"
+      outputs:
+        - name: hostname
+        - name: resource_group
+  - az:
+      description:
+        "Login to Azure"
+      arguments:
+        - login
+      flags:
+        identity:
+        username: "{{ bundle.credentials.azure_client_id }}"
+  - az:
       description:
         "Start the VM"
-      command: echo
       arguments:
-        - "NotImplemented"
+        - vm
+        - start
+      flags:
+        name: "{{ bundle.outputs.hostname }}"
+        resource-group: "{{ bundle.outputs.resource_group }}"
 
 stop:
-  - exec:
+  - terraform:
+      arguments:
+        - "output"
+      description: "Get VM hostname and rg from Terraform outputs"
+      backendConfig:
+        resource_group_name:
+          "{{ bundle.parameters.tfstate_resource_group_name }}"
+        storage_account_name:
+          "{{ bundle.parameters.tfstate_storage_account_name }}"
+        container_name: "{{ bundle.parameters.tfstate_container_name }}"
+        key: "{{ bundle.parameters.id }}"
+      outputs:
+        - name: hostname
+        - name: resource_group
+  - az:
+      description:
+        "Login to Azure"
+      arguments:
+        - login
+      flags:
+        identity:
+        username: "{{ bundle.credentials.azure_client_id }}"
+  - az:
       description:
         "Stop the VM"
-      command: echo
       arguments:
-        - "NotImplemented"
+        - vm
+        - stop
+      flags:
+        name: "{{ bundle.outputs.hostname }}"
+        resource-group: "{{ bundle.outputs.resource_group }}"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
@@ -52,7 +52,11 @@ output "ip" {
 }
 
 output "hostname" {
-  value = azurerm_windows_virtual_machine.windowsvm.name
+  value = local.vm_name
+}
+
+output "resource_group" {
+  value = data.azurerm_resource_group.ws.name
 }
 
 output "azure_resource_id" {

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
@@ -52,7 +52,7 @@ output "ip" {
 }
 
 output "hostname" {
-  value = local.vm_name
+  value = azurerm_windows_virtual_machine.windowsvm.name
 }
 
 output "resource_group" {


### PR DESCRIPTION
# PR for issue

## What is being addressed

Building on my custom actions work, I've created start and stop actions for the VM porter bundles (Windows and Linux) using the az and terraform mixins. This allows invoking of the 'start' and 'stop' actions in the TRE API for a user resource

## How is this addressed

- Added start/stop custom actions to porter bundles (guacamole user resources)
- Used Terraform mixing to get tf outputs for vm names and resource groups
- Used az mixim to authenticate using MSI and apply the start/stop commands
