### PR TITLE
Add HTTP 302 as terminal status for Guacamole ping test

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -535,6 +535,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: CICD
     needs: [register_bundles, build_additional_images]
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -584,7 +585,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: E2E Test Results (Python ${{ matrix.python-version }})
+          name: E2E Test (Smoke) Results
           path: "./e2e_tests/pytest_e2e_smoke.xml"
 
       - name: Publish Test Results
@@ -599,6 +600,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: CICD
     needs: [register_bundles, build_additional_images]
+    timeout-minutes: 50
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -634,7 +636,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: E2E Test (Extended) Results (Python ${{ matrix.python-version }})
+          name: E2E Test (Extended) Results
           path: "./e2e_tests/pytest_e2e_extended.xml"
 
       - name: Publish Test Results

--- a/e2e_tests/helpers.py
+++ b/e2e_tests/helpers.py
@@ -118,7 +118,11 @@ async def ping_guacamole_workspace_service(workspace_id, workspace_service_id, t
     short_workspace_service_id = workspace_service_id[-4:]
     endpoint = f"https://guacamole-{config.TRE_ID}-ws-{short_workspace_id}-svc-{short_workspace_service_id}.azurewebsites.net/guacamole"
     headers = {'x-access-token': f'{token}'}
-    terminal_http_status = [status.HTTP_200_OK, status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
+    terminal_http_status = [status.HTTP_200_OK,
+                            status.HTTP_401_UNAUTHORIZED,
+                            status.HTTP_403_FORBIDDEN,
+                            status.HTTP_302_FOUND  # usually means auth header wasn't accepted
+                            ]
 
     async with AsyncClient(verify=verify) as client:
         while (True):
@@ -131,8 +135,8 @@ async def ping_guacamole_workspace_service(workspace_id, workspace_service_id, t
 
                 await asyncio.sleep(30)
 
-            except Exception as e:
-                LOGGER.error(e)
+            except Exception:
+                LOGGER.exception("Generic execption in ping.")
 
         assert (response.status_code == status.HTTP_200_OK), "Guacamole cannot be reached"
 
@@ -147,9 +151,8 @@ async def wait_for(func, client, operation_endoint, headers, failure_state):
         LOGGER.info(f"{done}, {done_state}, {message}")
     try:
         assert done_state != failure_state
-    except Exception as e:
-        LOGGER.error(f"Failed to deploy status message: {message}")
-        LOGGER.error(e)
+    except Exception:
+        LOGGER.exception(f"Failed to deploy status message: {message}")
         raise
 
 


### PR DESCRIPTION
Fixes #1302 

## What is being addressed

The E2E got into an infinite loop when http 302 was returned

## How is this addressed

- Add 302 as a terminal status so that no retries would be attempted
- Add action timeouts so to the e2e jobs so that they will be killed if running too long. This is needed since pytest-timeout doesn't always stop the test (see the run in the mentioned issue).
- Rename some of the steps
