### PR TITLE
Fix linting issues in github actions

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -47,55 +47,55 @@ inputs:
     required: true
   API_CLIENT_ID:
     description: "The API Client Id."
-    required: true
+    required: false
   AAD_TENANT_ID:
     description: "The Tenant Id where the App is registered and the Test User is registered for the E2E Tests."
-    required: true
+    required: false
   TEST_APP_ID:
     description: "The Test Application Id used to interact with the API."
-    required: true
+    required: false
   TEST_ACCOUNT_CLIENT_ID:
     description: "The Test Automation Account Client Id used to interact with the API."
-    required: true
+    required: false
   TEST_ACCOUNT_CLIENT_SECRET:
     description: "The Test Automation Account Client Secret used to interact with the API."
-    required: true
+    required: false
   TEST_WORKSPACE_APP_ID:
     description: "The Test Workspace Id used to interact with the API."
-    required: true
+    required: false
   TRE_ID:
     description: "The TRE Id."
-    required: true
+    required: false
   TF_VAR_terraform_state_container_name:
     description: "The name of the container to store the Terraform state."
-    required: true
+    required: false
   TF_VAR_mgmt_resource_group_name:
     description: "The resource group used to store the Terraform state."
-    required: true
+    required: false
   TF_VAR_mgmt_storage_account_name:
     description: "The storage account used to store the Terraform state."
-    required: true
+    required: false
   TF_VAR_core_address_space:
     description: "Core address space."
-    required: true
+    required: false
   TF_VAR_tre_address_space:
     description: "TRE address apace."
-    required: true
+    required: false
   TF_VAR_swagger_ui_client_id:
     description: "The Swagger UI Client ID."
-    required: true
+    required: false
   TF_VAR_api_client_id:
     description: "The API Client Id. (Same as Resource)"
-    required: true
+    required: false
   TF_VAR_api_client_secret:
     description: "The API Client Secret."
-    required: true
+    required: false
   ACR_NAME:
     description: "The Container Registry that holds our Research images."
-    required: true
+    required: false
   LOCATION:
     description: "The Azure Region (e.g. WestEurope)."
-    required: true
+    required: false
   BUNDLE_TYPE:
     description: "The Bundle type (workspace / Workspace-service / User Resource)."
     required: false

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -1,7 +1,7 @@
 ---
 name: Docker build
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish docs via Github Pages
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   push:
     branches: [main]

--- a/.github/workflows/clean_validation_envs.yml
+++ b/.github/workflows/clean_validation_envs.yml
@@ -1,7 +1,7 @@
 ---
 name: Clean Validation Environments
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     # Every 2 hours
     - cron: "0 */2 * * *"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@
 #
 name: "CodeQL"
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -3,7 +3,7 @@ name: Deploy Azure TRE
 # This workflow is the integration build run for pushes to the main branch
 # It also runs on a schedule, serving as the nightly build
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     # 1am each night https://crontab.guru/#0_1_*_*_*
     - cron: "0 1 * * *"

--- a/.github/workflows/deploy_tre_branch.yml
+++ b/.github/workflows/deploy_tre_branch.yml
@@ -6,7 +6,7 @@ name: Deploy Azure TRE (branch)
 # Note that the branch must be in the main repo as secrets are not passed
 # to workflows run from forks
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       runExtendedTests:
@@ -38,7 +38,7 @@ jobs:
           echo "git SHA:    $(git rev-parse --abbrev-ref HEAD)"
           echo "git ref:    $(git rev-parse HEAD)"
           echo "github ref: ${GITHUB_REF}"
-          REFID=$(echo ${GITHUB_REF} | shasum | cut -c1-8)
+          REFID=$(echo "${GITHUB_REF}" | shasum | cut -c1-8)
           echo "using id of: ${REFID} for GitHub Ref: ${GITHUB_REF}"
           echo "::set-output name=refid::${REFID}"
 

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -1,7 +1,7 @@
 ---
 name: Deploy Azure TRE Resuable
 
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       prRef:
@@ -23,58 +23,85 @@ on:
         required: false
     secrets:
       AAD_TENANT_ID:
+        description: ""
         required: true
       ACR_NAME:
+        description: ""
         required: true
       ACTIONS_ACR_NAME:
+        description: ""
         required: true
       ACTIONS_ACR_URI:
+        description: ""
         required: true
       ACTIONS_ACR_PASSWORD:
+        description: ""
         required: true
       ACTIONS_DEVCONTAINER_TAG:
