### PR TITLE
Fix race condition on base workspace subnets

### DIFF
--- a/templates/workspaces/base/terraform/storage.tf
+++ b/templates/workspaces/base/terraform/storage.tf
@@ -32,6 +32,10 @@ resource "azurerm_private_endpoint" "stgfilepe" {
   resource_group_name = azurerm_resource_group.ws.name
   subnet_id           = azurerm_subnet.services.id
 
+  depends_on = [
+    azurerm_subnet.services
+  ]
+
   lifecycle { ignore_changes = [tags] }
 
   private_dns_zone_group {
@@ -53,6 +57,10 @@ resource "azurerm_private_endpoint" "stgblobpe" {
   location            = azurerm_resource_group.ws.location
   resource_group_name = azurerm_resource_group.ws.name
   subnet_id           = azurerm_subnet.services.id
+
+  depends_on = [
+    azurerm_subnet.services
+  ]
 
   lifecycle { ignore_changes = [tags] }
 


### PR DESCRIPTION
Fixes #1494 

## What is being addressed

TF might think a subnet is ready to be used in other resources but Azure is still preparing it. See the error in the connected issue.

## How is this addressed

- Add explicit dependencies on the subnet, which has been seen to solve it on other cases (but not specifically for private endpoints which is our issue). Although I couldn't verify it solves the issue (hard to reproduce), I don't think the fix will cause more problems.