### PR TITLE
Split out Shared Services tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -92,6 +92,22 @@
           ]
         },
         {
+          "name": "E2E Shared Services",
+          "type": "python",
+          "request": "launch",
+          "module": "pytest",
+          "justMyCode": true,
+          "cwd": "${workspaceFolder}/e2e_tests/",
+          "preLaunchTask": "Copy_env_file_for_e2e_debug",
+          "envFile": "${workspaceFolder}/templates/core/private.env",
+          "args": [
+            "-m",
+            "shared_services",
+            "--verify",
+            "false"
+          ]
+        },
+        {
           "name": "E2E Performance",
           "type": "python",
           "request": "launch",

--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -95,6 +95,15 @@ async function getCommandFromComment({ core, context, github }) {
           break;
         }
 
+      case "/test-shared-services":
+        {
+          const runTests = await handleTestCommand({ core, github }, parts, "shared service tests", runId, { number: prNumber, authorUsername: prAuthorUsername, repoOwner, repoName, headSha: prHeadSha, refId: prRefId, details: pr }, { username: commentUsername, link: commentLink });
+          if (runTests) {
+            command = "run-tests-shared-services";
+          }
+          break;
+        }
+
       case "/test-force-approve":
         {
           command = "test-force-approve";
@@ -229,6 +238,7 @@ async function showHelp({ github }, repoOwner, repoName, prNumber, commentUser, 
 You can use the following commands:
 &nbsp;&nbsp;&nbsp;&nbsp;/test - build, deploy and run smoke tests on a PR
 &nbsp;&nbsp;&nbsp;&nbsp;/test-extended - build, deploy and run smoke & extended tests on a PR
+&nbsp;&nbsp;&nbsp;&nbsp;/test-shared-services - test the deployment of shared services on a PR build
 &nbsp;&nbsp;&nbsp;&nbsp;/test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)
 &nbsp;&nbsp;&nbsp;&nbsp;/test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)
 &nbsp;&nbsp;&nbsp;&nbsp;/help - show this help`;

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -364,6 +364,32 @@ describe('getCommandFromComment', () => {
         });
       });
 
+      describe(`for '/test-shared-services'`, () => {
+        test(`should set command to 'run-tests-shared-services'`, async () => {
+          const context = createCommentContext({
+            username: 'admin',
+            body: '/test-shared-services',
+          });
+          await getCommandFromComment({ core, context, github });
+          expect(outputFor(mockCoreSetOutput, 'command')).toBe('run-tests-shared-services');
+        });
+
+        test(`should add comment with run link`, async () => {
+          const context = createCommentContext({
+            username: 'admin',
+            body: '/test-shared-services',
+            pullRequestNumber: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+          });
+          await getCommandFromComment({ core, context, github });
+          expect(mockGithubRestIssuesCreateComment).toHaveComment({
+            owner: 'someOwner',
+            repo: 'someRepo',
+            issue_number: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+            bodyMatcher: /Running shared service tests: https:\/\/github.com\/someOwner\/someRepo\/actions\/runs\/11112222 \(with refid `cbce50da`\)/,
+          });
+        });
+      });
+
       describe(`for '/test-extended' for external PR (i.e. without commit SHA specified)`, () => {
         test(`should set command to 'none'`, async () => {
           const context = createCommentContext({

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       ciGitRef: ${{ github.ref }}
       runExtendedTests: true
+      runSharedServicesTests: true
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ secrets.ACR_NAME }}

--- a/.github/workflows/deploy_tre_branch.yml
+++ b/.github/workflows/deploy_tre_branch.yml
@@ -14,6 +14,11 @@ on:  # yamllint disable-line rule:truthy
         type: boolean
         default: false
         required: false
+      runSharedServicesTests:
+        description: Run the shared services tests as part of the deployment?
+        type: boolean
+        default: false
+        required: false
 
 # This will prevent multiple runs of this entire workflow.
 # We should NOT cancel in progress runs as that can destabilize the environment.
@@ -51,6 +56,7 @@ jobs:
       ciGitRef: ${{ github.ref }}
       # testing input against string 'true' - see https://github.com/actions/runner/issues/1483
       runExtendedTests: ${{ github.event.inputs.runExtendedTests == 'true' }}
+      runSharedSevicesTests: ${{ github.event.inputs.runSharedServicesTests == 'true' }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ format('tre{0}', needs.prepare-not-main.outputs.refid) }}

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -21,6 +21,11 @@ on:  # yamllint disable-line rule:truthy
         type: boolean
         default: false
         required: false
+      runSharedServicesTests:
+        description: Controls whether to run the shared services tests as part of the deployment
+        type: boolean
+        default: false
+        required: false
     secrets:
       AAD_TENANT_ID:
         description: ""
@@ -706,9 +711,61 @@ jobs:
         with:
           files: "./e2e_tests/pytest_e2e_extended.xml"
 
+  e2e_tests_shared_services:
+    name: "Run E2E Tests (Shared Services)"
+    if: ${{ inputs.runSharedServicesTests }}
+    runs-on: ubuntu-latest
+    environment: CICD
+    needs: [deploy_shared_services, build_additional_images]
+    timeout-minutes: 50
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          # if the following values are missing (i.e. not triggered via comment workflow)
+          # then the default checkout will apply
+          ref: ${{ inputs.prRef }}
+
+      - name: Run E2E Tests (Shared Services)
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make test-e2e-shared-services"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_URI }}
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ACTIONS_DEVCONTAINER_TAG: ${{ secrets.ACTIONS_DEVCONTAINER_TAG }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          LOCATION: "${{ secrets.LOCATION }}"
+          API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
+          AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
+          TEST_WORKSPACE_APP_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
+          TEST_WORKSPACE_APP_SECRET: "${{ secrets.TEST_WORKSPACE_APP_SECRET }}"
+          TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
+          TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          IS_API_SECURED: false
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: E2E Test (Shared Services) Results
+          path: "./e2e_tests/pytest_e2e_shared_services.xml"
+
+      - name: Publish Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "./e2e_tests/pytest_e2e_shared_services.xml"
+
   summary:
     name: Summary Notification
-    needs: [e2e_tests_smoke, e2e_tests_extended]
+    needs: [e2e_tests_smoke, e2e_tests_extended, e2e_tests_shared_services]
     runs-on: ubuntu-latest
     if: ${{ always() && (github.ref == 'refs/heads/main' && inputs.prRef == '') }}
     environment: CICD

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,3 +72,37 @@ jobs:
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
           TRE_ID: "${{ secrets.TRE_ID }}"
           IS_API_SECURED: "false"
+
+  e2e_tests-shared-services:
+    name: "Run E2E Tests (Shared Services)"
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    environment: CICD
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Run E2E Tests (Shared Services)
+        uses: ./.github/actions/devcontainer_run_command
+        with:
+          COMMAND: "make test-e2e-shared-services"
+          ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
+          ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_NAME }}.azurecr.io/
+          ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
+          ACTIONS_DEVCONTAINER_TAG: ${{ secrets.ACTIONS_DEVCONTAINER_TAG }}
+          ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}"
+          ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}"
+          ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}"
+          ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+          LOCATION: "${{ secrets.LOCATION }}"
+          API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
+          AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
+          TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
+          TEST_WORKSPACE_APP_ID: "${{ secrets.TEST_WORKSPACE_APP_ID }}"
+          TEST_WORKSPACE_APP_SECRET: "${{ secrets.TEST_WORKSPACE_APP_SECRET }}"
+          TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
+          TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
+          TRE_ID: "${{ secrets.TRE_ID }}"
+          IS_API_SECURED: "false"

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -134,7 +134,7 @@ jobs:
   run_test:
     # Run the tests with the re-usable workflow
     needs: [pr_comment]
-    if: ${{ needs.pr_comment.outputs.command == 'run-tests' || needs.pr_comment.outputs.command == 'run-tests-extended' }}
+    if: ${{ needs.pr_comment.outputs.command == 'run-tests' || needs.pr_comment.outputs.command == 'run-tests-extended' || needs.pr_comment.outputs.command == 'run-tests-shared-services' }}
     name: Deploy PR
     uses: ./.github/workflows/deploy_tre_reusable.yml
     with:
@@ -142,6 +142,7 @@ jobs:
       prHeadSha: ${{ needs.pr_comment.outputs.prHeadSha }}
       ciGitRef: ${{ needs.pr_comment.outputs.ciGitRef }}
       runExtendedTests: ${{ needs.pr_comment.outputs.command == 'run-tests-extended' }}
+      runSharedServicesTests: ${{ needs.pr_comment.outputs.command == 'run-tests-shared-services' }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}

--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,11 @@ test-e2e-extended:
 	cd e2e_tests && \
 	python -m pytest -m extended --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_extended.xml
 
+test-e2e-shared-services:
+	$(call target_title, "Running E2E shared service tests") && \
+	cd e2e_tests && \
+	python -m pytest -m shared_services --verify $${IS_API_SECURED:-true} --junit-xml pytest_e2e_shared_services.xml
+
 setup-local-debugging:
 	$(call target_title,"Setting up the ability to debug the API and Resource Processor") \
 	&& . ${MAKEFILE_DIR}/devops/scripts/check_dependencies.sh nodocker \

--- a/e2e_tests/test_shared_services.py
+++ b/e2e_tests/test_shared_services.py
@@ -12,7 +12,7 @@ from resources import strings
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.extended
+@pytest.mark.shared_services
 async def test_patch_firewall(admin_token, verify):
     template_name = strings.FIREWALL_SHARED_SERVICE
 
@@ -95,7 +95,7 @@ shared_service_templates_to_create = [
 ]
 
 
-@pytest.mark.extended
+@pytest.mark.shared_services
 @pytest.mark.timeout(30 * 60)
 @pytest.mark.parametrize("template_name", shared_service_templates_to_create)
 async def test_create_shared_service(template_name, admin_token, verify) -> None:

--- a/maintainers.md
+++ b/maintainers.md
@@ -35,11 +35,13 @@ Check for changes to anything that is run during the build/deploy/test cycle, in
 - modifications to scripts
 - new python packages being installed
 
-### `/test-extended [<sha>]`
+### `/test-extended [<sha>]` / `/test-shared-services [<sha>]`
 
-This command runs the build, deploy, and smoke & extended tests for a PR.
+This command runs the build, deploy, and smoke & extended / shared services tests for a PR.
 
 For PRs from maintainers (i.e. users with write access to microsoft/AzureTRE), `/test-extended` is sufficient.
+
+If a change has been made which would affect any of the core shared services, make sure you run `/test-shared-services`.
 
 For other PRs, the checks below should be carried out. Once satisfied that the PR is safe to run tests against, you should use `/test-extended <sha>` where `<sha>` is the SHA for the commit that you have verified.
 You can use the full or short form of the SHA, but it must be at least 7 characters (GitHub UI shows 7 characters).


### PR DESCRIPTION
# Fixes #1787 

Instead of running the tests using parallel workers - as we're not ready for that yet - we can split the shared services tests out to run alongside the 'regular' extended tests. 

- PR bot target added
- shared services tests run in parallel task to extended
- extended tests now just create workspace + guac
