### PR TITLE
Fix pr-bot e2eTestsCustomSelector param

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -144,9 +144,9 @@ jobs:
       prRef: ${{ needs.pr_comment.outputs.prRef }}
       prHeadSha: ${{ needs.pr_comment.outputs.prHeadSha }}
       ciGitRef: ${{ needs.pr_comment.outputs.ciGitRef }}
-      e2eTestsCustomSelector: |
+      e2eTestsCustomSelector: >-
         ${{ (needs.pr_comment.outputs.command == 'run-tests-extended' && 'extended') ||
-        (needs.pr_comment.outputs.command == 'run-tests-shared-services' && 'shared_sevices')}}
+        (needs.pr_comment.outputs.command == 'run-tests-shared-services' && 'shared_sevices') }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}


### PR DESCRIPTION
## What is being addressed

A prior change introduced a new line in a string that is causing an issue as shown [here](https://github.com/microsoft/AzureTRE/runs/6694319610?check_suite_focus=true#step:4:6).

## How is this addressed

- Fix prbot yaml file to strip any new line breaks from the string