### PR TITLE
Allow Azure Trusted Services and add note in the docs

### DIFF
--- a/docs/tre-templates/workspaces/base.md
+++ b/docs/tre-templates/workspaces/base.md
@@ -9,3 +9,12 @@ The base workspace template contains the following resources:
 - Key Vault
 - VNet Peer to Core VNet
 - Network Security Group
+- App Service Plan
+
+## Azure Trusted Services
+*Azure Trusted Services* are allowed to connect to both the key vault and storage account provsioned within the workspace. If this is undesirable additonal resources without this setting configured can be deployed.
+
+Further details around which Azure services are allowed to connect can be found below:
+
+- Key Vault: <https://docs.microsoft.com/en-us/azure/key-vault/general/overview-vnet-service-endpoints#trusted-services>
+- Azure Storage: <https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security?msclkid=ee4e79e4b97911eca46dae54da464d11&tabs=azure-portal#trusted-access-for-resources-registered-in-your-subscription>

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-base
-version: 0.1.12
+version: 0.1.13
 description: "A base Azure TRE workspace"
 registry: azuretre
 

--- a/templates/workspaces/base/terraform/keyvault.tf
+++ b/templates/workspaces/base/terraform/keyvault.tf
@@ -7,7 +7,7 @@ resource "azurerm_key_vault" "kv" {
   tenant_id                = data.azurerm_client_config.current.tenant_id
 
   network_acls {
-    bypass         = "None"
+    bypass         = "AzureServices"
     default_action = "Deny"
   }
 


### PR DESCRIPTION
# Allow Azure Trusted Services to Key Vault in base workspace

Closes #1654 

## What is being addressed

As per #1654 this setting is needed to enable certain Azure PaaS services to interact with the Key Vault. As it is set on the storage account, makes sense to have it set on the Key Vault.

As some users may not be comfortable with this added a note to the docs to explain.
