### PR TITLE
Add diagnostic settings for core resources

### DIFF
--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -195,9 +195,9 @@ data "azurerm_log_analytics_workspace" "tre" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "agw" {
-  name                           = "diagnostics-agw-${var.tre_id}"
-  target_resource_id             = azurerm_application_gateway.agw.id
-  log_analytics_workspace_id     = var.log_analytics_workspace_id
+  name                       = "diagnostics-agw-${var.tre_id}"
+  target_resource_id         = azurerm_application_gateway.agw.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
   # log_analytics_destination_type = "Dedicated"
 
   dynamic "log" {
@@ -208,7 +208,7 @@ resource "azurerm_monitor_diagnostic_setting" "agw" {
 
       retention_policy {
         enabled = true
-        days = 365
+        days    = 365
       }
     }
   }
@@ -219,7 +219,7 @@ resource "azurerm_monitor_diagnostic_setting" "agw" {
 
     retention_policy {
       enabled = true
-      days = 365
+      days    = 365
     }
   }
 }

--- a/templates/core/terraform/appgateway/appgateway.tf
+++ b/templates/core/terraform/appgateway/appgateway.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "appgwpip" {
   name                = "pip-agw-${var.tre_id}"
   resource_group_name = var.resource_group_name
   location            = var.location
-  allocation_method   = "Static"
+  allocation_method   = "Static" # Static IPs are allocated immediately
   sku                 = "Standard"
   domain_name_label   = var.tre_id
 
@@ -189,8 +189,39 @@ resource "azurerm_application_gateway" "agw" {
 
 }
 
-data "azurerm_public_ip" "appgwpip_data" {
-  depends_on          = [azurerm_application_gateway.agw]
-  name                = "pip-agw-${var.tre_id}"
+data "azurerm_log_analytics_workspace" "tre" {
+  name                = "log-${var.tre_id}"
   resource_group_name = var.resource_group_name
 }
+
+resource "azurerm_monitor_diagnostic_setting" "agw" {
+  name                           = "diagnostics-agw-${var.tre_id}"
+  target_resource_id             = azurerm_application_gateway.agw.id
+  log_analytics_workspace_id     = var.log_analytics_workspace_id
+  # log_analytics_destination_type = "Dedicated"
+
+  dynamic "log" {
+    for_each = toset(["ApplicationGatewayAccessLog", "ApplicationGatewayPerformanceLog", "ApplicationGatewayFirewallLog"])
+    content {
+      category = log.value
+      enabled  = true
+
+      retention_policy {
+        enabled = true
+        days = 365
+      }
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days = 365
+    }
+  }
+}
+
+

--- a/templates/core/terraform/appgateway/output.tf
+++ b/templates/core/terraform/appgateway/output.tf
@@ -1,5 +1,5 @@
 output "app_gateway_fqdn" {
-  value = data.azurerm_public_ip.appgwpip_data.fqdn
+  value = azurerm_public_ip.appgwpip.fqdn
 }
 
 output "app_gateway_name" {

--- a/templates/core/terraform/appgateway/variables.tf
+++ b/templates/core/terraform/appgateway/variables.tf
@@ -7,3 +7,4 @@ variable "shared_subnet" {}
 variable "api_fqdn" {}
 variable "keyvault_id" {}
 variable "static_web_dns_zone_id" {}
+variable "log_analytics_workspace_id" {}

--- a/templates/core/terraform/keyvault.tf
+++ b/templates/core/terraform/keyvault.tf
@@ -86,3 +86,33 @@ resource "azurerm_key_vault_secret" "auth_tenant_id" {
     azurerm_key_vault_access_policy.deployer
   ]
 }
+
+resource "azurerm_monitor_diagnostic_setting" "kv" {
+  name                           = "diagnostics-kv-${var.tre_id}"
+  target_resource_id             = azurerm_key_vault.kv.id
+  log_analytics_workspace_id     = module.azure_monitor.log_analytics_workspace_id
+  # log_analytics_destination_type = "Dedicated"
+
+  dynamic "log" {
+    for_each = toset(["AuditEvent", "AzurePolicyEvaluationDetails"])
+    content {
+      category = log.value
+      enabled  = true
+
+      retention_policy {
+        enabled = true
+        days = 365
+      }
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days = 365
+    }
+  }
+}

--- a/templates/core/terraform/keyvault.tf
+++ b/templates/core/terraform/keyvault.tf
@@ -88,9 +88,9 @@ resource "azurerm_key_vault_secret" "auth_tenant_id" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "kv" {
-  name                           = "diagnostics-kv-${var.tre_id}"
-  target_resource_id             = azurerm_key_vault.kv.id
-  log_analytics_workspace_id     = module.azure_monitor.log_analytics_workspace_id
+  name                       = "diagnostics-kv-${var.tre_id}"
+  target_resource_id         = azurerm_key_vault.kv.id
+  log_analytics_workspace_id = module.azure_monitor.log_analytics_workspace_id
   # log_analytics_destination_type = "Dedicated"
 
   dynamic "log" {
@@ -101,7 +101,7 @@ resource "azurerm_monitor_diagnostic_setting" "kv" {
 
       retention_policy {
         enabled = true
-        days = 365
+        days    = 365
       }
     }
   }
@@ -112,7 +112,7 @@ resource "azurerm_monitor_diagnostic_setting" "kv" {
 
     retention_policy {
       enabled = true
-      days = 365
+      days    = 365
     }
   }
 }

--- a/templates/core/terraform/main.tf
+++ b/templates/core/terraform/main.tf
@@ -55,15 +55,16 @@ module "network" {
 }
 
 module "appgateway" {
-  source                 = "./appgateway"
-  tre_id                 = var.tre_id
-  location               = var.location
-  resource_group_name    = azurerm_resource_group.core.name
-  app_gw_subnet          = module.network.app_gw_subnet_id
-  shared_subnet          = module.network.shared_subnet_id
-  api_fqdn               = azurerm_app_service.api.default_site_hostname
-  keyvault_id            = azurerm_key_vault.kv.id
-  static_web_dns_zone_id = module.network.static_web_dns_zone_id
+  source                     = "./appgateway"
+  tre_id                     = var.tre_id
+  location                   = var.location
+  resource_group_name        = azurerm_resource_group.core.name
+  app_gw_subnet              = module.network.app_gw_subnet_id
+  shared_subnet              = module.network.shared_subnet_id
+  api_fqdn                   = azurerm_app_service.api.default_site_hostname
+  keyvault_id                = azurerm_key_vault.kv.id
+  static_web_dns_zone_id     = module.network.static_web_dns_zone_id
+  log_analytics_workspace_id = module.azure_monitor.log_analytics_workspace_id
 
   depends_on = [
     azurerm_key_vault.kv,

--- a/templates/core/terraform/servicebus.tf
+++ b/templates/core/terraform/servicebus.tf
@@ -71,3 +71,33 @@ resource "azurerm_servicebus_namespace_network_rule_set" "servicebus_network_rul
   public_network_access_enabled = var.enable_local_debugging
   ip_rules                      = var.enable_local_debugging ? ["${local.myip}"] : null
 }
+
+resource "azurerm_monitor_diagnostic_setting" "sb" {
+  name                           = "diagnostics-sb-${var.tre_id}"
+  target_resource_id             = azurerm_servicebus_namespace.sb.id
+  log_analytics_workspace_id     = module.azure_monitor.log_analytics_workspace_id
+  # log_analytics_destination_type = "Dedicated"
+
+  dynamic "log" {
+    for_each = toset(["OperationalLogs", "VNetAndIPFilteringLogs", "RuntimeAuditLogs", "ApplicationMetricsLogs"])
+    content {
+      category = log.value
+      enabled  = true
+
+      retention_policy {
+        enabled = true
+        days = 365
+      }
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+
+    retention_policy {
+      enabled = true
+      days = 365
+    }
+  }
+}

--- a/templates/core/terraform/servicebus.tf
+++ b/templates/core/terraform/servicebus.tf
@@ -73,9 +73,9 @@ resource "azurerm_servicebus_namespace_network_rule_set" "servicebus_network_rul
 }
 
 resource "azurerm_monitor_diagnostic_setting" "sb" {
-  name                           = "diagnostics-sb-${var.tre_id}"
-  target_resource_id             = azurerm_servicebus_namespace.sb.id
-  log_analytics_workspace_id     = module.azure_monitor.log_analytics_workspace_id
+  name                       = "diagnostics-sb-${var.tre_id}"
+  target_resource_id         = azurerm_servicebus_namespace.sb.id
+  log_analytics_workspace_id = module.azure_monitor.log_analytics_workspace_id
   # log_analytics_destination_type = "Dedicated"
 
   dynamic "log" {
@@ -86,7 +86,7 @@ resource "azurerm_monitor_diagnostic_setting" "sb" {
 
       retention_policy {
         enabled = true
-        days = 365
+        days    = 365
       }
     }
   }
@@ -97,7 +97,7 @@ resource "azurerm_monitor_diagnostic_setting" "sb" {
 
     retention_policy {
       enabled = true
-      days = 365
+      days    = 365
     }
   }
 }


### PR DESCRIPTION
Fixes #1746 

## What is being addressed

When something gets wrong in some azure resources it's hard to figure out the problem without logs. I came across this with Application Gateway, but we have other resources as well that don't save logs.
It is also valuable information for security audits and trackback scenarios. 

## How is this addressed

- Add diagnostic settings definition for resource in the core tre infra: application gateway, service bus, keyvault
- Small: remove appgw ip data object as it's not really needed for static IPs.
