### PR TITLE
fix delete e2e workspace

### DIFF
--- a/devops/scripts/clean_ci_validation_envs.sh
+++ b/devops/scripts/clean_ci_validation_envs.sh
@@ -65,9 +65,10 @@ while read -r rg_name rg_ref_name; do
   fi
 done
 
-# check if any workflows run on the main branch (except the cleanup one)
+# check if any workflows run on the main branch (except the cleanup=current one)
 # to prevent us deleting a workspace for which an E2E (on main) is currently running
-if [[ -z $(gh api "https://api.github.com/repos/microsoft/AzureTRE/actions/runs?branch=main&status=in_progress" | jq '.workflow_runs | select(.[].name != "Clean Validation Environments")') ]]
+echo "workflow name is: ${GITHUB_WORKFLOW}"
+if [[ -z $(gh api "https://api.github.com/repos/microsoft/AzureTRE/actions/runs?branch=main&status=in_progress" | jq --arg GITHUB_WORKFLOW '.workflow_runs | select(.[].name != "$GITHUB_WORKFLOW")') ]]
 then
   # if not, we can delete old workspace resource groups that were left due to errors.
   az group list --query "[?starts_with(name, 'rg-${MAIN_TRE_ID}-')].name" -o tsv |


### PR DESCRIPTION
## What is being addressed

Cleanup script always skips deleting old e2e workspaces.

## How is this addressed

- Adjust the running workflow condition to not check the cleanup workflow itself before deciding to delete workspaces.
