### PR TITLE
Fix cleanup bug that deleted main env

### DIFF
--- a/.github/workflows/clean_validation_envs.yml
+++ b/.github/workflows/clean_validation_envs.yml
@@ -29,5 +29,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAIN_TRE_ID: ${{ secrets.TRE_ID }}
-          BRANCH_LAST_ACTIVITY_IN_HOURS: 4
+          BRANCH_LAST_ACTIVITY_IN_HOURS: 2
         run: devops/scripts/clean_ci_validation_envs.sh

--- a/devops/scripts/clean_ci_validation_envs.sh
+++ b/devops/scripts/clean_ci_validation_envs.sh
@@ -70,7 +70,7 @@ done
 if [[ -z $(gh api "https://api.github.com/repos/microsoft/AzureTRE/actions/runs?branch=main&status=in_progress" | jq --arg name "$GITHUB_WORKFLOW" '.workflow_runs | select(.[].name != $name)') ]]
 then
   # if not, we can delete old workspace resource groups that were left due to errors.
-  az group list --query "[?starts_with(name, 'rg-${MAIN_TRE_ID}-')].name" -o tsv |
+  az group list --query "[?starts_with(name, 'rg-${MAIN_TRE_ID}-ws-')].name" -o tsv |
   while read -r rg_name; do
     echo "Deleting resource group: ${rg_name}"
     az group delete --yes --no-wait --name ${rg_name}


### PR DESCRIPTION
## What is being addressed

The cleanup script catch the "mgmt" resource group and deleted that despite not supposed to.

## How is this addressed

- Include the "ws" string when searching for workspace resource group that should be deleted.
- Reduce the time we wait before stopping an environment.