### PR TITLE
Fix race condition on base workspace subnets (2)

### DIFF
--- a/templates/workspaces/base/terraform/keyvault.tf
+++ b/templates/workspaces/base/terraform/keyvault.tf
@@ -20,6 +20,10 @@ resource "azurerm_private_endpoint" "kvpe" {
   resource_group_name = azurerm_resource_group.ws.name
   subnet_id           = azurerm_subnet.services.id
 
+  depends_on = [
+    azurerm_subnet.services
+  ]
+
   lifecycle { ignore_changes = [tags] }
 
   private_dns_zone_group {

--- a/templates/workspaces/base/terraform/network.tf
+++ b/templates/workspaces/base/terraform/network.tf
@@ -92,11 +92,19 @@ resource "azurerm_network_security_group" "ws" {
 resource "azurerm_subnet_network_security_group_association" "services" {
   network_security_group_id = azurerm_network_security_group.ws.id
   subnet_id                 = azurerm_subnet.services.id
+
+  depends_on = [
+    azurerm_subnet.services
+  ]
 }
 
 resource "azurerm_subnet_network_security_group_association" "webapps" {
   network_security_group_id = azurerm_network_security_group.ws.id
   subnet_id                 = azurerm_subnet.webapps.id
+
+  depends_on = [
+    azurerm_subnet.webapps
+  ]
 }
 
 resource "azurerm_network_security_rule" "deny-outbound-override" {
@@ -282,11 +290,19 @@ data "azurerm_route_table" "rt" {
 resource "azurerm_subnet_route_table_association" "rt_services_subnet_association" {
   route_table_id = data.azurerm_route_table.rt.id
   subnet_id      = azurerm_subnet.services.id
+
+  depends_on = [
+    azurerm_subnet.services
+  ]
 }
 
 resource "azurerm_subnet_route_table_association" "rt_webapps_subnet_association" {
   route_table_id = data.azurerm_route_table.rt.id
   subnet_id      = azurerm_subnet.webapps.id
+
+  depends_on = [
+    azurerm_subnet.webapps
+  ]
 }
 
 data "azurerm_private_dns_zone" "azurewebsites" {

--- a/templates/workspaces/base/terraform/storage.tf
+++ b/templates/workspaces/base/terraform/storage.tf
@@ -32,6 +32,10 @@ resource "azurerm_private_endpoint" "stgfilepe" {
   resource_group_name = azurerm_resource_group.ws.name
   subnet_id           = azurerm_subnet.services.id
 
+  depends_on = [
+    azurerm_subnet.services
+  ]
+
   lifecycle { ignore_changes = [tags] }
 
   private_dns_zone_group {
@@ -53,6 +57,10 @@ resource "azurerm_private_endpoint" "stgblobpe" {
   location            = azurerm_resource_group.ws.location
   resource_group_name = azurerm_resource_group.ws.name
   subnet_id           = azurerm_subnet.services.id
+
+  depends_on = [
+    azurerm_subnet.services
+  ]
 
   lifecycle { ignore_changes = [tags] }
 


### PR DESCRIPTION
Fixes #1494 

## What is being addressed

TF might think a subnet is ready to be used in other resources but Azure is still preparing it. See the error in the connected issue.

## How is this addressed

- Explicitly depend on the subnet where we reference its id