### PR TITLE
Don't migrate Terraform state

### DIFF
--- a/templates/core/terraform/deploy.sh
+++ b/templates/core/terraform/deploy.sh
@@ -14,7 +14,7 @@ export TF_VAR_docker_registry_password
 
 # This is where we can migrate any Terraform before we plan and apply
 # For instance deprecated Terraform resources
-./migrate.sh
+#./migrate.sh
 
 PLAN_FILE="tfplan$$"
 TS=$(date +"%s")


### PR DESCRIPTION
## What is being addressed

We get an inconsistent json file returned to us from a call to `terraform show -json`. An example:

```
*** Migrating TF Resources ***
Failed to marshal state to json: schema version 1 for random_string.unique_id in state does not match version 2 from the provider
```

## How is this addressed

- Comment out the call to migrate.sh as we have already migrated the main build environment.
- Will pick this up again when we migrate azurerm_web_app_service to azurerm_linux_web_app
