### PR TITLE
Destroy both PR and branch environments on /test-destroy-env

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -24,6 +24,7 @@ jobs:
       prRef: ${{ steps.get_pr_details.outputs.prRef }}
       prHeadSha: ${{ steps.get_pr_details.outputs.prHeadSha }}
       refid: ${{ steps.get_pr_details.outputs.refid }}
+      branchRefid: ${{ steps.get_pr_details.outputs.branchRefid }}
       ciGitRef: ${{ steps.get_pr_details.outputs.ciGitRef }}
       not-md: ${{ steps.filter.outputs.not-md }}
     steps:
@@ -78,12 +79,30 @@ jobs:
           echo "Setting outputs"
           echo "::set-output name=prRef::${prMergeRef}"
 
+          # REFID is the basis for the TRE_ID for the PR
           github_pr_ref="refs/pull/${PR_NUMBER}/merge"
           echo "::set-output name=ciGitRef::${github_pr_ref}"
 
           REFID=$(echo "${github_pr_ref}" | shasum | cut -c1-8)
-          echo "using id of: ${REFID} for GitHub Ref: ${github_pr_ref} (RG base name)"
+          echo "using refid of: ${REFID} for GitHub Ref: ${github_pr_ref} (RG base name)"
           echo "::set-output name=refid::${REFID}"
+
+          # Also generate the REFID for the branch, but only if the headRepo is matches $REPO
+          # This is used later in the destroy to destroy for the PR + branch
+          pr_head_json=$(gh pr view $PR_NUMBER --repo $REPO --json headRefName,headRepositoryOwner,headRepository)
+          pr_head_repo=$(echo $pr_head_json | jq -r '"\(.headRepositoryOwner.login)\\\(.headRepository.name)"')
+          if [[ "$pr_head_repo" == "$REPO" ]]; then
+            github_branch_ref="refs/heads/$(echo $pr_head_json | jq -r '.headRefName')"
+            BRANCH_REFID=$(echo ${github_pr_ref} | shasum | cut -c1-8)
+            echo "Using branch refid of $BRANCH_REFID for branch $github_branch_ref"
+          else
+            echo "Head repo is '$pr_head_repo' - skipping BRANCH_REFID"
+            BRANCH_REFID=""
+          fi
+          echo "::set-output name=branchRefid::${BRANCH_REFID}"
+
+          github_branch_ref="refs/heads/${PR_NUMBER}/merge"
+          BRANCH_REFID=$(echo)
 
           # Get PR HEAD SHA for checks status
           echo "Getting PR head SHA"
@@ -150,21 +169,46 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      # Destroy validation deployment
+
+  destroy_pr_env:
+    needs: [pr_comment]
+    if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' }}
+    runs-on: ubuntu-latest
+    name: Destroy PR env
+    steps:
       - name: Run deployment cleanup
-        if: ${{ steps.check_command.outputs.result == 'test-destroy-env' }}
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.event.repository.full_name }}
-          RG_NAME: ${{ format('rg-tre{0}', steps.get_pr_details.outputs.refid) }}
+          RG_NAME: ${{ format('rg-tre{0}', needs.pr_comment.outputs.refid) }}
           RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
         run: |
           set -e
-          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Destroying test environment... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying PR test environment (RG: ${RG_NAME})... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          devops/scripts/destroy_env_no_terraform.sh --core-tre-rg ${RG_NAME}
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "PR test environment destroy complete (RG: ${RG_NAME})"
+
+  destroy_branch_env:
+    needs: [pr_comment]
+    if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' && needs.pr_comment.outputs.branchRefid != '' }}
+    runs-on: ubuntu-latest
+    name: Destroy branch env
+    steps:
+      - name: Run deployment cleanup
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.event.repository.full_name }}
+          RG_NAME: ${{ format('rg-tre{0}', needs.pr_comment.outputs.branchRefid) }}
+          RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
+        run: |
+          set -e
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying branch test environment (RG: ${RG_NAME})... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
           devops/scripts/destroy_env_no_terraform.sh --core-tre-rg "${RG_NAME}"
-          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Test environment destroy complete"
+          gh pr comment ${PR_NUMBER} --repo $REPO --body "Branch test environment destroy complete (RG: ${RG_NAME})"
 
   run_test:
     # Run the tests with the re-usable workflow

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -174,6 +174,7 @@ jobs:
     needs: [pr_comment]
     if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' }}
     runs-on: ubuntu-latest
