### PR TITLE
Fix default value for windows vm_size

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -49,7 +49,7 @@ parameters:
     default: "Windows 10"
   - name: vm_size
     type: string
-    default: "1 CPU | 3.5GB RAM"
+    default: "2 CPU | 8GB RAM"
   - name: shared_storage_access
     type: string
     default: "true"


### PR DESCRIPTION
# PR for issue #1697

## What is being addressed

The default value for the windows vm_size is incorrect, as a result cannot create a windows vm without the "vm_size" attribute