+        description: ""
         required: true
       API_CLIENT_ID:
+        description: ""
         required: true
       API_CLIENT_SECRET:
+        description: ""
         required: true
       ARM_CLIENT_ID:
+        description: ""
         required: true
       ARM_CLIENT_SECRET:
+        description: ""
         required: true
       ARM_SUBSCRIPTION_ID:
+        description: ""
         required: true
       ARM_TENANT_ID:
+        description: ""
         required: true
       CORE_ADDRESS_SPACE:
+        description: ""
         required: true
       LOCATION:
+        description: ""
         required: true
       MGMT_RESOURCE_GROUP:
+        description: ""
         required: true
       MS_TEAMS_WEBHOOK_URI:
+        description: ""
         required: true
       STATE_STORAGE_ACCOUNT_NAME:
+        description: ""
         required: true
       SWAGGER_UI_CLIENT_ID:
+        description: ""
         required: true
       TEST_APP_ID:
+        description: ""
         required: true
       TEST_WORKSPACE_APP_ID:
+        description: ""
         required: true
       TEST_ACCOUNT_CLIENT_ID:
+        description: ""
         required: true
       TEST_ACCOUNT_CLIENT_SECRET:
+        description: ""
         required: true
       TF_STATE_CONTAINER:
+        description: ""
         required: true
       TRE_ADDRESS_SPACE:
+        description: ""
         required: true
       TRE_ID:
+        description: ""
         required: true
       CI_CACHE_ACR_NAME:
+        description: ""
         required: false
       TF_LOG:
+        description: ""
         required: false
 
 # This will prevent multiple runs of this entire workflow.
@@ -116,7 +143,7 @@ jobs:
       - name: Build new devcontainer
         shell: bash
         env:
-            DOCKER_BUILDKIT: 1
+          DOCKER_BUILDKIT: 1
         run: |
           set -e
           USER_UID=$(id -u)
@@ -397,8 +424,7 @@ jobs:
     strategy:
       matrix:
         include:
-        # bundles type can be inferred from the bundle
-        # dir (but this is more explicit)
+          # bundles type can be inferred from the bundle dir (but this is more explicit)
           - {BUNDLE_TYPE: "workspace",
              BUNDLE_DIR: "./templates/workspaces/base"}
           - {BUNDLE_TYPE: "workspace",
@@ -481,8 +507,7 @@ jobs:
     strategy:
       matrix:
         include:
-        # bundles type can be inferred from the bundle
-        # dir (but this is more explicit)
+          # bundles type can be inferred from the bundle dir (but this is more explicit)
           - {BUNDLE_TYPE: "workspace",
              BUNDLE_DIR: "./templates/workspaces/base"}
           - {BUNDLE_TYPE: "workspace",
@@ -655,7 +680,7 @@ jobs:
       - uses: technote-space/workflow-conclusion-action@v2
 
       - name: Notify teams channel
-        if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure
+        if: env.WORKFLOW_CONCLUSION == 'failure'  # notify only if failure
         uses: sachinkundu/ms-teams-notification@1.4
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,8 @@
 ---
 name: End to End Tests
 
-on:
-  workflow_call:
+on:  # yamllint disable-line rule:truthy
+  # workflow_call:
   workflow_dispatch:
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
       - name: Run E2E Tests
         uses: ./.github/actions/devcontainer_run_command
         with:
-          DISPLAY_NAME: "Run E2E Tests (Smoke)"
           COMMAND: "make test-e2e-smoke"
           ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/
           ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
           ACTIONS_DEVCONTAINER_TAG: ${{ secrets.ACTIONS_DEVCONTAINER_TAG }}
           ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
@@ -52,9 +52,9 @@ jobs:
       - name: Run E2E Tests (Extended)
         uses: ./.github/actions/devcontainer_run_command
         with:
-          DISPLAY_NAME: "Run E2E Tests (Extended)"
           COMMAND: "make test-e2e-extended"
           ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/
           ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
           ACTIONS_DEVCONTAINER_TAG: ${{ secrets.ACTIONS_DEVCONTAINER_TAG }}
           ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"

--- a/.github/workflows/flag_external_pr.yml
+++ b/.github/workflows/flag_external_pr.yml
@@ -1,6 +1,6 @@
 name: flag_external_pr
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [opened] # only run on new PRs
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment

--- a/.github/workflows/lets_encrypt.yml
+++ b/.github/workflows/lets_encrypt.yml
@@ -1,7 +1,7 @@
 ---
 name: Renew Lets Encrypt Certificates
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     # 3am each month https://crontab.guru/#0_3_1_*_*
     - cron: "0 3 1 * *"
@@ -13,8 +13,8 @@ concurrency: letsencrypt
 
 env:
   USE_ENV_VARS_NOT_FILES: true
-  TF_INPUT: 0 # interactive is off
-  TF_IN_AUTOMATION: 1 # Run in headless mode
+  TF_INPUT: 0  # interactive is off
+  TF_IN_AUTOMATION: 1  # Run in headless mode
 
 jobs:
   renew_letsencrypt_certs:

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -1,8 +1,9 @@
+---
 name: pr_comment_bot
 
-on:
+on:  # yamllint disable-line rule:truthy
   issue_comment:
-    types: [created] # only run on new comments
+    types: [created]  # only run on new comments
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment
     # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
 
@@ -53,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Showing help on PR ${PR_NUMBER}"
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Hello<br/><br/>You can use the following commands:<br/>    /test - build, deploy and run smoke tests on a PR<br/>    /test-extended - build, deploy and run somke & extended tests on a PR<br/>    /test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)<br/>    /test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)    /help - show this help"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Hello<br/><br/>You can use the following commands:<br/>    /test - build, deploy and run smoke tests on a PR<br/>    /test-extended - build, deploy and run somke & extended tests on a PR<br/>    /test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)<br/>    /test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)    /help - show this help"
 
       # Get PR commit details for running tests
       - id: get_pr_details
