### PR TITLE
Fix check order in pr-bot

### DIFF
--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -53,27 +53,49 @@ describe('getCommandFromComment', () => {
   }
 
   describe('with non-contributor', () => {
-    test(`for '/test' should return 'none'`, async () => {
-      const context = createCommentContext({
-        username: 'non-contributor',
-        body: '/test',
+    describe(`for '/test`, () => {
+      test(`should return 'none'`, async () => {
+        const context = createCommentContext({
+          username: 'non-contributor',
+          body: '/test',
+        });
+        const command = await getCommandFromComment({ core, context, github });
+        expect(outputFor(mockCoreSetOutput, 'command')).toBe('none');
       });
-      const command = await getCommandFromComment({ core, context, github });
-      expect(outputFor(mockCoreSetOutput, 'command')).toBe('none');
-    });
 
-    test(`should add a comment indicating that the user cannot run commands`, async () => {
-      const context = createCommentContext({
-        username: 'non-contributor',
-        body: '/test',
-        pullRequestNumber: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+      test(`should add a comment indicating that the user cannot run commands`, async () => {
+        const context = createCommentContext({
+          username: 'non-contributor',
+          body: '/test',
+          pullRequestNumber: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+        });
+        await getCommandFromComment({ core, context, github });
+        expect(mockGithubRestIssuesCreateComment).toHaveComment({
+          owner: 'someOwner',
+          repo: 'someRepo',
+          issue_number: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+          bodyMatcher: /Sorry, @non-contributor, only users with write access to the repo can run pr-bot commands./
+        });
       });
-      await getCommandFromComment({ core, context, github });
-      expect(mockGithubRestIssuesCreateComment).toHaveComment({
-        owner: 'someOwner',
-        repo: 'someRepo',
-        issue_number: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
-        bodyMatcher: /Sorry, @non-contributor, only users with write access to the repo can run pr-bot commands./
+    });
+    describe(`for 'non-command`, () => {
+      test(`should return 'none'`, async () => {
+        const context = createCommentContext({
+          username: 'non-contributor',
+          body: 'non-command',
+        });
+        const command = await getCommandFromComment({ core, context, github });
+        expect(outputFor(mockCoreSetOutput, 'command')).toBe('none');
+      });
+
+      test(`should not add a comment`, async () => {
+        const context = createCommentContext({
+          username: 'non-contributor',
+          body: 'non-command',
+          pullRequestNumber: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+        });
+        await getCommandFromComment({ core, context, github });
+        expect(mockGithubRestIssuesCreateComment).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
Only check user permissions if a command is detected to avoid adding 'sorry, not allowed' comments in response to comments that aren't commands

Thanks to @martinpeck  for spotting this [here](https://github.com/microsoft/AzureTRE/pull/950#issuecomment-1128311551)