### PR TITLE
Fix for Workspace AAD

### DIFF
--- a/scripts/aad-app-reg.sh
+++ b/scripts/aad-app-reg.sh
@@ -296,7 +296,7 @@ declare workspaceAppRoles=$(jq -c . << JSON
 [
     {
         "id": "${ownerRoleId}",
-        "allowedMemberTypes": [ "User, Application" ],
+        "allowedMemberTypes": [ "User", "Application" ],
         "description": "Provides workspace owners access to the Workspace.",
         "displayName": "Workspace Owner",
         "isEnabled": true,
@@ -305,7 +305,7 @@ declare workspaceAppRoles=$(jq -c . << JSON
     },
     {
         "id": "${researcherRoleId}",
-        "allowedMemberTypes": [ "User, Application" ],
+        "allowedMemberTypes": [ "User", "Application" ],
         "description": "Provides researchers access to the Workspace.",
         "displayName": "Workspace Researcher",
         "isEnabled": true,


### PR DESCRIPTION
When registering the AAD for your workspace, it does not let you assign Users to the "Workspace Owner" "Workspace Researcher" app roles.

## How is this addressed

- There was some missing "
