### PR TITLE
Sync guacamole tags

### DIFF
--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -4,8 +4,12 @@ from contextlib import asynccontextmanager
 from httpx import AsyncClient
 from starlette import status
 
+import logging
+
 import config
 from resources import strings
+
+LOGGER = logging.getLogger(__name__)
 
 
 class InstallFailedException(Exception):
@@ -54,7 +58,7 @@ async def post_resource(payload, endpoint, resource_type, token, admin_token, ve
             auth_headers = get_auth_header(token)
 
         full_endpoint = f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{endpoint}"
-        print(f'POSTING RESOURCE TO: {full_endpoint}')
+        LOGGER.info(f'POSTING RESOURCE TO: {full_endpoint}')
 
         if method == "POST":
             response = await client.post(full_endpoint, headers=auth_headers, json=payload)
@@ -64,9 +68,9 @@ async def post_resource(payload, endpoint, resource_type, token, admin_token, ve
             check_method = patch_done
             response = await client.patch(full_endpoint, headers=auth_headers, json=payload)
 
-        print(f'RESPONSE: {response}')
-        print(f'RESPONSE Content: {response.content}')
-        print(f'RESPONSE status code: {response.status_code}')
+        LOGGER.info(f'RESPONSE: {response}')
+        LOGGER.info(f'RESPONSE Content: {response.content}')
+        LOGGER.info(f'RESPONSE status code: {response.status_code}')
         assert (response.status_code == status.HTTP_202_ACCEPTED), f"Request for resource {payload['templateName']} creation failed"
 
         resource_path = response.json()["operation"]["resourcePath"]
@@ -120,7 +124,7 @@ async def ping_guacamole_workspace_service(workspace_id, workspace_service_id, t
         while (True):
             try:
                 response = await client.get(url=endpoint, headers=headers, timeout=10)
-                print("GUAC RESPONSE", response)
+                LOGGER.info(f"GUAC RESPONSE: {response}")
 
                 if response.status_code in terminal_http_status:
                     break
@@ -128,7 +132,7 @@ async def ping_guacamole_workspace_service(workspace_id, workspace_service_id, t
                 await asyncio.sleep(30)
 
             except Exception as e:
-                print(e)
+                LOGGER.error(e)
 
         assert (response.status_code == status.HTTP_200_OK), "Guacamole cannot be reached"
 
@@ -136,16 +140,16 @@ async def ping_guacamole_workspace_service(workspace_id, workspace_service_id, t
 async def wait_for(func, client, operation_endoint, headers, failure_state):
     done, done_state, message = await func(client, operation_endoint, headers)
     while not done:
-        print(f'WAITING FOR OP: {operation_endoint}')
+        LOGGER.info(f'WAITING FOR OP: {operation_endoint}')
         await asyncio.sleep(30)
 
         done, done_state, message = await func(client, operation_endoint, headers)
-        print(done, done_state, message)
+        LOGGER.info(f"{done}, {done_state}, {message}")
     try:
         assert done_state != failure_state
     except Exception as e:
-        print(f"Failed to deploy status message: {message}")
-        print(e)
+        LOGGER.error(f"Failed to deploy status message: {message}")
+        LOGGER.error(e)
         raise
 
 
@@ -175,4 +179,5 @@ async def check_deployment(client, operation_endpoint, headers):
         message = response.json()["operation"]["message"]
         return deployment_status, message
     else:
+        LOGGER.error(f"Non 200 response in check_deployment: {response.status_code}")
         raise Exception("Non 200 response in check_deployment")

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -4,3 +4,8 @@ markers =
     extended: marks tests as extended ((run less frequently, relatively slow))
     timeout: used to set test timeout with pytest-timeout
 asyncio_mode = auto
+
+log_cli = 1
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/templates/workspace_services/guacamole/.dockerignore
+++ b/templates/workspace_services/guacamole/.dockerignore
@@ -5,3 +5,7 @@
 **/*_backend.tf
 
 Dockerfile.tmpl
+
+.env*
+guacamole-server/
+user_resources/

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-service-guacamole
-version: 0.1.9
+version: 0.1.10
 description: "An Azure TRE service for Guacamole"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -26,8 +26,7 @@ parameters:
     description: "The name of the guacamole image"
   - name: image_tag
     type: string
-    # TODO: replace with an image tag from resource proccessor (#848)
-    default: "0.1.9"
+    default: "" # will use the value in the version.txt file unless provided
     description: "The tag of the guacamole image"
   - name: mgmt_acr_name
     type: string
@@ -100,6 +99,7 @@ parameters:
     description: "The name of the Terraform state storage container"
   - name: arm_use_msi
     env: ARM_USE_MSI
+    type: boolean
     default: false
 
 outputs:
@@ -111,7 +111,7 @@ outputs:
 mixins:
   - exec
   - terraform:
-      clientVersion: 1.0.4
+      clientVersion: 1.1.7
 
 install:
   - terraform:

--- a/templates/workspace_services/guacamole/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/terraform/locals.tf
@@ -10,4 +10,6 @@ locals {
   issuer                         = "https://login.microsoftonline.com/${local.aad_tenant_id}/v2.0"
   api_url                        = "https://api-${var.tre_id}.azurewebsites.net"
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
+  image_tag_from_file            = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
+  image_tag                      = var.image_tag == "" ? local.image_tag_from_file : var.image_tag
 }

--- a/templates/workspace_services/guacamole/terraform/main.tf
+++ b/templates/workspace_services/guacamole/terraform/main.tf
@@ -77,6 +77,10 @@ data "azurerm_private_dns_zone" "filecore" {
   resource_group_name = local.core_resource_group_name
 }
 
+data "local_file" "version" {
+  filename = "${path.module}/../version.txt"
+}
+
 output "connection_uri" {
   value = "https://${azurerm_app_service.guacamole.default_site_hostname}/guacamole"
 }

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -11,7 +11,7 @@ resource "azurerm_app_service" "guacamole" {
   https_only          = true
 
   site_config {
-    linux_fx_version                     = "DOCKER|${data.azurerm_container_registry.mgmt_acr.login_server}/microsoft/azuretre/${var.image_name}:${var.image_tag}"
+    linux_fx_version                     = "DOCKER|${data.azurerm_container_registry.mgmt_acr.login_server}/microsoft/azuretre/${var.image_name}:${local.image_tag}"
     http2_enabled                        = true
     acr_use_managed_identity_credentials = true
   }

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -82,7 +82,7 @@ uninstall:
   - terraform:
       description: "Tear down workspace"
       # https://github.com/microsoft/AzureTRE/issues/1526
-      logLevel: Debug
+      # logLevel: Debug
       vars:
         tre_id: "{{ bundle.parameters.tre_id }}"
         tre_resource_id: "{{ bundle.parameters.id }}"


### PR DESCRIPTION
Fixes #1581, Fixes #848 

## What is being addressed

The Guacamole workspace service bundle referred to an image tag that didn't exist.

## How is this addressed

- Bundle image tag set to an empty string as a default which will instruct terraform to take the value from the version.txt file. If the bundle will get a value, that will be used for the image tag.
- Add folders to the bundle dockerignore file that aren't required for the bundle installer. This saves ~300 MB in its size.
- Upgrade Terraform version used in the bundle.
- E2E tests are using the logging lib (vs. the plain print)
- Turn live_cli logs in pytest so that we'll see what is going on while the tests are running rather than waiting for it to end. Also include the timestamp of each entry. 
