### PR TITLE
Move remaining pr-bot logic to GitHub Script

### DIFF
--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -62,7 +62,7 @@ async function getCommandFromComment({ core, context, github }) {
         {
           if (gotNonDocChanges) {
             command = "run-tests";
-            const message = `:runner: Running tests: https://github.com/${repoFullName}/actions/runs/${runId}`;
+            const message = `:runner: Running tests: https://github.com/${repoFullName}/actions/runs/${runId} (with refid \`${prRefId}\`)`;
             await addActionComment({ github }, repoOwner, repoName, prNumber, commentUsername, commentLink, message);
           } else {
             command = "test-force-approve";
@@ -75,7 +75,7 @@ async function getCommandFromComment({ core, context, github }) {
       case "/test-extended":
         {
           command = "run-tests-extended";
-          const message = `:runner: Running extended tests: https://github.com/${repoFullName}/actions/runs/${runId}`;
+          const message = `:runner: Running extended tests: https://github.com/${repoFullName}/actions/runs/${runId} (with refid \`${prRefId}\`)`;
           await addActionComment({ github }, repoOwner, repoName, prNumber, commentUsername, commentLink, message);
           break;
         }

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -89,13 +89,13 @@ async function getCommandFromComment({ core, context, github }) {
         break;
 
       case "/help":
-        showHelp({ github }, repoOwner, repoName, prNumber, null);
+        showHelp({ github }, repoOwner, repoName, prNumber, commentUsername, commentLink, null);
         command = "none"; // command has been handled, so don't need to return a value for future steps
         break;
 
       default:
         core.warning(`'${trimmedFirstLine}' not recognised as a valid command`);
-        await showHelp({ github }, repoOwner, repoName, prNumber, trimmedFirstLine);
+        await showHelp({ github }, repoOwner, repoName, prNumber, commentUsername, commentLink, trimmedFirstLine);
         command = "none";
         break;
     }
@@ -161,7 +161,7 @@ async function userHasWriteAccessToRepo({ core, github }, username, repoOwner, r
   return userHasWriteAccess
 }
 
-async function showHelp({ github }, repoOwner, repoName, prNumber, invalidCommand) {
+async function showHelp({ github }, repoOwner, repoName, prNumber, commentUser, commentLink, invalidCommand) {
   const leadingContent = invalidCommand ? `\`${invalidCommand}\` is not recognised as a valid command.` : "Hello!";
 
   const body = `${leadingContent}
@@ -173,12 +173,7 @@ You can use the following commands:
 &nbsp;&nbsp;&nbsp;&nbsp;/test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)
 &nbsp;&nbsp;&nbsp;&nbsp;/help - show this help`;
 
-  await github.rest.issues.createComment({
-    owner: repoOwner,
-    repo: repoName,
-    issue_number: prNumber,
-    body: body
-  });
+  await addActionComment({github}, repoOwner, repoName, prNumber, commentUser, commentLink, body);
 
 }
 async function addActionComment({ github }, repoOwner, repoName, prNumber, commentUser, commentLink, message) {

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -6,16 +6,21 @@ async function getCommandFromComment({ core, context, github }) {
   const repoParts = repoFullName.split("/");
   const repoOwner = repoParts[0];
   const repoName = repoParts[1];
+  const prNumber = context.payload.issue.number;
 
   // only allow actions for users with write access
   if (!await userHasWriteAccessToRepo({ core, github }, commentUsername, repoOwner, repoName)) {
     core.notice("Command: none - user doesn't have write permission]");
+    github.rest.issues.createComment({
+      owner: repoOwner,
+      repo: repoName,
+      issue_number: prNumber,
+      body: `Sorry, @${commentUsername}, only users with write access to the repo can run pr-bot commands.`
+    });
     return "none";
   }
 
   // Determine PR SHA etc
-  const prNumber = context.payload.issue.number;
-
   const ciGitRef = getRefForPr(prNumber);
   logAndSetOutput(core, "ciGitRef", ciGitRef);
 

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -73,10 +73,11 @@ async function getCommandFromComment({ core, context, github }) {
       default:
         core.warning(`'${trimmedFirstLine}' not recognised as a valid command`);
         await showHelp(github, repoOwner, repoName, prNumber, trimmedFirstLine);
-        return "none";
+        command = "none";
+        break;
     }
   }
-  core.info(`Command: ${command}`);
+  logAndSetOutput(core, "command", command);
   return command;
 }
 

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -11,7 +11,7 @@ async function getCommandFromComment({ core, context, github }) {
   // only allow actions for users with write access
   if (!await userHasWriteAccessToRepo({ core, github }, commentUsername, repoOwner, repoName)) {
     core.notice("Command: none - user doesn't have write permission]");
-    github.rest.issues.createComment({
+    await github.rest.issues.createComment({
       owner: repoOwner,
       repo: repoName,
       issue_number: prNumber,
@@ -88,7 +88,7 @@ async function labelAsExternalIfAuthorDoesNotHaveWriteAccess({ core, context, gi
 
   if (!await userHasWriteAccessToRepo({ core, github }, username, owner, repo)) {
     core.info("Adding external label to PR " + context.payload.pull_request.number)
-    github.rest.issues.addLabels({
+    await github.rest.issues.addLabels({
       owner,
       repo,
       issue_number: context.payload.pull_request.number,
@@ -135,7 +135,7 @@ You can use the following commands:
 &nbsp;&nbsp;&nbsp;&nbsp;/test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)
 &nbsp;&nbsp;&nbsp;&nbsp;/help - show this help`;
 
-  github.rest.issues.createComment({
+  await github.rest.issues.createComment({
     owner: repoOwner,
     repo: repoName,
     issue_number: prNumber,

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -81,8 +81,12 @@ async function getCommandFromComment({ core, context, github }) {
         }
 
       case "/test-force-approve":
-        command = "test-force-approve";
-        break;
+        {
+          command = "test-force-approve";
+            const message = `:white_check_mark: Marking tests as complete`;
+          await addActionComment({ github }, repoOwner, repoName, prNumber, commentUsername, commentLink, message);
+          break;
+        }
 
       case "/test-destroy-env":
         command = "test-destroy-env";

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -83,7 +83,7 @@ async function getCommandFromComment({ core, context, github }) {
       case "/test-force-approve":
         {
           command = "test-force-approve";
-            const message = `:white_check_mark: Marking tests as complete`;
+            const message = `:white_check_mark: Marking tests as complete (for commit ${prHeadSha})`;
           await addActionComment({ github }, repoOwner, repoName, prNumber, commentUsername, commentLink, message);
           break;
         }

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -154,8 +154,8 @@ describe('getCommandFromComment', () => {
         username: 'admin',
         body: 'foo'
       });
-      const command = await getCommandFromComment({ core, context, github });
-      expect(command).toBe('none');
+      await getCommandFromComment({ core, context, github });
+      expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'none');
     });
 
 
@@ -165,8 +165,8 @@ describe('getCommandFromComment', () => {
           username: 'admin',
           body: '/test'
         });
-        const command = await getCommandFromComment({ core, context, github });
-        expect(command).toBe('run-tests');
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'run-tests');
       });
 
       test(`should return 'run-tests-extended' for '/test-extended'`, async () => {
@@ -183,8 +183,8 @@ describe('getCommandFromComment', () => {
           username: 'admin',
           body: '/test-force-approve'
         });
-        const command = await getCommandFromComment({ core, context, github });
-        expect(command).toBe('test-force-approve');
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'test-force-approve');
       });
 
       test(`should return 'test-destroy-env' for '/test-destroy-env'`, async () => {
@@ -192,8 +192,8 @@ describe('getCommandFromComment', () => {
           username: 'admin',
           body: '/test-destroy-env'
         });
-        const command = await getCommandFromComment({ core, context, github });
-        expect(command).toBe('test-destroy-env');
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'test-destroy-env');
       });
 
       test(`should add help comment and return 'none' for '/help'`, async () => {
@@ -201,7 +201,8 @@ describe('getCommandFromComment', () => {
           username: 'admin',
           body: '/help'
         });
-        const command = await getCommandFromComment({ core, context, github });
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'none');
         expect(mockGithubRestIssuesCreateComment.mock.calls.length).toBe(1);
         const createCommentCall = mockGithubRestIssuesCreateComment.mock.calls[0];
         const createCommentParam = createCommentCall[0];
@@ -209,7 +210,6 @@ describe('getCommandFromComment', () => {
         expect(createCommentParam.repo).toBe("someRepo");
         expect(createCommentParam.issue_number).toBe(123);
         expect(createCommentParam.body).toMatch(/^Hello!\n\nYou can use the following commands:/);
-        expect(command).toBe('none');
       });
 
       test(`should add help comment and return 'none' for '/not-a-command'`, async () => {
@@ -217,7 +217,8 @@ describe('getCommandFromComment', () => {
           username: 'admin',
           body: '/not-a-command'
         });
-        const command = await getCommandFromComment({ core, context, github });
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'none');
         expect(mockGithubRestIssuesCreateComment.mock.calls.length).toBe(1);
         const createCommentCall = mockGithubRestIssuesCreateComment.mock.calls[0];
         const createCommentParam = createCommentCall[0];
@@ -225,7 +226,6 @@ describe('getCommandFromComment', () => {
         expect(createCommentParam.repo).toBe("someRepo");
         expect(createCommentParam.issue_number).toBe(123);
         expect(createCommentParam.body).toMatch(/^`\/not-a-command` is not recognised as a valid command.\n\nYou can use the following commands:/);
-        expect(command).toBe('none');
       });
     });
 
@@ -238,8 +238,8 @@ describe('getCommandFromComment', () => {
 Other comment content
 goes here`
         });
-        const command = await getCommandFromComment({ core, context, github });
-        expect(command).toBe('run-tests');
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'run-tests');
       });
 
       test(`should return 'none' if first line of comment is a command even if later lines contain '/test'`, async () => {
@@ -250,8 +250,8 @@ goes here`
 Other comment content
 goes here`
         });
-        const command = await getCommandFromComment({ core, context, github });
-        expect(command).toBe('none');
+        await getCommandFromComment({ core, context, github });
+        expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'none');
       });
     });
 

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -228,7 +228,7 @@ describe('getCommandFromComment', () => {
           expect(createCommentParam.owner).toBe("someOwner");
           expect(createCommentParam.repo).toBe("someRepo");
           expect(createCommentParam.issue_number).toBe(PR_NUMBER_UPSTREAM_NON_DOCS_CHANGES);
-          expect(createCommentParam.body).toMatch(/Running tests: https:\/\/github.com\/someOwner\/someRepo\/actions\/runs\/11112222/);
+          expect(createCommentParam.body).toMatch(/Running tests: https:\/\/github.com\/someOwner\/someRepo\/actions\/runs\/11112222 \(with refid `cbce50da`\)/);
         });
       })
 
@@ -294,7 +294,7 @@ describe('getCommandFromComment', () => {
         expect(createCommentParam.owner).toBe("someOwner");
         expect(createCommentParam.repo).toBe("someRepo");
         expect(createCommentParam.issue_number).toBe(PR_NUMBER_UPSTREAM_NON_DOCS_CHANGES);
-        expect(createCommentParam.body).toMatch(/Running extended tests: https:\/\/github.com\/someOwner\/someRepo\/actions\/runs\/11112222/);
+        expect(createCommentParam.body).toMatch(/Running extended tests: https:\/\/github.com\/someOwner\/someRepo\/actions\/runs\/11112222 \(with refid `cbce50da`\)/);
       });
 
       test(`for '/test-force-approve' should set command to 'test-force-approve'`, async () => {

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -318,7 +318,7 @@ describe('getCommandFromComment', () => {
         expect(createCommentParam.owner).toBe("someOwner");
         expect(createCommentParam.repo).toBe("someRepo");
         expect(createCommentParam.issue_number).toBe(PR_NUMBER_UPSTREAM_NON_DOCS_CHANGES);
-        expect(createCommentParam.body).toMatch(/Marking tests as complete/);
+        expect(createCommentParam.body).toMatch(/Marking tests as complete \(for commit 0123456789\)/);
       });
 
       test(`for '/test-destroy-env' should set command to 'test-destroy-env'`, async () => {

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -306,6 +306,21 @@ describe('getCommandFromComment', () => {
         expect(mockCoreSetOutput).toHaveBeenCalledWith('command', 'test-force-approve');
       });
 
+      test(`for '/test-force-approve' should add comment`, async () => {
+        const context = createCommentContext({
+          username: 'admin',
+          body: '/test-force-approve',
+        });
+        await getCommandFromComment({ core, context, github });
+        expect(mockGithubRestIssuesCreateComment.mock.calls.length).toBe(1);
+        const createCommentCall = mockGithubRestIssuesCreateComment.mock.calls[0];
+        const createCommentParam = createCommentCall[0];
+        expect(createCommentParam.owner).toBe("someOwner");
+        expect(createCommentParam.repo).toBe("someRepo");
+        expect(createCommentParam.issue_number).toBe(PR_NUMBER_UPSTREAM_NON_DOCS_CHANGES);
+        expect(createCommentParam.body).toMatch(/Marking tests as complete/);
+      });
+
       test(`for '/test-destroy-env' should set command to 'test-destroy-env'`, async () => {
         const context = createCommentContext({
           username: 'admin',

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -130,6 +130,22 @@ describe('getCommandFromComment', () => {
       const command = await getCommandFromComment({ core, context, github });
       expect(command).toBe('none');
     });
+
+    test(`should add a comment indicating that the user cannot run commands`, async () => {
+      const context = createCommentContext({
+        username: 'non-contributor',
+        body: '/test'
+      });
+      await getCommandFromComment({ core, context, github });
+      expect(mockGithubRestIssuesCreateComment.mock.calls.length).toBe(1);
+      const createCommentCall = mockGithubRestIssuesCreateComment.mock.calls[0];
+      const createCommentParam = createCommentCall[0];
+      expect(createCommentParam.owner).toBe("someOwner");
+      expect(createCommentParam.repo).toBe("someRepo");
+      expect(createCommentParam.issue_number).toBe(123);
+      expect(createCommentParam.body).toBe('Sorry, @non-contributor, only users with write access to the repo can run pr-bot commands.');
+    });
+
   });
 
   describe('with contributor', () => {

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -329,7 +329,7 @@ describe('getCommandFromComment', () => {
         expect(createCommentParam.owner).toBe("someOwner");
         expect(createCommentParam.repo).toBe("someRepo");
         expect(createCommentParam.issue_number).toBe(PR_NUMBER_UPSTREAM_NON_DOCS_CHANGES);
-        expect(createCommentParam.body).toMatch(/^Hello!\n\nYou can use the following commands:/);
+        expect(createCommentParam.body).toMatch(/Hello!\n\nYou can use the following commands:/);
       });
 
       test(`for '/not-a-command' should add help comment and set command to 'none'`, async () => {
@@ -346,7 +346,7 @@ describe('getCommandFromComment', () => {
         expect(createCommentParam.owner).toBe("someOwner");
         expect(createCommentParam.repo).toBe("someRepo");
         expect(createCommentParam.issue_number).toBe(PR_NUMBER_UPSTREAM_NON_DOCS_CHANGES);
-        expect(createCommentParam.body).toMatch(/^`\/not-a-command` is not recognised as a valid command.\n\nYou can use the following commands:/);
+        expect(createCommentParam.body).toMatch(/`\/not-a-command` is not recognised as a valid command.\n\nYou can use the following commands:/);
       });
     });
 

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -11,4 +11,19 @@ else
   "$DIR/install-node.sh"
 fi
 
+echo "Running JavaScript build tests..."
 (cd "$DIR" && yarn test)
+
+script_temp_dir="$DIR/script_temp"
+if [[ -x "$script_temp_dir/actionlint" ]]; then
+  echo "actionlint already installed"
+  "$script_temp_dir/actionlint" -version
+else
+  echo "actionlint not found - installing..."
+  mkdir -p "$script_temp_dir"
+  echo '*' > "$script_temp_dir/.gitignore"
+  (cd "$script_temp_dir" && bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash))
+fi
+echo "Running actionlint..."
+"$script_temp_dir/actionlint"
+echo "Tests complete"

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Lint code base
         # the slim image is 2GB smaller and we don't use the extra stuff
         # Moved this after the Terraform checks above due something similar to this issue: https://github.com/github/super-linter/issues/2433
-        # Using SHA dca6e104e781e429b27da8393defc90f8eafe124 below, but revert to slim@v4 (or another release) once there is a release with this: https://github.com/github/super-linter/pull/2759 (Need actionlint>=1.6.11 for https://github.com/rhysd/actionlint/issues/104)
-        uses: github/super-linter/slim@dca6e104e781e429b27da8393defc90f8eafe124
+        uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -61,4 +61,4 @@ jobs:
           JAVA_FILE_NAME: checkstyle.xml
           VALIDATE_BASH: true
           VALIDATE_BASH_EXEC: true
-          VALIDATE_GITHUB_ACTIONS: true
+          # VALIDATE_GITHUB_ACTIONS: true # https://github.com/microsoft/AzureTRE/issues/1723 tracks reverting this to enabled

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -61,4 +61,6 @@ jobs:
           JAVA_FILE_NAME: checkstyle.xml
           VALIDATE_BASH: true
           VALIDATE_BASH_EXEC: true
-          # VALIDATE_GITHUB_ACTIONS: true # https://github.com/microsoft/AzureTRE/issues/1723 tracks reverting this to enabled
+          # https://github.com/microsoft/AzureTRE/issues/1723 tracks re-instating VALIDATE_GITHUB_ACTIONS
+          # Note: in the meantime, the `.github/scripts/run-test.sh` script includes the `actionlint` checks)
+          # VALIDATE_GITHUB_ACTIONS: true

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Lint code base
         # the slim image is 2GB smaller and we don't use the extra stuff
         # Moved this after the Terraform checks above due something similar to this issue: https://github.com/github/super-linter/issues/2433
-        uses: github/super-linter/slim@v4
+        # Using SHA dca6e104e781e429b27da8393defc90f8eafe124 below, but revert to slim@v4 (or another release) once there is a release with this: https://github.com/github/super-linter/pull/2759 (Need actionlint>=1.6.11 for https://github.com/rhysd/actionlint/issues/104)
+        uses: github/super-linter/slim@dca6e104e781e429b27da8393defc90f8eafe124
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -46,17 +46,6 @@ jobs:
             console.log(result);
             return result;
 
-      # Add comment with help text in response to help command
-      - name: Show Help
-        if: ${{ steps.check_command.outputs.result == 'show-help' }}
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.event.repository.full_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Showing help on PR ${PR_NUMBER}"
-          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Hello<br/><br/>You can use the following commands:<br/>    /test - build, deploy and run smoke tests on a PR<br/>    /test-extended - build, deploy and run somke & extended tests on a PR<br/>    /test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)<br/>    /test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)    /help - show this help"
-
       # Get PR commit details for running tests
       - id: get_pr_details
         name: Get PR details

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -99,14 +99,6 @@ jobs:
           echo "Adding comment with link to run on PR ${PR_NUMBER}"
           gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Running tests: https://github.com/${REPO}/actions/runs/${RUN_ID}"
 
-      # Perform az login for destroy env script to be able to run
-      - name: Azure Login
-        if: ${{ steps.check_command.outputs.result == 'test-destroy-env' }}
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-
   destroy_pr_env:
     needs: [pr_comment]
     if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' }}

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -26,7 +26,6 @@ jobs:
       prRefId: ${{ steps.check_command.outputs.prRefId }}
       branchRefId: ${{ steps.check_command.outputs.branchRefid }}
       ciGitRef: ${{ steps.check_command.outputs.ciGitRef }}
-      not-md: ${{ steps.filter.outputs.not-md }}
     steps:
       # Ensure we have the script file for the github-script action to use
       - name: Checkout
@@ -53,29 +52,10 @@ jobs:
           echo "ciGitRef    : ${{ steps.check_command.outputs.ciGitRef }}"
           echo "branchRefId : ${{ steps.check_command.outputs.prRefId }}"
 
-      # Check if the PR build/test needs to run
-      - name: Checkout
-        if: ${{ steps.check_command.outputs.command == 'run-tests' || steps.check_command.outputs.command == 'test-force-approve' || steps.check_command.outputs.command == 'test-destroy-env' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.check_command.outputs.prRef }}
-          persist-credentials: false
-
-      - uses: dorny/paths-filter@v2
-        id: filter
-        if: ${{ steps.check_command.outputs.command == 'run-tests' }}
-        with:
-          base: main
-          ref: ${{ steps.check_command.outputs.prRef }}
-          filters: |
-            not-md:
-              # we need to check for changes in files other than *.md
-              - '**/!(*.md)'
-
-      # If we don't run the actual deploy (below) we won't receive a check-run status,
+      # If we don't run the actual deploy (see the run_test job below) we won't receive a check-run status,
       # and will have to send it "manually"
       - name: Bypass E2E check-runs status
-        if: ${{ (steps.check_command.outputs.command == 'run-tests' && steps.filter.outputs.not-md == 'false' ) || steps.check_command.outputs.command == 'test-force-approve' }}
+        if: ${{ steps.check_command.outputs.command == 'test-force-approve' }}
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -154,7 +134,7 @@ jobs:
   run_test:
     # Run the tests with the re-usable workflow
     needs: [pr_comment]
-    if: ${{ (needs.pr_comment.outputs.command == 'run-tests' && needs.pr_comment.outputs.not-md == 'true') || needs.pr_comment.outputs.command == 'run-tests-extended' }}
+    if: ${{ needs.pr_comment.outputs.command == 'run-tests' || needs.pr_comment.outputs.command == 'run-tests-extended' }}
     name: Deploy PR
     uses: ./.github/workflows/deploy_tre_reusable.yml
     with:

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     outputs:
-      command: ${{ steps.check_command.outputs.result }}
+      command: ${{ steps.check_command.outputs.command }}
       prRef: ${{ steps.check_command.outputs.prRef }}
       prHeadSha: ${{ steps.check_command.outputs.prHeadSha }}
       prRefId: ${{ steps.check_command.outputs.prRefId }}
@@ -39,12 +39,9 @@ jobs:
         name: Check for a command using GitHub script
         uses: actions/github-script@v6
         with:
-          result-encoding: string
           script: |
             const script = require('./.github/scripts/build.js')
-            const result = script.getCommandFromComment({core, context, github});
-            console.log(result);
-            return result;
+            await script.getCommandFromComment({core, context, github});
 
       - name: Output PR details
         run: |
@@ -58,7 +55,7 @@ jobs:
 
       # Check if the PR build/test needs to run
       - name: Checkout
-        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'test-force-approve' || steps.check_command.outputs.result == 'test-destroy-env' }}
+        if: ${{ steps.check_command.outputs.command == 'run-tests' || steps.check_command.outputs.command == 'test-force-approve' || steps.check_command.outputs.command == 'test-destroy-env' }}
         uses: actions/checkout@v2
         with:
           ref: ${{ steps.check_command.outputs.prRef }}
@@ -66,7 +63,7 @@ jobs:
 
       - uses: dorny/paths-filter@v2
         id: filter
-        if: ${{ steps.check_command.outputs.result == 'run-tests' }}
+        if: ${{ steps.check_command.outputs.command == 'run-tests' }}
         with:
           base: main
           ref: ${{ steps.check_command.outputs.prRef }}
@@ -78,7 +75,7 @@ jobs:
       # If we don't run the actual deploy (below) we won't receive a check-run status,
       # and will have to send it "manually"
       - name: Bypass E2E check-runs status
-        if: ${{ (steps.check_command.outputs.result == 'run-tests' && steps.filter.outputs.not-md == 'false' ) || steps.check_command.outputs.result == 'test-force-approve' }}
+        if: ${{ (steps.check_command.outputs.command == 'run-tests' && steps.filter.outputs.not-md == 'false' ) || steps.check_command.outputs.command == 'test-force-approve' }}
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +86,7 @@ jobs:
           conclusion: "success"
 
       - name: Comment with link to run
-        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'run-tests-extended' }}
+        if: ${{ steps.check_command.outputs.command == 'run-tests' || steps.check_command.outputs.command == 'run-tests-extended' }}
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.event.repository.full_name }}

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -85,17 +85,6 @@ jobs:
           status: "completed"
           conclusion: "success"
 
-      - name: Comment with link to run
-        if: ${{ steps.check_command.outputs.command == 'run-tests' || steps.check_command.outputs.command == 'run-tests-extended' }}
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.event.repository.full_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          echo "Adding comment with link to run on PR ${PR_NUMBER}"
-          gh pr comment "${PR_NUMBER}" --repo "$REPO" --body "Running tests: https://github.com/${REPO}/actions/runs/${RUN_ID}"
-
   destroy_pr_env:
     needs: [pr_comment]
     if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' }}

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       command: ${{ steps.check_command.outputs.result }}
-      prRef: ${{ steps.get_pr_details.outputs.prRef }}
-      prHeadSha: ${{ steps.get_pr_details.outputs.prHeadSha }}
-      refid: ${{ steps.get_pr_details.outputs.refid }}
-      branchRefid: ${{ steps.get_pr_details.outputs.branchRefid }}
-      ciGitRef: ${{ steps.get_pr_details.outputs.ciGitRef }}
+      prRef: ${{ steps.check_command.outputs.prRef }}
+      prHeadSha: ${{ steps.check_command.outputs.prHeadSha }}
+      prRefId: ${{ steps.check_command.outputs.prRefId }}
+      branchRefId: ${{ steps.check_command.outputs.branchRefid }}
+      ciGitRef: ${{ steps.check_command.outputs.ciGitRef }}
       not-md: ${{ steps.filter.outputs.not-md }}
     steps:
       # Ensure we have the script file for the github-script action to use
@@ -46,71 +46,22 @@ jobs:
             console.log(result);
             return result;
 
-      # Get PR commit details for running tests
-      - id: get_pr_details
-        name: Get PR details
-        if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'run-tests-extended' || steps.check_command.outputs.result == 'test-force-approve' || steps.check_command.outputs.result == 'test-destroy-env' }}
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.event.repository.full_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Leaving this as bash script as GitHub Script doesn't seem to support multiple output values
-
-          echo "Getting PR ref..."
-          ref=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json commits | jq -r ".[] | last | .oid")
-          echo -e "\tLatest commit ref: $ref"
-          # Get the prMergeCommit as this is what the pull_request trigger would build
-          prMergeRef=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json potentialMergeCommit | jq -r .potentialMergeCommit.oid)
-          echo -e "\tprMergeRef: $prMergeRef"
-          echo
-
-          echo "Setting outputs"
-          echo "::set-output name=prRef::${prMergeRef}"
-
-          # REFID is the basis for the TRE_ID for the PR
-          github_pr_ref="refs/pull/${PR_NUMBER}/merge"
-          echo "::set-output name=ciGitRef::${github_pr_ref}"
-
-          REFID=$(echo "${github_pr_ref}" | shasum | cut -c1-8)
-          echo "using refid of: ${REFID} for GitHub Ref: ${github_pr_ref} (RG base name)"
-          echo "::set-output name=refid::${REFID}"
-
-          # Also generate the REFID for the branch, but only if the headRepo is matches $REPO
-          # This is used later in the destroy to destroy for the PR + branch
-          pr_head_json=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName,headRepositoryOwner,headRepository)
-          pr_head_repo=$(echo "$pr_head_json" | jq -r '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
-          if [[ "$pr_head_repo" == "$REPO" ]]; then
-            github_branch_ref="refs/heads/$(echo "$pr_head_json" | jq -r '.headRefName')"
-            BRANCH_REFID=$(echo "${github_branch_ref}" | shasum | cut -c1-8)
-            echo "Using branch refid of $BRANCH_REFID for branch $github_branch_ref"
-          else
-            echo "Head repo is '$pr_head_repo' - skipping BRANCH_REFID"
-            BRANCH_REFID=""
-          fi
-          echo "::set-output name=branchRefid::${BRANCH_REFID}"
-
-          # Get PR HEAD SHA for checks status
-          echo "Getting PR head SHA"
-          PR_HEAD_SHA=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)
-          echo "PR_HEAD_SHA: ${PR_HEAD_SHA}"
-          echo "::set-output name=prHeadSha::${PR_HEAD_SHA}"
-
       - name: Output PR details
         run: |
           echo "PR Details"
           echo "=========="
