### PR TITLE
Output healthcheck response to aid debugging

### DIFF
--- a/devops/scripts/api_healthcheck.sh
+++ b/devops/scripts/api_healthcheck.sh
@@ -10,9 +10,9 @@ echo
 not_ok_count=$(echo "${response}"  | jq -r '[.services | .[] | select(.status!="OK")] | length')
 
 if [[ "$not_ok_count" == "0" ]]; then
-  echo "*** API healthy ***"
+  echo "*** ✅ API healthy ***"
 else
-  echo "*** API _not_ healthy ***"
+  echo "*** ⚠️ API _not_ healthy ***"
   echo "Unhealthy services:"
   echo "${response}"  | jq -r '[.services | .[] | select(.status!="OK")]'
   exit 1

--- a/devops/scripts/api_healthcheck.sh
+++ b/devops/scripts/api_healthcheck.sh
@@ -3,12 +3,17 @@ set -e
 
 response=$(curl -k "https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health")
 
+echo "Got response from https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health:"
+echo "$response"
+echo
+
 not_ok_count=$(echo "${response}"  | jq -r '[.services | .[] | select(.status!="OK")] | length')
 
 if [[ "$not_ok_count" == "0" ]]; then
-  echo "API Healthy"
+  echo "*** API healthy ***"
 else
-  echo "API _not_ healthy. Unhealthy services:"
+  echo "*** API _not_ healthy ***"
+  echo "Unhealthy services:"
   echo "${response}"  | jq -r '[.services | .[] | select(.status!="OK")]'
   exit 1
 fi


### PR DESCRIPTION
Update the output from the API Healthcheck script to include the full response to aid debugging #1593 

Along with outputting the full response, this PR makes the status check result more noticeable:

![image](https://user-images.githubusercontent.com/1824461/159936853-8ab5b685-040e-43d9-a6c1-93db5da3af70.png)

(https://github.com/microsoft/AzureTRE/runs/5677725829?check_suite_focus=true#step:4:160)