### PR TITLE
Include TRE_ID in debugging SP name

### DIFF
--- a/scripts/setup_local_debugging.sh
+++ b/scripts/setup_local_debugging.sh
@@ -45,7 +45,7 @@ az role assignment create \
 
 # Configure SP for local resource processor debugging (Porter can't use local creds)
 echo "Configuring Service Principal for Resource Processor debugging..."
-RP_TESTING_SP=$(az ad sp create-for-rbac --name ResourceProcessorTesting --role Owner --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID} -o json)
+RP_TESTING_SP=$(az ad sp create-for-rbac --name "ResourceProcessorTesting-${TRE_ID}" --role Owner --scopes /subscriptions/${AZURE_SUBSCRIPTION_ID} -o json)
 RP_TESTING_SP_APP_ID=$(echo ${RP_TESTING_SP} | jq -r .appId)
 RP_TESTING_SP_PASSWORD=$(echo ${RP_TESTING_SP} | jq -r .password)
 


### PR DESCRIPTION
If multiple developers are using the same AAD tenant then it looks like the first developer is able to run `make setup-local-debugging` but other developers using that tenant will get an error similar to the error below:

```
WARNING: Found an existing application instance of "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx". We will patch it
ERROR: Insufficient privileges to complete the operation.
```

Adding the `TRE_ID` into the SP name will ensure uniqueness and allow multiple developers to run in a shared AAD tenant.

