### PR TITLE
Fix a pytest error when running only smoke tests in CI

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -146,7 +146,8 @@ jobs:
       ciGitRef: ${{ needs.pr_comment.outputs.ciGitRef }}
       e2eTestsCustomSelector: >-
         ${{ (needs.pr_comment.outputs.command == 'run-tests-extended' && 'extended') ||
-        (needs.pr_comment.outputs.command == 'run-tests-shared-services' && 'shared_sevices') }}
+        (needs.pr_comment.outputs.command == 'run-tests-shared-services' && 'shared_sevices') ||
+        (needs.pr_comment.outputs.command == 'run-tests' && '') }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}


### PR DESCRIPTION
## What is being addressed

When running /test via the pr-bot, only smoke tests should run, however the extended job has also started and ended with an error because no tests were "selected" by pytest

## How is this addressed

- Pass in an empty marker selector to the reusable workflow, so that it will not try to run the extended job