### PR TITLE
Import missing env vars from Terraform make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ terraform-deploy:
 	$(call target_title, "Deploying ${DIR} with Terraform") \
 	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ./devops/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ${DIR}/.env \
@@ -199,6 +200,7 @@ terraform-import:
 	$(call target_title, "Importing ${DIR} with Terraform") \
 	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ./devops/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ${DIR}/.env \
@@ -208,6 +210,7 @@ terraform-destroy:
 	$(call target_title, "Destroying ${DIR} Service") \
 	&& . ./devops/scripts/check_dependencies.sh \
 	&& . ./devops/scripts/load_env.sh ./devops/.env \
+	&& . ./devops/scripts/load_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ./devops/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ./templates/core/.env \
 	&& . ./devops/scripts/load_terraform_env.sh ${DIR}/.env \


### PR DESCRIPTION
# Import missing env vars from Terraform make commands

Closes #1675 

Add `&& . ./devops/scripts/load_env.sh ./templates/core/.env \` to each of the terraform make file commands.



