### PR TITLE
Missing TF_VARS passed into devcontainer

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -165,6 +165,8 @@ runs:
         TF_VAR_aad_tenant_id: "${{ inputs.AAD_TENANT_ID }}"
         TF_VAR_api_client_id: "${{ inputs.TF_VAR_api_client_id }}"
         TF_VAR_api_client_secret: "${{ inputs.TF_VAR_api_client_secret }}"
+        TF_VAR_application_admin_client_id: "${{ inputs.TF_VAR_application_admin_client_id }}"
+        TF_VAR_application_admin_client_secret: "${{ inputs.TF_VAR_application_admin_client_secret }}"
         TF_VAR_acr_name: ${{ inputs.ACR_NAME }}
         IS_API_SECURED: ${{ inputs.IS_API_SECURED }}
       run: |


### PR DESCRIPTION
## What is being addressed

We were not passing in TF_VAR_application_admin_client_id and TF_VAR_application_admin_client_secret into the devcontainer
