### PR TITLE
Change linter order

### DIFF
--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -24,23 +24,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Lint code base
-        # the slim image is 2GB smaller and we don't use the extra stuff
-        uses: github/super-linter/slim@v4
-        env:
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_MARKDOWN: true
-          VALIDATE_PYTHON_FLAKE8: true
-          VALIDATE_YAML: true
-          VALIDATE_TERRAFORM_TFLINT: true
-          VALIDATE_JAVA: true
-          JAVA_FILE_NAME: checkstyle.xml
-          VALIDATE_BASH: true
-          VALIDATE_BASH_EXEC: true
-          VALIDATE_GITHUB_ACTIONS: true
-
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -61,3 +44,21 @@ jobs:
           find . -type d -name 'terraform' -not -path '*cnab*' -print0 \
           | xargs -0 -I{} sh -c 'echo "***** Validating: {} *****"; \
           terraform -chdir={} init -backend=false; terraform -chdir={} validate'
+
+      - name: Lint code base
+        # the slim image is 2GB smaller and we don't use the extra stuff
+        # Moved this after the Terraform checks above due something similar to this issue: https://github.com/github/super-linter/issues/2433
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_MARKDOWN: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_YAML: true
+          VALIDATE_TERRAFORM_TFLINT: true
+          VALIDATE_JAVA: true
+          JAVA_FILE_NAME: checkstyle.xml
+          VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
+          VALIDATE_GITHUB_ACTIONS: true


### PR DESCRIPTION
After getting [this error](https://github.com/microsoft/AzureTRE/runs/5851703641?check_suite_focus=true#step:11:360):

```
 Error: Failed to install provider
│ 
│ Error while installing hashicorp/azurerm v2.97.0: mkdir .terraform:
│ permission denied
```

It turns out that the super-linter step changes the file ownership to `root` for a bunch of files.

This PR moves the super-linter step to the end of the workflow so that other steps aren't affected.