### PR TITLE
Connect button on resource card

### DIFF
--- a/ui/app/src/components/shared/ResourceCard.tsx
+++ b/ui/app/src/components/shared/ResourceCard.tsx
@@ -81,8 +81,7 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
     },
   });
 
-  let canConnect = props.resource.properties && props.resource.properties['connection_uri'];
-  let connectUri = canConnect ? props.resource.properties['connection_uri'] : '';
+  let connectUri = props.resource.properties && props.resource.properties['connection_uri'];
 
   return (
     <>
@@ -98,10 +97,11 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
             </Stack>
           </Stack.Item>
         </Stack>
-        <Stack.Item grow={3} style={ (canConnect) ? bodyStylesWithConnect : bodyStyles}>
+        <Stack.Item grow={3} style={ (connectUri) ? bodyStylesWithConnect : bodyStyles}>
           <Text>{props.resource.properties.description}</Text>
         </Stack.Item>
-        { canConnect &&
+        { 
+        connectUri &&
         <Stack.Item style={connectStyles}>
             <PrimaryButton onClick={ () => window.open(connectUri) }>Connect</PrimaryButton>
         </Stack.Item>

--- a/ui/app/src/components/shared/ResourceCard.tsx
+++ b/ui/app/src/components/shared/ResourceCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Resource } from '../../models/resource';
-import { Callout, DefaultPalette, FontWeights, IconButton, mergeStyleSets, Stack, Text } from '@fluentui/react';
+import { Callout, DefaultPalette, FontWeights, IconButton, mergeStyleSets, PrimaryButton, Stack, Text } from '@fluentui/react';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 
@@ -35,13 +35,22 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
   }
 
   const bodyStyles: React.CSSProperties = {
-    borderBottom: '1px #ccc solid',
     padding: '5px 10px',
     minHeight: '70px'
   }
 
+  const bodyStylesWithConnect: React.CSSProperties = {
+    padding: '5px 10px',
+    minHeight: '40px'
+  }
+
+  const connectStyles: React.CSSProperties = {
+    padding: '5px 10px'
+  }
+
   const footerStyles: React.CSSProperties = {
     backgroundColor: DefaultPalette.white,
+    borderTop: '1px #ccc solid',
     padding: '5px 10px',
     minHeight: '30px'
   }
@@ -72,24 +81,31 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
     },
   });
 
+  let canConnect = props.resource.properties && props.resource.properties['connection_uri'];
+  let connectUri = canConnect ? props.resource.properties['connection_uri'] : '';
+
   return (
     <>
       <Stack style={cardStyles}>
         <Stack horizontal>
-        <Stack.Item grow={5} style={headerStyles}>
-          <Link to={props.resource.resourcePath} onClick={() => {props.selectResource(props.resource); return false}} style={headerLinkStyles}>{props.resource.properties.display_name}</Link>
-        </Stack.Item>
-        <Stack.Item style={headerIconStyles}>
-          <Stack horizontal>
-            <Stack.Item><IconButton iconProps={{iconName: 'Info'}} id={`item-${props.itemId}`} onClick={() => setShowInfo(!showInfo)} /></Stack.Item>
-            <Stack.Item>{props.contextMenuElement && props.contextMenuElement}</Stack.Item>
-          </Stack>
-          
-        </Stack.Item>
+          <Stack.Item grow={5} style={headerStyles}>
+            <Link to={props.resource.resourcePath} onClick={() => {props.selectResource(props.resource); return false}} style={headerLinkStyles}>{props.resource.properties.display_name}</Link>
+          </Stack.Item>
+          <Stack.Item style={headerIconStyles}>
+            <Stack horizontal>
+              <Stack.Item><IconButton iconProps={{iconName: 'Info'}} id={`item-${props.itemId}`} onClick={() => setShowInfo(!showInfo)} /></Stack.Item>
+              <Stack.Item>{props.contextMenuElement && props.contextMenuElement}</Stack.Item>
+            </Stack>
+          </Stack.Item>
         </Stack>
-        <Stack.Item grow={3} style={bodyStyles}>
+        <Stack.Item style={ (canConnect) ? bodyStylesWithConnect : bodyStyles}>
           <Text>{props.resource.properties.description}</Text>
         </Stack.Item>
+        { canConnect &&
+        <Stack.Item style={connectStyles}>
+            <PrimaryButton onClick={ () => window.open(connectUri) }>Connect</PrimaryButton>
+        </Stack.Item>
+        }
         <Stack.Item style={footerStyles}>
           &nbsp;
         </Stack.Item>

--- a/ui/app/src/components/shared/ResourceCard.tsx
+++ b/ui/app/src/components/shared/ResourceCard.tsx
@@ -98,7 +98,7 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
             </Stack>
           </Stack.Item>
         </Stack>
-        <Stack.Item style={ (canConnect) ? bodyStylesWithConnect : bodyStyles}>
+        <Stack.Item grow={3} style={ (canConnect) ? bodyStylesWithConnect : bodyStyles}>
           <Text>{props.resource.properties.description}</Text>
         </Stack.Item>
         { canConnect &&


### PR DESCRIPTION
# PR for issue #1868

* Adds a Connect button to the `ResourceCard`
* Connect button shown if there's a `connection_uri` available in the resource props.
* `connection_uri` launched in new window.

<img width="296" alt="image" src="https://user-images.githubusercontent.com/166592/169287995-6c55ad46-8efd-4f84-a9e5-2fd58420a3ca.png">

<img width="293" alt="image" src="https://user-images.githubusercontent.com/166592/169288018-183e2d29-e85f-4944-8a56-e52cd617caa8.png">

User Resource Actions to be addressed in separate PR.