### PR TITLE
Resource Card

### DIFF
--- a/ui/app/src/App.scss
+++ b/ui/app/src/App.scss
@@ -72,7 +72,9 @@ ul.tre-notifications-steps-list li{
 .ms-Persona-primaryText{
     color: #fff;
 }
-
+.tre-hide-chevron i[data-icon-name=ChevronDown] {
+    display:none;
+}
 .tre-body{
     height: 100%;
     overflow: hidden;

--- a/ui/app/src/components/root/RootDashboard.tsx
+++ b/ui/app/src/components/root/RootDashboard.tsx
@@ -3,6 +3,9 @@ import { Workspace } from '../../models/workspace';
 
 import { ResourceCardList } from '../shared/ResourceCardList';
 import { Resource } from '../../models/resource';
+import { IconButton, IContextualMenuProps } from '@fluentui/react';
+import { SecuredByRole } from '../shared/SecuredByRole';
+import { RoleName } from '../../models/roleNames';
 
 interface RootDashboardProps {
   selectWorkspace: (workspace: Workspace) => void,
@@ -11,12 +14,29 @@ interface RootDashboardProps {
 
 export const RootDashboard: React.FunctionComponent<RootDashboardProps> = (props: RootDashboardProps) => {
 
+  // context menu only seen by admins
+  const menuProps: IContextualMenuProps = {
+    shouldFocusOnMount: true,
+    
+    // TODO - implement this menu when update / delete components are available
+    items: [
+      { key: 'update', text: 'Update', iconProps: {iconName: 'WindowEdit' }, onClick: () => console.log('update clicked') },
+      { key: 'disable', text: 'Disable', iconProps: {iconName: 'StatusCircleBlock' }, onClick: () => console.log('disable clicked') },
+      { key: 'delete', text: 'Delete', iconProps: {iconName: 'Delete' }, onClick: () => console.log('delete clicked') }
+    ],
+  };
+
+  const workspaceContextMenu = <SecuredByRole allowedRoles={[RoleName.TREAdmin]} element={
+    <IconButton iconProps={{ iconName: 'More' }} menuProps={menuProps} className="tre-hide-chevron"/>
+  } />
+
   return (
     <>
       <h1>Workspaces</h1>
-      <ResourceCardList 
-        resources={props.workspaces} 
-        selectResource={(r: Resource) => {props.selectWorkspace(r as Workspace)}} 
+      <ResourceCardList
+        resources={props.workspaces}
+        selectResource={(r: Resource) => { props.selectWorkspace(r as Workspace) }}
+        contextMenuElement={workspaceContextMenu} 
         emptyText="No workspaces to display. Create one to get started." />
     </>
   );

--- a/ui/app/src/components/root/RootDashboard.tsx
+++ b/ui/app/src/components/root/RootDashboard.tsx
@@ -1,65 +1,23 @@
-import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
-import { ApiEndpoint } from '../../models/apiEndpoints';
+import React from 'react';
 import { Workspace } from '../../models/workspace';
 
-import { RootRolesContext } from '../shared/RootRolesContext';
-import { PrimaryButton } from '@fluentui/react';
-import { SecuredByRole } from '../shared/SecuredByRole';
-import { RoleName } from '../../models/roleNames';
-import { AddNotificationDemo } from '../shared/notifications/AddNotificationDemo';
-
-// TODO:
-// - Create WorkspaceCard component + use instead of <Link>
+import { ResourceCardList } from '../shared/ResourceCardList';
+import { Resource } from '../../models/resource';
 
 interface RootDashboardProps {
   selectWorkspace: (workspace: Workspace) => void,
   workspaces: Array<Workspace>
 }
 
-export const RootDashboard: React.FunctionComponent<RootDashboardProps> = (props:RootDashboardProps) => {
-  const rootRolesContext = useContext(RootRolesContext);
+export const RootDashboard: React.FunctionComponent<RootDashboardProps> = (props: RootDashboardProps) => {
 
   return (
     <>
-      <AddNotificationDemo />
-      <h3>TRE Roles</h3>
-      <ul>
-        {
-          rootRolesContext.roles &&
-          rootRolesContext.roles.map((role:string, i:number) => {
-            return (
-              <li key={i}>
-                {role}
-              </li>
-            )
-          })
-        }
-      </ul>
-      <SecuredByRole allowedRoles={[RoleName.TREAdmin]} element={
-        <PrimaryButton>Admin Only</PrimaryButton>
-      } />
-      &nbsp; 
-      <SecuredByRole allowedRoles={[RoleName.TREAdmin, RoleName.TREUser]} element={
-        <PrimaryButton>Admin + TRE User Only</PrimaryButton>
-      } />
-      &nbsp; 
-      <SecuredByRole allowedRoles={["NotARole"]} element={
-        <PrimaryButton>Will be hidden for all</PrimaryButton>
-      } />
-      <hr/>
       <h1>Workspaces</h1>
-      <ul>
-      {
-        props.workspaces.map((ws, i) => {
-          return (
-            <li key={i}>
-              <Link to={`/${ApiEndpoint.Workspaces}/${ws.id}`} onClick={() => props.selectWorkspace(ws)}>{ws.properties?.display_name}</Link>
-            </li>
-          )
-        })
-      }
-      </ul>
+      <ResourceCardList 
+        resources={props.workspaces} 
+        selectResource={(r: Resource) => {props.selectWorkspace(r as Workspace)}} 
+        emptyText="No workspaces to display. Create one to get started." />
     </>
   );
 };

--- a/ui/app/src/components/root/RootLayout.tsx
+++ b/ui/app/src/components/root/RootLayout.tsx
@@ -15,7 +15,7 @@ interface RootLayoutProps {
 }
 
 export const RootLayout: React.FunctionComponent<RootLayoutProps> = (props: RootLayoutProps) => {
-  const [workspaces, setWorkspaces] = useState([{} as Workspace]);
+  const [workspaces, setWorkspaces] = useState([] as Array<Workspace>);
   const rootRolesContext = useRef(useContext(RootRolesContext));
   const [loadingState, setLoadingState] = useState('loading');
   const apiCall = useAuthApiCall();

--- a/ui/app/src/components/shared/ResourceCard.tsx
+++ b/ui/app/src/components/shared/ResourceCard.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Resource } from '../../models/resource';
+import { DefaultPalette, Stack, Text } from '@fluentui/react';
+import { Link } from 'react-router-dom';
+
+interface ResourceCardProps {
+  resource: Resource,
+  to: string,
+  selectResource: (resource: Resource) => void
+}
+
+export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: ResourceCardProps) => {
+
+
+  const cardStyles: React.CSSProperties = {
+    width: '100%',
+    borderRadius: '2px',
+    border: '1px #ccc solid'
+  }
+
+  const headerStyles: React.CSSProperties = {
+    padding: '5px 10px',
+    fontSize: '1.3rem',
+
+  };
+
+  const headerLinkStyles: React.CSSProperties = {
+    color: DefaultPalette.themePrimary,
+    textDecoration: 'none'
+  }
+
+  const bodyStyles: React.CSSProperties = {
+    borderBottom: '1px #ccc solid',
+    padding: '5px 10px',
+    minHeight: '70px'
+  }
+
+  const footerStyles: React.CSSProperties = {
+    backgroundColor: DefaultPalette.white,
+    padding: '5px 10px',
+    minHeight: '30px'
+  }
+
+  return (
+    <>
+      <Stack style={cardStyles}>
+        <Stack.Item style={headerStyles}>
+          <Link to={props.resource.resourcePath} onClick={() => {props.selectResource(props.resource); return false}} style={headerLinkStyles}>{props.resource.properties.display_name}</Link>
+        </Stack.Item>
+        <Stack.Item grow={3} style={bodyStyles}>
+          <Text>{props.resource.properties.description}</Text>
+        </Stack.Item>
+        <Stack.Item style={footerStyles}>
+          &nbsp;
+        </Stack.Item>
+      </Stack>
+    </>
+  )
+};
+

--- a/ui/app/src/components/shared/ResourceCard.tsx
+++ b/ui/app/src/components/shared/ResourceCard.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Resource } from '../../models/resource';
-import { DefaultPalette, Stack, Text } from '@fluentui/react';
+import { Callout, DefaultPalette, FontWeights, IconButton, mergeStyleSets, Stack, Text } from '@fluentui/react';
 import { Link } from 'react-router-dom';
+import moment from 'moment';
 
 interface ResourceCardProps {
   resource: Resource,
-  to: string,
-  selectResource: (resource: Resource) => void
+  itemId: number,
+  selectResource: (resource: Resource) => void,
+  contextMenuElement?: JSX.Element
 }
 
 export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: ResourceCardProps) => {
-
+  const [showInfo, setShowInfo] = useState(false);
 
   const cardStyles: React.CSSProperties = {
     width: '100%',
@@ -21,8 +23,11 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
   const headerStyles: React.CSSProperties = {
     padding: '5px 10px',
     fontSize: '1.3rem',
-
   };
+
+  const headerIconStyles: React.CSSProperties = {
+    padding: '5px'
+  }
 
   const headerLinkStyles: React.CSSProperties = {
     color: DefaultPalette.themePrimary,
@@ -41,12 +46,47 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
     minHeight: '30px'
   }
 
+  const calloutKeyStyles: React.CSSProperties = {
+    width: 100
+  } 
+
+  const calloutValueStyles: React.CSSProperties = {
+    width: 200
+  }
+
+  const styles = mergeStyleSets({
+    button: {
+      width: 130,
+    },
+    callout: {
+      width: 350,
+      padding: '20px 24px',
+    },
+    title: {
+      marginBottom: 12,
+      fontWeight: FontWeights.semilight,
+    },
+    link: {
+      display: 'block',
+      marginTop: 20,
+    },
+  });
+
   return (
     <>
       <Stack style={cardStyles}>
-        <Stack.Item style={headerStyles}>
+        <Stack horizontal>
+        <Stack.Item grow={5} style={headerStyles}>
           <Link to={props.resource.resourcePath} onClick={() => {props.selectResource(props.resource); return false}} style={headerLinkStyles}>{props.resource.properties.display_name}</Link>
         </Stack.Item>
+        <Stack.Item style={headerIconStyles}>
+          <Stack horizontal>
+            <Stack.Item><IconButton iconProps={{iconName: 'Info'}} id={`item-${props.itemId}`} onClick={() => setShowInfo(!showInfo)} /></Stack.Item>
+            <Stack.Item>{props.contextMenuElement && props.contextMenuElement}</Stack.Item>
+          </Stack>
+          
+        </Stack.Item>
+        </Stack>
         <Stack.Item grow={3} style={bodyStyles}>
           <Text>{props.resource.properties.description}</Text>
         </Stack.Item>
@@ -54,6 +94,38 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
           &nbsp;
         </Stack.Item>
       </Stack>
+
+      {
+        showInfo &&
+        <Callout
+          className={styles.callout}
+          ariaLabelledBy={`item-${props.itemId}-label`}
+          ariaDescribedBy={`item-${props.itemId}-description`}
+          role="dialog"
+          gapSpace={0}
+          target={`#item-${props.itemId}`}
+          onDismiss={() => setShowInfo(false)}
+          setInitialFocus
+        >
+          <Text block variant="xLarge" className={styles.title} id={`item-${props.itemId}-label`}>
+          {props.resource.templateName} - ({props.resource.templateVersion})
+          </Text>
+          <Text block variant="small" id={`item-${props.itemId}-description`}>
+           <Stack>
+             <Stack.Item>
+               <Stack horizontal tokens={{childrenGap: 5}}>
+                 <Stack.Item style={calloutKeyStyles}>Created By:</Stack.Item>
+                 <Stack.Item style={calloutValueStyles}>{props.resource.user.name}</Stack.Item>
+               </Stack>
+               <Stack horizontal tokens={{childrenGap: 5}}>
+                 <Stack.Item style={calloutKeyStyles}>Last Updated:</Stack.Item>
+                 <Stack.Item style={calloutValueStyles}>{moment.unix(props.resource.updatedWhen).toDate().toDateString()}</Stack.Item>
+               </Stack>
+             </Stack.Item>
+           </Stack>
+          </Text>
+        </Callout>
+      }
     </>
   )
 };

--- a/ui/app/src/components/shared/ResourceCardList.tsx
+++ b/ui/app/src/components/shared/ResourceCardList.tsx
@@ -7,6 +7,7 @@ import { Resource } from '../../models/resource';
 interface ResourceCardListProps {
   resources: Array<Resource>,
   selectResource: (resource: Resource) => void,
+  contextMenuElement?: JSX.Element,
   emptyText: string
 }
 
@@ -36,7 +37,7 @@ export const ResourceCardList: React.FunctionComponent<ResourceCardListProps> = 
               props.resources.map((r, i) => {
                 return (
                   <Stack.Item key={i} style={gridItemStyles} >
-                    <ResourceCard resource={r} selectResource={() => props.selectResource(r)} to={''} />
+                    <ResourceCard resource={r} selectResource={() => props.selectResource(r)} itemId={i} contextMenuElement={props.contextMenuElement}/>
                   </Stack.Item>
                 )
               })

--- a/ui/app/src/components/shared/ResourceCardList.tsx
+++ b/ui/app/src/components/shared/ResourceCardList.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { IStackStyles, IStackTokens, Stack, Text } from '@fluentui/react';
+import { ResourceCard } from '../shared/ResourceCard';
+import { Resource } from '../../models/resource';
+
+interface ResourceCardListProps {
+  resources: Array<Resource>,
+  selectResource: (resource: Resource) => void,
+  emptyText: string
+}
+
+export const ResourceCardList: React.FunctionComponent<ResourceCardListProps> = (props: ResourceCardListProps) => {
+
+  const stackStyles: IStackStyles = {
+    root: {
+      width: 'calc(100% - 20px)'
+    },
+  };
+
+  const wrapStackTokens: IStackTokens = { childrenGap: 20 };
+
+  const gridItemStyles: React.CSSProperties = {
+    alignItems: 'left',
+    display: 'flex',
+    width: 300,
+    background: '#f9f9f9'
+  };
+
+  return (
+    <>
+      {
+        props.resources.length > 0 ?
+          <Stack horizontal wrap styles={stackStyles} tokens={wrapStackTokens}>
+            {
+              props.resources.map((r, i) => {
+                return (
+                  <Stack.Item key={i} style={gridItemStyles} >
+                    <ResourceCard resource={r} selectResource={() => props.selectResource(r)} to={''} />
+                  </Stack.Item>
+                )
+              })
+            }
+          </Stack> :
+          <Text variant="large" block>{props.emptyText}</Text>
+      }
+    </>
+  );
+};

--- a/ui/app/src/components/shared/notifications/NotificationItem.tsx
+++ b/ui/app/src/components/shared/notifications/NotificationItem.tsx
@@ -1,12 +1,10 @@
 import React, { useState } from 'react';
-import { Icon, ProgressIndicator, Link as FluentLink, Stack } from '@fluentui/react';
+import { Icon, ProgressIndicator, Link as FluentLink, Stack, DefaultPalette } from '@fluentui/react';
 import { TRENotification } from '../../../models/treNotification';
 import { completedStates, failedStates, inProgressStates, OperationStep } from '../../../models/operation';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import { useInterval } from './useInterval';
-import { isNoSubstitutionTemplateLiteral } from 'typescript';
-import { relative } from 'path';
 
 interface NotificationItemProps {
   notification: TRENotification
@@ -29,7 +27,7 @@ export const NotificationItem: React.FunctionComponent<NotificationItemProps> = 
     if (failedStates.includes(status)) return ['ErrorBadge', 'red'];
     if (completedStates.includes(status)) return ['SkypeCheck', 'green'];
     if (status === "not_deployed") return ['Clock', '#cccccc'];
-    return ['ProgressLoopInner', 'blue'];
+    return ['ProgressLoopInner', DefaultPalette.themePrimary];
   }
 
   return (
@@ -39,7 +37,7 @@ export const NotificationItem: React.FunctionComponent<NotificationItemProps> = 
           <>
             <ProgressIndicator
               barHeight={4}
-              label={<Link style={{ textDecoration: 'none', fontWeight: 'bold', color: 'blue' }} to={props.notification.operation.resourcePath}>
+              label={<Link style={{ textDecoration: 'none', fontWeight: 'bold', color: DefaultPalette.themePrimary }} to={props.notification.operation.resourcePath}>
                 {props.notification.resource.properties.display_name}: {props.notification.operation.action}
               </Link>}
               description={`${props.notification.resource.resourceType} is ${props.notification.operation.status}`} />
@@ -49,7 +47,7 @@ export const NotificationItem: React.FunctionComponent<NotificationItemProps> = 
             barHeight={4}
             percentComplete={100}
             label={
-              <Link style={{ textDecoration: 'none', fontWeight: 'bold', color: 'blue' }} to={props.notification.operation.resourcePath}>
+              <Link style={{ textDecoration: 'none', fontWeight: 'bold', color: DefaultPalette.themePrimary }} to={props.notification.operation.resourcePath}>
                 <Icon iconName={getIconAndColourForStatus(props.notification.operation.status)[0]} style={{ color: getIconAndColourForStatus(props.notification.operation.status)[1], position: 'relative', top: '2px', marginRight: '10px' }} />
                 {props.notification.resource.properties.display_name}: {props.notification.operation.action}
               </Link>

--- a/ui/app/src/components/workspaces/WorkspaceServiceItem.tsx
+++ b/ui/app/src/components/workspaces/WorkspaceServiceItem.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import {  useParams } from 'react-router-dom';
 import { ApiEndpoint } from '../../models/apiEndpoints';
 import { Workspace } from '../../models/workspace';
 import { useAuthApiCall, HttpMethod } from '../../useAuthApiCall';
@@ -7,9 +7,10 @@ import { UserResource } from '../../models/userResource';
 import { WorkspaceService } from '../../models/workspaceService';
 import { ResourceDebug } from '../shared/ResourceDebug';
 import { MessageBar, MessageBarType, Spinner, SpinnerSize } from '@fluentui/react';
+import { Resource } from '../../models/resource';
+import { ResourceCardList } from '../shared/ResourceCardList';
 
 // TODO:
-// - replace list of user resources with cards
 // - separate loading placeholders for user resources instead of spinner
 
 interface WorkspaceServiceItemProps {
@@ -55,17 +56,10 @@ export const WorkspaceServiceItem: React.FunctionComponent<WorkspaceServiceItemP
           <h2>User Resources:</h2>
           {
             userResources &&
-            <ul>
-              {
-                userResources.map((userResource, i) => {
-                  return (
-                    <li key={i}>
-                      <Link to={`user-resources/${userResource.id}`} onClick={() => props.setUserResource(userResource)}>{userResource.properties?.display_name}</Link>
-                    </li>
-                  )
-                })
-              }
-            </ul>
+            <ResourceCardList 
+              resources={userResources} 
+              selectResource={(r: Resource) => props.setUserResource(r as UserResource)} 
+              emptyText="This workspace service contains no user resources."/>
           }
           <ResourceDebug resource={workspaceService} />
         </>

--- a/ui/app/src/components/workspaces/WorkspaceServiceItem.tsx
+++ b/ui/app/src/components/workspaces/WorkspaceServiceItem.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {  useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { ApiEndpoint } from '../../models/apiEndpoints';
 import { Workspace } from '../../models/workspace';
 import { useAuthApiCall, HttpMethod } from '../../useAuthApiCall';
@@ -56,10 +56,10 @@ export const WorkspaceServiceItem: React.FunctionComponent<WorkspaceServiceItemP
           <h2>User Resources:</h2>
           {
             userResources &&
-            <ResourceCardList 
-              resources={userResources} 
-              selectResource={(r: Resource) => props.setUserResource(r as UserResource)} 
-              emptyText="This workspace service contains no user resources."/>
+            <ResourceCardList
+              resources={userResources}
+              selectResource={(r: Resource) => props.setUserResource(r as UserResource)}
+              emptyText="This workspace service contains no user resources." />
           }
           <ResourceDebug resource={workspaceService} />
         </>

--- a/ui/app/src/components/workspaces/WorkspaceServices.tsx
+++ b/ui/app/src/components/workspaces/WorkspaceServices.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Resource } from '../../models/resource';
 import { Workspace } from '../../models/workspace';
 import { WorkspaceService } from '../../models/workspaceService';
-
-// TODO:
-// - workspace service cards
+import { ResourceCardList } from '../shared/ResourceCardList';
 
 interface WorkspaceServicesProps {
   workspace: Workspace,
@@ -16,18 +14,11 @@ export const WorkspaceServices: React.FunctionComponent<WorkspaceServicesProps> 
 
   return (
     <>
-     <h1>Workspace Services Landing</h1>
-
-      <h2>Services</h2>
-      <ul>
-      {
-        props.workspaceServices.map((ws:WorkspaceService, i:number) => {
-          return (
-            <li key={i}><Link to={ws.id.toString()} onClick={() => props.setWorkspaceService(ws)}>{ws.properties.display_name}</Link></li>
-          )
-        })
-      }
-      </ul>
+     <h1>Workspace Services</h1>
+      <ResourceCardList 
+        resources={props.workspaceServices} 
+        selectResource={(r: Resource) => props.setWorkspaceService(r as WorkspaceService)} 
+        emptyText="This workspace currently has no workspace services."/>
     </>
   );
 };

--- a/ui/app/src/components/workspaces/WorkspaceServices.tsx
+++ b/ui/app/src/components/workspaces/WorkspaceServices.tsx
@@ -10,15 +10,15 @@ interface WorkspaceServicesProps {
   setWorkspaceService: (workspaceService: WorkspaceService) => void
 }
 
-export const WorkspaceServices: React.FunctionComponent<WorkspaceServicesProps> = (props:WorkspaceServicesProps) => {
+export const WorkspaceServices: React.FunctionComponent<WorkspaceServicesProps> = (props: WorkspaceServicesProps) => {
 
   return (
     <>
-     <h1>Workspace Services</h1>
-      <ResourceCardList 
-        resources={props.workspaceServices} 
-        selectResource={(r: Resource) => props.setWorkspaceService(r as WorkspaceService)} 
-        emptyText="This workspace currently has no workspace services."/>
+      <h1>Workspace Services</h1>
+      <ResourceCardList
+        resources={props.workspaceServices}
+        selectResource={(r: Resource) => props.setWorkspaceService(r as WorkspaceService)}
+        emptyText="This workspace has no workspace services." />
     </>
   );
 };


### PR DESCRIPTION
Closes #1803 

Resource card showing high level details of the Resource, as shown in the mocks. 
- Call out '(i)' menu
- Example of handing a role-secured contextual menu to the card layout to be used in different situations:

![image](https://user-images.githubusercontent.com/35696285/169075682-d1ce2226-9964-4be8-8676-ca6c25e7a082.png)
