### PR TITLE
Register VM Bundle for E2E tests

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -487,6 +487,8 @@ jobs:
              BUNDLE_DIR: "./templates/shared_services/sonatype-nexus"}
           - {BUNDLE_TYPE: "shared_service",
              BUNDLE_DIR: "./templates/shared_services/gitea"}
+          - {BUNDLE_TYPE: "user_resource",
+             BUNDLE_DIR: "./templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm"}
     environment: CICD
     steps:
       - name: Checkout


### PR DESCRIPTION
# PR for issue #831

## What is being addressed

We cant create a user_resource in the E2E as none are registered

## How is this addressed

- Register a user_resource bundle type 