-          echo "prRef    : ${{ steps.get_pr_details.outputs.prRef }}"
-          echo "prHeadSha: ${{ steps.get_pr_details.outputs.prHeadSha }}"
-          echo "refid    : ${{ steps.get_pr_details.outputs.refid }}"
-          echo "ciGitRef : ${{ steps.get_pr_details.outputs.ciGitRef }}"
+          echo "prRef       : ${{ steps.check_command.outputs.prRef }}"
+          echo "prHeadSha   : ${{ steps.check_command.outputs.prHeadSha }}"
+          echo "prRefId     : ${{ steps.check_command.outputs.prRefId }}"
+          echo "ciGitRef    : ${{ steps.check_command.outputs.ciGitRef }}"
+          echo "branchRefId : ${{ steps.check_command.outputs.prRefId }}"
 
       # Check if the PR build/test needs to run
       - name: Checkout
         if: ${{ steps.check_command.outputs.result == 'run-tests' || steps.check_command.outputs.result == 'test-force-approve' || steps.check_command.outputs.result == 'test-destroy-env' }}
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.get_pr_details.outputs.prRef }}
+          ref: ${{ steps.check_command.outputs.prRef }}
           persist-credentials: false
 
       - uses: dorny/paths-filter@v2
@@ -118,7 +69,7 @@ jobs:
         if: ${{ steps.check_command.outputs.result == 'run-tests' }}
         with:
           base: main
