### PR TITLE
Revert to persisting git credentials for docs publish workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x


### PR DESCRIPTION
After looking at a diff between the [last successful docs publish](https://github.com/microsoft/AzureTRE/actions/runs/1880673684) and the [subsequent failure](https://github.com/microsoft/AzureTRE/actions/runs/1909567264), I believe that disabling the git credential persistence is the cause of the issue.

The error in the failed build (below) suggests that a lack of credentials is preventing the `git push` to the `gh-pages` branch.

```
fatal: could not read Username for 'https://github.com/': No such device or address
...
subprocess.CalledProcessError: Command '['git', 'push', 'origin', 'gh-pages', '--force']' returned non-zero exit status 1[28](https://github.com/microsoft/AzureTRE/runs/5544177989?check_suite_focus=true#step:5:28).
```