### PR TITLE
Always show TRE core output at end of tre-deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ FULL_IMAGE_NAME_PREFIX:=`echo "${FULL_CONTAINER_REGISTRY_NAME}/${IMAGE_NAME_PREF
 
 target_title = @echo -e "\n\e[34m»»» 🧩 \e[96m$(1)\e[0m..."
 
-all: bootstrap mgmt-deploy images tre-deploy
+all: bootstrap mgmt-deploy images tre-deploy show-core-output
 images: build-and-push-api build-and-push-resource-processor build-and-push-gitea build-and-push-guacamole
 
 build-and-push-api: build-api-image push-api-image
@@ -308,3 +308,7 @@ register-aad-workspace:
 	&& pushd ./templates/core/terraform/ > /dev/null && . ./outputs.sh && popd > /dev/null \
 	&& . ./devops/scripts/load_env.sh ./templates/core/private.env \
 	&& . ./devops/scripts/register-aad-workspace.sh
+
+show-core-output:
+	$(call target_title,"Display TRE core output") \
+	&& pushd ./templates/core/terraform/ > /dev/null && terraform show && popd > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ FULL_IMAGE_NAME_PREFIX:=`echo "${FULL_CONTAINER_REGISTRY_NAME}/${IMAGE_NAME_PREF
 
 target_title = @echo -e "\n\e[34m»»» 🧩 \e[96m$(1)\e[0m..."
 
-all: bootstrap mgmt-deploy images tre-deploy show-core-output
+all: bootstrap mgmt-deploy images tre-deploy
 images: build-and-push-api build-and-push-resource-processor build-and-push-gitea build-and-push-guacamole
 
 build-and-push-api: build-api-image push-api-image
 build-and-push-resource-processor: build-resource-processor-vm-porter-image push-resource-processor-vm-porter-image
 build-and-push-gitea: build-gitea-image push-gitea-image
 build-and-push-guacamole: build-guacamole-image push-guacamole-image
-tre-deploy: deploy-core deploy-shared-services
+tre-deploy: deploy-core deploy-shared-services show-core-output
 deploy-shared-services: firewall-install gitea-install nexus-install
 
 # to move your environment from the single 'core' deployment (which includes the firewall)


### PR DESCRIPTION
# PR for issue #1428

Also fixes #1508

## What is being addressed

TRE core output from TF was being lost in the terminal output, as shared services (eg. nexus) run last.  The TF core env values are needed when following the AzureTRE deployment steps.

## How is this addressed

- Always show the TRE core output at the end of tre-deploy stage
- TRE core output will remain in the terminal output window eg:

```bash
app_gateway_name = "agw-tre"
azure_tre_fqdn = "tre.westeurope.cloudapp.azure.com"
core_resource_group_location = "westeurope"
core_resource_group_name = "rg-tre"
keyvault_name = "kv-tre"

... (output truncated)
```