-          ref: ${{ steps.get_pr_details.outputs.prRef }}
+          ref: ${{ steps.check_command.outputs.prRef }}
           filters: |
             not-md:
               # we need to check for changes in files other than *.md
@@ -132,7 +83,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # the name must be identical to the one received by the real job
-          sha: ${{ steps.get_pr_details.outputs.prHeadSha }}
+          sha: ${{ steps.check_command.outputs.prHeadSha }}
           name: "Deploy PR / Run E2E Tests (Smoke)"
           status: "completed"
           conclusion: "success"
@@ -179,7 +130,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.event.repository.full_name }}
-          RG_NAME: ${{ format('rg-tre{0}', needs.pr_comment.outputs.refid) }}
+          RG_NAME: ${{ format('rg-tre{0}', needs.pr_comment.outputs.prRefId) }}
           RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
@@ -191,7 +142,7 @@ jobs:
 
   destroy_branch_env:
     needs: [pr_comment]
-    if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' && needs.pr_comment.outputs.branchRefid != '' }}
+    if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' && needs.pr_comment.outputs.branchRefId != '' }}
     runs-on: ubuntu-latest
     environment: CICD
     name: Destroy branch env
@@ -212,7 +163,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.event.repository.full_name }}
-          RG_NAME: ${{ format('rg-tre{0}', needs.pr_comment.outputs.branchRefid) }}
+          RG_NAME: ${{ format('rg-tre{0}', needs.pr_comment.outputs.branchRefId) }}
           RUN_ID: ${{ github.run_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOW_KEYVAULT_DEBUG_ON_DESTROY: ${{ secrets.SHOW_KEYVAULT_DEBUG_ON_DESTROY }}
@@ -235,11 +186,11 @@ jobs:
       runExtendedTests: ${{ needs.pr_comment.outputs.command == 'run-tests-extended' }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
-      ACR_NAME: ${{ format('tre{0}', needs.pr_comment.outputs.refid) }}
+      ACR_NAME: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}
       ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
       ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/
       ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
-      ACTIONS_DEVCONTAINER_TAG: ${{ needs.pr_comment.outputs.refid }}
+      ACTIONS_DEVCONTAINER_TAG: ${{ needs.pr_comment.outputs.prRefId }}
       API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
       API_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET }}
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
@@ -248,9 +199,9 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
       CORE_ADDRESS_SPACE: ${{ secrets.CORE_ADDRESS_SPACE }}
       LOCATION: ${{ secrets.LOCATION }}
