### PR TITLE
Soft delete Guacamole Keyvault secrets

### DIFF
--- a/templates/workspace_services/guacamole/terraform/main.tf
+++ b/templates/workspace_services/guacamole/terraform/main.tf
@@ -11,7 +11,11 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}


### PR DESCRIPTION
## What is being addressed

PR #1739 introduced an error while deleting the Guacamole workspace service as the default TF behavior is to purge secrets on destroy.

## How is this addressed

- Update the provider behavior to only soft delete a secret