### PR TITLE
Reimage Resource Processor Automatically

### DIFF
--- a/templates/core/terraform/.terraform.lock.hcl
+++ b/templates/core/terraform/.terraform.lock.hcl
@@ -57,6 +57,25 @@ provider "registry.terraform.io/hashicorp/local" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.2.0"
   hashes = [

--- a/templates/core/terraform/resource_processor/vmss_porter/cloud-config.yaml
+++ b/templates/core/terraform/resource_processor/vmss_porter/cloud-config.yaml
@@ -23,6 +23,15 @@ packages:
   - gnupg2
   - pass
 
+# create the docker group
+groups:
+  - docker
+
+# add default auto created user to docker group
+system_info:
+  default_user:
+    groups: [docker]
+
 write_files:
   - path: .env
     content: |


### PR DESCRIPTION
Closes #512, #1722 

## What is being addressed

When making a change to the resource processor image and/or config we had to remember to manually reimage the vmss instances.

## How is this addressed

- Include an az cli command to reimage the vmss within our terraform scripts that is triggered when custom data is changed.
- Small: add the vm user to the docker group so it has permissions to interact with the docker daemon. This saves us developers from using sudo when using docker cli.