### PR TITLE
E2E tests in parallel 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -88,7 +88,9 @@
             "-m",
             "extended",
             "--verify",
-            "false"
+            "false",
+            "-n",
+            "5"
           ]
         },
         {
@@ -104,7 +106,9 @@
             "-m",
             "performance",
             "--verify",
-            "false"
+            "false",
+            "-n",
+            "5"
           ]
         },
         {
@@ -190,6 +194,8 @@
             "pytest",
             "-m",
             "smoke",
+            "-n",
+            "5"
           ]
         }
       ]

--- a/Makefile
+++ b/Makefile
@@ -354,12 +354,12 @@ prepare-for-e2e:
 test-e2e-smoke:
 	$(call target_title, "Running E2E smoke tests") && \
 	cd e2e_tests && \
-	python -m pytest -m smoke --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_smoke.xml
+	python -m pytest -m smoke -n 5 --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_smoke.xml
 
 test-e2e-extended:
 	$(call target_title, "Running E2E extended tests") && \
 	cd e2e_tests && \
-	python -m pytest -m extended --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_extended.xml
+	python -m pytest -m extended -n 5 --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_extended.xml
 
 setup-local-debugging:
 	$(call target_title,"Setting up the ability to debug the API and Resource Processor") \

--- a/e2e_tests/requirements.txt
+++ b/e2e_tests/requirements.txt
@@ -4,3 +4,4 @@ pytest==7.1.1
 pytest-asyncio==0.18.2
 starlette==0.17.1
 pytest-timeout==2.1.0
+pytest-xdist==2.5.0

--- a/templates/core/terraform/variables.tf
+++ b/templates/core/terraform/variables.tf
@@ -78,7 +78,7 @@ variable "resource_processor_client_secret" {
 
 variable "resource_processor_number_processes_per_instance" {
   type        = string
-  default     = "2"
+  default     = "5"
   description = "The number of CPU processes to run the RP on per VM instance"
 }
 


### PR DESCRIPTION
# Fixes #1787 

Uses `pytest-xdist` to allow tests to be run in parallel rather than sequentially. 