@@ -67,10 +68,10 @@ jobs:
           # Leaving this as bash script as GitHub Script doesn't seem to support multiple output values
 
           echo "Getting PR ref..."
-          ref=$(gh pr view $PR_NUMBER --repo $REPO --json commits | jq -r ".[] | last | .oid")
+          ref=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json commits | jq -r ".[] | last | .oid")
           echo -e "\tLatest commit ref: $ref"
           # Get the prMergeCommit as this is what the pull_request trigger would build
-          prMergeRef=$(gh pr view $PR_NUMBER --repo $REPO --json potentialMergeCommit | jq -r .potentialMergeCommit.oid)
+          prMergeRef=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json potentialMergeCommit | jq -r .potentialMergeCommit.oid)
           echo -e "\tprMergeRef: $prMergeRef"
           echo
 
@@ -80,13 +81,13 @@ jobs:
           github_pr_ref="refs/pull/${PR_NUMBER}/merge"
           echo "::set-output name=ciGitRef::${github_pr_ref}"
 
-          REFID=$(echo ${github_pr_ref} | shasum | cut -c1-8)
+          REFID=$(echo "${github_pr_ref}" | shasum | cut -c1-8)
           echo "using id of: ${REFID} for GitHub Ref: ${github_pr_ref} (RG base name)"
           echo "::set-output name=refid::${REFID}"
 
           # Get PR HEAD SHA for checks status
           echo "Getting PR head SHA"
-          PR_HEAD_SHA=$(gh api /repos/$REPO/pulls/$PR_NUMBER --jq .head.sha)
+          PR_HEAD_SHA=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)
           echo "PR_HEAD_SHA: ${PR_HEAD_SHA}"
           echo "::set-output name=prHeadSha::${PR_HEAD_SHA}"
 
@@ -140,7 +141,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           echo "Adding comment with link to run on PR ${PR_NUMBER}"
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Running tests: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Running tests: https://github.com/${REPO}/actions/runs/${RUN_ID}"
 
       # Perform az login for destroy env script to be able to run
       - name: Azure Login
@@ -161,9 +162,9 @@ jobs:
           SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
         run: |
           set -e
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying test environment... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
-          devops/scripts/destroy_env_no_terraform.sh --core-tre-rg ${RG_NAME}
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Test environment destroy complete"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Destroying test environment... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          devops/scripts/destroy_env_no_terraform.sh --core-tre-rg "${RG_NAME}"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Test environment destroy complete"
 
   run_test:
     # Run the tests with the re-usable workflow


### PR DESCRIPTION
## What is being addressed

Following the addition of GitHub Actions linter we should make some fixes.

## How is this addressed

- run container command action - most inputs need to be optional since they are not always passed in
- disable yamllint rule for the "on" key as it's not valid
- double quotes for all vars in run steps (this need to happen for regular bash script in *.sh files but it was too much for me - need proper testing)