-      MGMT_RESOURCE_GROUP: ${{ format('rg-tre{0}-mgmt', needs.pr_comment.outputs.refid) }}
+      MGMT_RESOURCE_GROUP: ${{ format('rg-tre{0}-mgmt', needs.pr_comment.outputs.prRefId) }}
       MS_TEAMS_WEBHOOK_URI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-      STATE_STORAGE_ACCOUNT_NAME: ${{ format('tre{0}mgmt', needs.pr_comment.outputs.refid) }}
+      STATE_STORAGE_ACCOUNT_NAME: ${{ format('tre{0}mgmt', needs.pr_comment.outputs.prRefId) }}
       SWAGGER_UI_CLIENT_ID: ${{ secrets.SWAGGER_UI_CLIENT_ID }}
       TEST_APP_ID: ${{ secrets.TEST_APP_ID }}
       TEST_WORKSPACE_APP_ID: ${{ secrets.TEST_WORKSPACE_APP_ID }}
@@ -259,6 +210,6 @@ jobs:
       TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
       TF_STATE_CONTAINER: ${{ secrets.TF_STATE_CONTAINER }}
       TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
-      TRE_ID: ${{ format('tre{0}', needs.pr_comment.outputs.refid) }}
+      TRE_ID: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}
       CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME }}
       TF_LOG: ${{ secrets.TF_LOG }}

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ lint:
 		-e VALIDATE_BASH_EXEC=true \
 		-e VALIDATE_GITHUB_ACTIONS=true \
 		-v $${LOCAL_WORKSPACE_FOLDER}:/tmp/lint \
