### PR TITLE
Enable running docs publish via workflow_dispatch

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,6 +2,7 @@
 name: Publish docs via Github Pages
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Enable manually running the docs publish process by adding a workflow_dispatch trigger to `build_docs.yml`