### PR TITLE
Handle non-success error codes in healthcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,3 @@ pytest_api_unit_failed
 validation.txt
 
 index.html
-
-# ignore api-healthcheck response file
-api-response.txt

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ pytest_api_unit_failed
 validation.txt
 
 index.html
+
+# ignore api-healthcheck response file
+api-response.txt

--- a/devops/scripts/api_healthcheck.sh
+++ b/devops/scripts/api_healthcheck.sh
@@ -1,26 +1,33 @@
 #!/bin/bash
 set -e
 
-echo "Calling /health endpoint..."
-response_code=$(curl --insecure --silent --output api-response.txt --write-out "%{http_code}" "https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health")
+# Get the directory that this script is in
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Create a .gitignore'd  directory for temp output
+mkdir -p "$DIR/script_tmp"
+echo '*' > "$DIR/script_tmp/.gitignore"
+api_response_file="$DIR/script_tmp/api_response.txt"
 
-echo "Got response from https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health:"
-cat "api-response.txt"
+echo "Calling /health endpoint..."
+response_code=$(curl --insecure --silent --output "$api_response_file" --write-out "%{http_code}" "https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health")
+
 echo
 
 if [[ "$response_code" != "200" ]]; then
   echo "*** ⚠️ API _not_ healthy ***"
   echo "Non-success code returned: $response_code"
+  echo "Response:"
+  cat "$api_response_file"
   exit 1
 fi
 
-not_ok_count=$(jq -r '[.services | .[] | select(.status!="OK")] | length' < api-response.txt)
+not_ok_count=$(jq -r '[.services | .[] | select(.status!="OK")] | length' < "$api_response_file")
 
 if [[ "$not_ok_count" == "0" ]]; then
   echo "*** ✅ API healthy ***"
 else
   echo "*** ⚠️ API _not_ healthy ***"
   echo "Unhealthy services:"
-  jq -r '[.services | .[] | select(.status!="OK")]' < api-response.txt
+  jq -r '[.services | .[] | select(.status!="OK")]' < "$api_response_file"
   exit 1
 fi

--- a/devops/scripts/api_healthcheck.sh
+++ b/devops/scripts/api_healthcheck.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 set -e
 
-response=$(curl -k "https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health")
+echo "Calling /health endpoint..."
+response_code=$(curl --insecure --silent --output api-response.txt --write-out "%{http_code}" "https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health")
 
 echo "Got response from https://${TRE_ID}.${LOCATION}.cloudapp.azure.com/api/health:"
-echo "$response"
+cat "api-response.txt"
 echo
 
-not_ok_count=$(echo "${response}"  | jq -r '[.services | .[] | select(.status!="OK")] | length')
+if [[ "$response_code" != "200" ]]; then
+  echo "*** ⚠️ API _not_ healthy ***"
+  echo "Non-success code returned: $response_code"
+  exit 1
+fi
+
+not_ok_count=$(jq -r '[.services | .[] | select(.status!="OK")] | length' < api-response.txt)
 
 if [[ "$not_ok_count" == "0" ]]; then
   echo "*** ✅ API healthy ***"
 else
   echo "*** ⚠️ API _not_ healthy ***"
   echo "Unhealthy services:"
-  echo "${response}"  | jq -r '[.services | .[] | select(.status!="OK")]'
+  jq -r '[.services | .[] | select(.status!="OK")]' < api-response.txt
   exit 1
 fi


### PR DESCRIPTION

# PR fixes #1593

## What is being addressed

When the App Gateway returns a `502 Bad Gateway` response, the body is HTML rather than JSON and we get an error: `parse error: Invalid numeric literal at line 1, column 7`


## How is this addressed

This PR changes the healthcheck to only attempt to parse response as JSON for 200 success responses. This avoids attempting to parse HTML from 502 Bad Gateway responses as JSON.
