### PR TITLE
Simplify KV destroy debugging

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -210,7 +210,7 @@ jobs:
           RG_NAME: ${{ format('rg-tre{0}', steps.get_pr_details.outputs.refid) }}
           RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LOG_KEYVAULT: true
+          SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
         run: |
           set -e
           gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying test environment... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"

--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -100,16 +100,8 @@ az keyvault list --resource-group ${core_tre_rg} --query "[].properties"
 echo "keyvault purge protection evaluation result:"
 az keyvault list --resource-group ${core_tre_rg} --query "[?properties.enablePurgeProtection==``null``] | length (@)"
 
-if [[ -n ${LOG_KEYVAULT:-} ]]; then
-  # write the debug output from listing the Key Vaults to a file and upload to storage
-  TS=$(date +"%s")
-  LOG_FILE="${TS}-${core_tre_rg}-kv-list.json"
-  echo "Logging KeyVault query to ${LOG_FILE}"
-  az keyvault list --resource-group ${core_tre_rg} --query "[].properties" --debug > $LOG_FILE
-  az storage blob upload --file $LOG_FILE \
-    --container-name "tflogs" \
-    --account-name $TF_VAR_mgmt_storage_account_name \
-    --auth-mode key
+if [[ -n ${SHOW_KEYVAULT_DEBUG_ON_DESTROY:-} ]]; then
+  az keyvault list --resource-group ${core_tre_rg} --query "[].properties" --debug
 fi
 # DEBUG END
 


### PR DESCRIPTION
Since the `az` CLI masks auth values, and other values that match secrets are masked by GH actions, this PR simplifies the logging of KeyVault deletes by outputting to the console.

Also makes it simple to enable/disable without code change (via GH secret)