+    environment: CICD
     name: Destroy PR env
     steps:
       - name: Run deployment cleanup
@@ -194,6 +195,7 @@ jobs:
     needs: [pr_comment]
     if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' && needs.pr_comment.outputs.branchRefid != '' }}
     runs-on: ubuntu-latest
+    environment: CICD
     name: Destroy branch env
     steps:
       - name: Run deployment cleanup

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -89,11 +89,11 @@ jobs:
 
           # Also generate the REFID for the branch, but only if the headRepo is matches $REPO
           # This is used later in the destroy to destroy for the PR + branch
-          pr_head_json=$(gh pr view $PR_NUMBER --repo $REPO --json headRefName,headRepositoryOwner,headRepository)
-          pr_head_repo=$(echo $pr_head_json | jq -r '"\(.headRepositoryOwner.login)\\\(.headRepository.name)"')
+          pr_head_json=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName,headRepositoryOwner,headRepository)
+          pr_head_repo=$(echo "$pr_head_json" | jq -r '"\(.headRepositoryOwner.login)\\\(.headRepository.name)"')
           if [[ "$pr_head_repo" == "$REPO" ]]; then
-            github_branch_ref="refs/heads/$(echo $pr_head_json | jq -r '.headRefName')"
-            BRANCH_REFID=$(echo ${github_pr_ref} | shasum | cut -c1-8)
+            github_branch_ref="refs/heads/$(echo "$pr_head_json" | jq -r '.headRefName')"
+            BRANCH_REFID=$(echo "${github_pr_ref}" | shasum | cut -c1-8)
             echo "Using branch refid of $BRANCH_REFID for branch $github_branch_ref"
           else
             echo "Head repo is '$pr_head_repo' - skipping BRANCH_REFID"
@@ -186,9 +186,9 @@ jobs:
           SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
         run: |
           set -e
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying PR test environment (RG: ${RG_NAME})... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
-          devops/scripts/destroy_env_no_terraform.sh --core-tre-rg ${RG_NAME}
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "PR test environment destroy complete (RG: ${RG_NAME})"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Destroying PR test environment (RG: ${RG_NAME})... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          devops/scripts/destroy_env_no_terraform.sh --core-tre-rg "${RG_NAME}"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "PR test environment destroy complete (RG: ${RG_NAME})"
 
   destroy_branch_env:
     needs: [pr_comment]
