### PR TITLE
Debug the Smoke Tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -84,6 +84,22 @@
           ]
         },
         {
+          "name": "E2E Smoke",
+          "type": "python",
+          "request": "launch",
+          "module": "pytest",
+          "justMyCode": true,
+          "cwd": "${workspaceFolder}/e2e_tests/",
+          "preLaunchTask": "Copy_env_file_for_e2e_debug",
+          "envFile": "${workspaceFolder}/templates/core/private.env",
+          "args": [
+            "-m",
+            "smoke",
+            "--verify",
+            "false"
+          ]
+        },
+        {
           "name": "Resource Processor",
           "type": "python",
           "request": "launch",

--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -759,8 +759,9 @@ if [[ $createAutomationAccount -ne 0 ]]; then
     az ad sp update --id $automationSpId --set tags="['WindowsAzureActiveDirectoryIntegratedApp']"
 
   # Grant admin consent for the delegated workspace scopes
-  # BUG I've noticed that there can sometimes be a delay in the app having the permissions set
-  # before we give admin-consent. If this occurs - rerun and it will work. TODO
+  # https://github.com/microsoft/AzureTRE/issues/1513
+  # I've noticed that there can sometimes be a delay in the app having the permissions set
+  # before we give admin-consent. If this occurs - rerun and it will work.
   if [[ $grantAdminConsent -eq 1 ]]; then
       echo "Granting admin consent for ${appName} Automation Admin App (service principal ID ${automationSpId})"
       az ad app permission admin-consent --id $automationAppId

--- a/templates/core/.env.sample
+++ b/templates/core/.env.sample
@@ -6,6 +6,10 @@ DEPLOY_GITEA=true
 DEPLOY_NEXUS=true
 RESOURCE_PROCESSOR_TYPE="vmss_porter"
 
+# This setting will enable your local machine to be able to
+# communicate with Service Bus and Cosmos.
+#ENABLE_LOCAL_DEBUGGING=true
+
 # Auth configuration
 AAD_TENANT_ID=__CHANGE_ME__
 API_CLIENT_ID=__CHANGE_ME__

--- a/templates/core/terraform/locals.tf
+++ b/templates/core/terraform/locals.tf
@@ -12,3 +12,7 @@ data "azurerm_container_registry" "mgmt_acr" {
   name                = var.acr_name
   resource_group_name = var.mgmt_resource_group_name
 }
+
+data "http" "myip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/templates/core/terraform/servicebus.tf
+++ b/templates/core/terraform/servicebus.tf
@@ -63,5 +63,6 @@ resource "azurerm_private_endpoint" "sbpe" {
 # See https://docs.microsoft.com/azure/service-bus-messaging/service-bus-service-endpoints
 resource "azurerm_servicebus_namespace_network_rule_set" "servicebus_network_rule_set" {
   namespace_id                  = azurerm_servicebus_namespace.sb.id
-  public_network_access_enabled = false
+  public_network_access_enabled = var.enable_local_debugging
+  ip_rules                      = var.enable_local_debugging ? ["${chomp(data.http.myip.body)}"] : null
 }

--- a/templates/core/terraform/statestore.tf
+++ b/templates/core/terraform/statestore.tf
@@ -1,11 +1,11 @@
 resource "azurerm_cosmosdb_account" "tre-db-account" {
-  name                = "cosmos-${var.tre_id}"
-  location            = azurerm_resource_group.core.location
-  resource_group_name = azurerm_resource_group.core.name
-  offer_type          = "Standard"
-  kind                = "GlobalDocumentDB"
-
+  name                      = "cosmos-${var.tre_id}"
+  location                  = azurerm_resource_group.core.location
+  resource_group_name       = azurerm_resource_group.core.name
+  offer_type                = "Standard"
+  kind                      = "GlobalDocumentDB"
   enable_automatic_failover = false
+  ip_range_filter           = var.enable_local_debugging ? "${chomp(data.http.myip.body)}" : null
 
   consistency_policy {
     consistency_level       = "BoundedStaleness"

--- a/templates/core/terraform/variables.tf
+++ b/templates/core/terraform/variables.tf
@@ -135,11 +135,16 @@ variable "stateful_resources_locked" {
   description = "Used to add locks on resources with state"
 }
 
-
 variable "ci_git_ref" {
   default     = ""
   description = "The git ref used by the ci to deploy this TRE"
   type        = string
+}
+
+variable "enable_local_debugging" {
+  default     = false
+  description = "This will allow Cosmos to be accesible from your local IP address and add some extra role permissions."
+  type        = bool
 }
 
 # this var is optional and used to avoid assigning a role on every run.


### PR DESCRIPTION
Add an easy way for developers to be able to debug the E2E tests. Currently we have `make setup-local-debugging` which works, but everytime your redeploy your infrastructure, the firewall settings are replaced. This now does this at a Terraform level, so is persisted. It is triggered by the following setting in /workspaces/AzureTRE/templates/core/.env
```
ENABLE_LOCAL_DEBUGGING=true
```

Also added a vscode launch configuration to be able to debug the smoke tests