-		github/super-linter:slim-v4
+		github/super-linter:slim-latest
 
 bundle-build:
 	$(call target_title, "Building ${DIR} bundle with Porter") \

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ lint:
 		-e VALIDATE_BASH_EXEC=true \
 		-e VALIDATE_GITHUB_ACTIONS=true \
 		-v $${LOCAL_WORKSPACE_FOLDER}:/tmp/lint \
-		github/super-linter:slim-latest
+		github/super-linter:slim-v4
 
 bundle-build:
 	$(call target_title, "Building ${DIR} bundle with Porter") \


### PR DESCRIPTION
Continuing work for #1538 

The bulk of this work is moving the remaining pr-bot logic into GitHub script and adding tests for it. There are some other small improvements along the way. Future PRs will update the logic to complete #1538.

- Add tests to validate outputs are set correctly
- Update workflow to use outputs from GitHub script step
- Move help output to GitHub script and update command handling to treat all commands starting with `/` as commands and output message via comment if command isn't recognised
- Use core for logging. This gives more options for controlling the output, and cleans up the test run output.
- Simplify test context setup
- Remove redundant `az login` step
- Disable GitHub Actions linting due to `actionlint` bug (tracking re-enabling in #1723)
- Update build test script to install and run latest `actionlint` which has the above bug fixed (also provides a quicker way to run the workflow linting when working on the workflows)
- Add missing awaits on github SDK calls
- Move "running tests" comments to GitHub script
- Handle docs-only check in GitHub script (bonus, we can now count `mkdocs.yml` as a doc file 😄 )
- Include SHA of commit being approved for `/test-force-approve`
- Include the `refid` (used in the deployment RG name) in the comment for `/test` and `/test-extended`

