### PR TITLE
Add index.html generated by 'make letsencrypt' to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ e2e_tests/workspace_id.txt
 pytest_api_unit.xml
 pytest_api_unit_failed
 validation.txt
+
+index.html


### PR DESCRIPTION
After running `make letsencrypt` from the shell locally, I end up with `index.html` in the project root folder. Adding to `.gitignore` to avoid accidentally committing