### PR TITLE
Add GitHub script to capture PR info

### DIFF
--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -15,25 +15,25 @@ async function getCommandFromComment({ core, context, github }) {
 
   // Determine PR SHA etc
   const prNumber = context.payload.issue.number;
-	const pr = (await github.rest.pulls.get({ owner: repoOwner, repo: repoName, pull_number: prNumber })).data;
-	console.log("==========================================================================================");
-	console.log(pr);
-	console.log("==========================================================================================");
+  const pr = (await github.rest.pulls.get({ owner: repoOwner, repo: repoName, pull_number: prNumber })).data;
+  console.log("==========================================================================================");
+  console.log(pr);
+  console.log("==========================================================================================");
 
-	const prRefId = getRefIdForPr(prNumber);
-	console.log(`prRefId: ${prRefId}`);
-	core.setOutput("prRefId", prRefId);
+  const prRefId = getRefIdForPr(prNumber);
+  console.log(`prRefId: ${prRefId}`);
+  core.setOutput("prRefId", prRefId);
 
-	console.log(`Using head ref: ${pr.head.ref}`)
-	const branchRefId = getRefIdForBranch(pr.head.ref);
-	console.log(`branchRefId: ${branchRefId}`);
+  console.log(`Using head ref: ${pr.head.ref}`)
+  const branchRefId = getRefIdForBranch(pr.head.ref);
+  console.log(`branchRefId: ${branchRefId}`);
 
-	const potentialMergeCommit = pr.merge_commit_sha;
-	console.log(`potentialMergeCommit: ${potentialMergeCommit}`);
-	core.setOutput("potentialMergeCommit", potentialMergeCommit);
+  const potentialMergeCommit = pr.merge_commit_sha;
+  console.log(`potentialMergeCommit: ${potentialMergeCommit}`);
+  core.setOutput("potentialMergeCommit", potentialMergeCommit);
 
-	const prHeadSha = pr.head.sha;;
-	console.log(`prHeadSha: ${prHeadSha}`);
+  const prHeadSha = pr.head.sha;;
+  console.log(`prHeadSha: ${prHeadSha}`);
 
 
   //
@@ -107,16 +107,16 @@ async function userHasWriteAccessToRepo({ github }, username, repoOwner, repoNam
 }
 
 function getRefIdForPr(prNumber) {
-	// Trailing newline is for compatibility with previous bash SHA calculation
-	return createShortHash(`refs/pull/${prNumber}/merge\n`);
+  // Trailing newline is for compatibility with previous bash SHA calculation
+  return createShortHash(`refs/pull/${prNumber}/merge\n`);
 }
 function getRefIdForBranch(branchName) {
-	// Trailing newline is for compatibility with previous bash SHA calculation
-	return createShortHash(`refs/heads/${branchName}\n`);
+  // Trailing newline is for compatibility with previous bash SHA calculation
+  return createShortHash(`refs/heads/${branchName}\n`);
 }
 function createShortHash(ref) {
-	const hash = createHash('sha1').update(ref, 'utf8').digest('hex')
-	return hash.substring(0, 8);
+  const hash = createHash('sha1').update(ref, 'utf8').digest('hex')
+  return hash.substring(0, 8);
 }
 
 module.exports = {

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -1,33 +1,65 @@
 const { getCommandFromComment, labelAsExternalIfAuthorDoesNotHaveWriteAccess } = require('./build.js')
 
-mockGithubRestIssuesAddLabels = jest.fn();
-
-const github = {
-  request: async (route, data) => {
-    if (route === 'GET /repos/{owner}/{repo}/collaborators/{username}') {
-      if (data.username === "admin") {
-        return {
-          status: 204
-        };
-      } else {
-        throw {
-          status: 404,
-        };
-      }
-    }
-  },
-  rest: {
-    issues: {
-      addLabels: mockGithubRestIssuesAddLabels,
+function createGitHubContext() {
+  mockGithubRestIssuesAddLabels = jest.fn();
+  mockCoreSetOutput = jest.fn();
+  return {
+    mockGithubRestIssuesAddLabels,
+    mockCoreSetOutput,
+    core: {
+      setOutput: mockCoreSetOutput,
     },
-  },
-};
-
-const core = {};
+    github: {
+      request: async (route, data) => {
+        if (route === 'GET /repos/{owner}/{repo}/collaborators/{username}') {
+          if (data.username === "admin") {
+            return {
+              status: 204
+            };
+          } else {
+            throw {
+              status: 404,
+            };
+          }
+        }
+      },
+      rest: {
+        issues: {
+          addLabels: mockGithubRestIssuesAddLabels,
+        },
+        pulls: {
+          get: async (params) => {
+            if (params.owner === 'someOwner'
+              && params.repo === 'someRepo'
+              && params.pull_number === 123) {
+              return {
+                data: {
+                  head: {
+                    ref: 'pr-head-ref',
+                    sha: '0123456789',
+                  },
+                  merge_commit_sha: '123456789a',
+                },
+              }
+            }
+            throw 'Unhandled params in fake pulls.get: ' + JSON.stringify(params)
+          },
+        },
+      },
+    }
+  };
+}
 
 describe('getCommandFromComment', () => {
 
-  function createCommentContext(username, commentBody) {
+  var github;
+  var core;
+  var mockCoreSetOutput;
+  beforeEach(() => {
+    ({ core, github, mockCoreSetOutput } = createGitHubContext());
+  });
+
+  function createCommentContext(username, pullRequestNumber, commentBody) {
     return {
       payload: {
         comment: {
@@ -36,8 +68,11 @@ describe('getCommandFromComment', () => {
           },
           body: commentBody,
         },
+        issue: {
+          number: pullRequestNumber,
+        },
         repository: {
-          full_name: 'someOwner/SomeRepo'
+          full_name: 'someOwner/someRepo'
         }
       },
     };
@@ -45,48 +80,48 @@ describe('getCommandFromComment', () => {
 
   describe('with non-contributor', () => {
     test(`should return 'none' for '/test'`, async () => {
-      context = createCommentContext('non-contributor', '/test');
-      var command = await getCommandFromComment({ context, github })
+      context = createCommentContext('non-contributor', 123, '/test');
+      var command = await getCommandFromComment({ core, context, github });
       expect(command).toBe('none');
     });
   });
 
   describe('with contributor', () => {
     test(`should return 'none' if doesn't start with '/'`, async () => {
-      context = createCommentContext('admin', 'foo');
-      var command = await getCommandFromComment({ context, github })
+      context = createCommentContext('admin', 123, 'foo');
+      var command = await getCommandFromComment({ core, context, github });
       expect(command).toBe('none');
     });
 
 
     describe('and single line comments', () => {
       test(`should return 'run-tests' for '/test'`, async () => {
-        context = createCommentContext('admin', '/test');
-        var command = await getCommandFromComment({ context, github })
+        context = createCommentContext('admin', 123, '/test');
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('run-tests');
       });
 
       test(`should return 'run-tests-extended' for '/test-extended'`, async () => {
-        context = createCommentContext('admin', '/test-extended');
-        var command = await getCommandFromComment({ context, github })
+        context = createCommentContext('admin', 123, '/test-extended');
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('run-tests-extended');
       });
 
       test(`should return 'test-force-approve' for '/test-force-approve'`, async () => {
-        context = createCommentContext('admin', '/test-force-approve');
-        var command = await getCommandFromComment({ context, github })
+        context = createCommentContext('admin', 123, '/test-force-approve');
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('test-force-approve');
       });
 
       test(`should return 'test-destroy-env' for '/test-destroy-env'`, async () => {
-        context = createCommentContext('admin', '/test-destroy-env');
-        var command = await getCommandFromComment({ context, github })
+        context = createCommentContext('admin', 123, '/test-destroy-env');
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('test-destroy-env');
       });
 
       test(`should return 'show-help' for '/help'`, async () => {
-        context = createCommentContext('admin', '/help');
-        var command = await getCommandFromComment({ context, github })
+        context = createCommentContext('admin', 123, '/help');
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('show-help');
       });
     });
@@ -94,28 +129,46 @@ describe('getCommandFromComment', () => {
 
     describe('and multi-line comments', () => {
       test(`should return 'run-tests' if first line of comment is '/test'`, async () => {
-        context = createCommentContext('admin', `/test
+        context = createCommentContext('admin', 123, `/test
 Other comment content
 goes here`);
-        var command = await getCommandFromComment({ context, github })
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('run-tests');
       });
 
       test(`should return 'none' if first line of comment is a command even if later lines contain '/test'`, async () => {
-        context = createCommentContext('admin', `Non-command comment
+        context = createCommentContext('admin', 123, `Non-command comment
 /test
 Other comment content
 goes here`);
-        var command = await getCommandFromComment({ context, github })
+        var command = await getCommandFromComment({ core, context, github });
         expect(command).toBe('none');
       });
     });
 
   });
+
+
+  describe('PR context', () => {
+    test('should set correct output for refid', async () => {
+      // Using a PR number of 123 should give a refid of 'cbce50da'
+      // Based on running `echo "refs/pull/123/merge" | shasum | cut -c1-8` (as per the original bash scripts)
+      context = createCommentContext('admin', 123, '/help');
+      await getCommandFromComment({ core, context, github });
+      expect(mockCoreSetOutput).toHaveBeenCalledWith('prRefId', 'cbce50da');
+    });
+  })
 });
 
 
 describe('labelAsExternalIfAuthorDoesNotHaveWriteAccess', () => {
+
+  var core;
+  var github;
+  var mockGithubRestIssuesAddLabels;
+  beforeEach(() => {
+    ({ core, github, mockGithubRestIssuesAddLabels } = createGitHubContext());
+  });
 
   function createPullRequestContext(username, pullRequestNumber) {
     return {
@@ -130,23 +183,23 @@ describe('labelAsExternalIfAuthorDoesNotHaveWriteAccess', () => {
           full_name: 'someOwner/SomeRepo'
         }
       },
-      repo : {
+      repo: {
         owner: 'someOwner',
         repo: 'someRepo'
-      }
+      },
     };
   }
 
-  test(`should return not apply the 'external' label for contributor author`, async () => {
-    context = createPullRequestContext('admin', 123);
-    await labelAsExternalIfAuthorDoesNotHaveWriteAccess({ core, context, github })
-    expect(mockGithubRestIssuesAddLabels).toHaveBeenCalledTimes(0); // shouldn't set the label for contributor
-  });
-
   test(`should apply the 'external' label for non-contributor author`, async () => {
     context = createPullRequestContext('non-contributor', 123);
-    await labelAsExternalIfAuthorDoesNotHaveWriteAccess({ core, context, github })
+    await labelAsExternalIfAuthorDoesNotHaveWriteAccess({ core, context, github });
     expect(mockGithubRestIssuesAddLabels).toHaveBeenCalled(); // should set the label for non-contributor
+  });
+
+  test(`should return not apply the 'external' label for contributor author`, async () => {
+    context = createPullRequestContext('admin', 123);
+    await labelAsExternalIfAuthorDoesNotHaveWriteAccess({ core, context, github });
+    expect(mockGithubRestIssuesAddLabels).toHaveBeenCalledTimes(0); // shouldn't set the label for contributor
   });
 
 });


### PR DESCRIPTION
- Capture info and dump to compare with existing method of generation
- Update tests to create new mock per test for more reliable assertions on calls to mocks (i.e. avoid interference across tests)


Part of #1538 

Future PR(s) will update the pipeline to start using the outputs from the GitHub script and remove some of the bash steps in the workflow.
