### PR TITLE
Add TFLint config

### DIFF
--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -1,0 +1,13 @@
+config {
+  module = true
+  force = false
+}
+
+# https://github.com/github/super-linter/issues/2954
+plugin "aws" {
+  enabled = false  # Override: disable AWS
+}
+
+plugin "azurerm" {
+    enabled = true
+}


### PR DESCRIPTION
## What is being addressed

TFLint had a breaking change coming though a recent release of SuperLinter.

## How is this addressed

- Turn off aws plugin (a bug with super linter probably)
- Took the opportunity to turn on azurerm plugin as was waiting for SuperLinter 4.9.3 anyway for that to happen
