### PR TITLE
Fix Guacamole firewall rule name

### DIFF
--- a/templates/workspace_services/guacamole/terraform/firewall.tf
+++ b/templates/workspace_services/guacamole/terraform/firewall.tf
@@ -50,7 +50,7 @@ resource "azurerm_firewall_network_rule_collection" "networkrulecollection" {
   action              = "Allow"
 
   rule {
-    name = "allowStorage"
+    name = "AllowAzureAD"
 
     source_addresses = data.azurerm_virtual_network.ws.address_space
 


### PR DESCRIPTION
Fix the name of a firewall rule in Guacamole as it wasn't correct.