@@ -206,9 +206,9 @@ jobs:
           SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
         run: |
           set -e
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Destroying branch test environment (RG: ${RG_NAME})... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Destroying branch test environment (RG: ${RG_NAME})... (run: https://github.com/${REPO}/actions/runs/${RUN_ID})"
           devops/scripts/destroy_env_no_terraform.sh --core-tre-rg "${RG_NAME}"
-          gh pr comment ${PR_NUMBER} --repo $REPO --body "Branch test environment destroy complete (RG: ${RG_NAME})"
+          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Branch test environment destroy complete (RG: ${RG_NAME})"
 
   run_test:
     # Run the tests with the re-usable workflow

--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -66,6 +66,12 @@ then
   no_wait_option="--no-wait"
 fi
 
+group_show_result=$(az group show --name ${core_tre_rg} > /dev/null 2>&1; echo $?)
+if [[ "$group_show_result" !=  "0" ]]; then
+  echo "Resource group ${core_tre_rg} not found - skipping destroy"
+  exit 1
+fi
+
 locks=$(az group lock list -g ${core_tre_rg} --query [].id -o tsv)
 if [ ! -z "${locks:-}" ]
 then

--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -52,7 +52,7 @@ done
 set -o nounset
 
 if [[ -z ${core_tre_rg:-} ]]; then
-  if [[ ! -z ${TRE_ID:-} ]]; then
+  if [[ -n ${TRE_ID:-} ]]; then
     core_tre_rg="rg-${TRE_ID}"
   else
     echo "Core TRE resource group name wasn't provided"
@@ -66,25 +66,25 @@ then
   no_wait_option="--no-wait"
 fi
 
-group_show_result=$(az group show --name ${core_tre_rg} > /dev/null 2>&1; echo $?)
+group_show_result=$(az group show --name "${core_tre_rg}" > /dev/null 2>&1; echo $?)
 if [[ "$group_show_result" !=  "0" ]]; then
   echo "Resource group ${core_tre_rg} not found - skipping destroy"
   exit 1
 fi
 
-locks=$(az group lock list -g ${core_tre_rg} --query [].id -o tsv)
-if [ ! -z "${locks:-}" ]
+locks=$(az group lock list -g "${core_tre_rg}" --query [].id -o tsv)
+if [ -n "${locks:-}" ]
 then
   echo "Deleting locks..."
-  az resource lock delete --ids ${locks}
+  az resource lock delete --ids "${locks}"
 fi
 
 delete_resource_diagnostic() {
   # the command will return an error if the resource doesn't support this setting, so need to suppress it.
-  az monitor diagnostic-settings list --resource $1 --query "value[].name" -o tsv 2> /dev/null |
+  az monitor diagnostic-settings list --resource "$1" --query "value[].name" -o tsv 2> /dev/null |
   while read -r diag_name; do
     echo "Deleting ${diag_name} on $1"
-    az monitor diagnostic-settings delete --resource $1 --name ${diag_name}
+    az monitor diagnostic-settings delete --resource "$1" --name "${diag_name}"
   done
 }
 export -f delete_resource_diagnostic
@@ -93,7 +93,7 @@ echo "Looking for diagnostic settings..."
 # sometimes, diagnostic settings aren't deleted with the resource group. we need to manually do that,
 # and unfortunately, there's no easy way to list all that are present.
 # using xargs to run in parallel.
-az resource list --resource-group ${core_tre_rg} --query '[].[id]' -o tsv | xargs -P 10 -I {} bash -c 'delete_resource_diagnostic "{}"'
+az resource list --resource-group "${core_tre_rg}" --query '[].[id]' -o tsv | xargs -P 10 -I {} bash -c 'delete_resource_diagnostic "{}"'
 
 
 # purge keyvault if possible (makes it possible to reuse the same tre_id later)
@@ -102,24 +102,24 @@ az resource list --resource-group ${core_tre_rg} --query '[].[id]' -o tsv | xarg
 # DEBUG START
 # This section is to aid debugging an issue where keyvaults aren't being deleted and purged
 echo "keyvault properties:"
-az keyvault list --resource-group ${core_tre_rg} --query "[].properties"
+az keyvault list --resource-group "${core_tre_rg}" --query "[].properties"
 echo "keyvault purge protection evaluation result:"
-az keyvault list --resource-group ${core_tre_rg} --query "[?properties.enablePurgeProtection==``null``] | length (@)"
+az keyvault list --resource-group "${core_tre_rg}" --query "[?properties.enablePurgeProtection==``null``] | length (@)"
 
 if [[ -n ${SHOW_KEYVAULT_DEBUG_ON_DESTROY:-} ]]; then
-  az keyvault list --resource-group ${core_tre_rg} --query "[].properties" --debug
+  az keyvault list --resource-group "${core_tre_rg}" --query "[].properties" --debug
 fi
 # DEBUG END
 
-if [[ $(az keyvault list --resource-group ${core_tre_rg} --query "[?properties.enablePurgeProtection==``null``] | length (@)") != 0 ]]; then
+if [[ $(az keyvault list --resource-group "${core_tre_rg}" --query "[?properties.enablePurgeProtection==``null``] | length (@)") != 0 ]]; then
   tre_id=${core_tre_rg#"rg-"}
   keyvault_name="kv-${tre_id}"
 
   echo "Deleting keyvault: ${keyvault_name}"
-  az keyvault delete --name ${keyvault_name} --resource-group ${core_tre_rg}
+  az keyvault delete --name "${keyvault_name}" --resource-group "${core_tre_rg}"
 
   echo "Purging keyvault: ${keyvault_name}"
-  az keyvault purge --name ${keyvault_name} ${no_wait_option}
+  az keyvault purge --name "${keyvault_name}" ${no_wait_option}
 else
   echo "Resource group ${core_tre_rg} doesn't have a keyvault without pruge protection."
 fi


### PR DESCRIPTION
Update `/test-destroy-env` to destroy both the PR environment (created by `/test`) and the branch environment (created by `workflow_dispatch` of `deploy_tre_branch.yml`) to make environment clean-up easier:
- Don't error if environment doesn't exist in destroy_env_no_terraform.sh
- Update pr-bot to also destory branch environment on /test-destroy-env

Part of #1538 
