### PR TITLE
Block WS Airlock storage acccounts from public network

### DIFF
--- a/templates/workspaces/base/terraform/airlock/eventgrid_topics.tf
+++ b/templates/workspaces/base/terraform/airlock/eventgrid_topics.tf
@@ -7,7 +7,7 @@ resource "azurerm_eventgrid_system_topic" "import_approved_blob_created" {
   topic_type             = "Microsoft.Storage.StorageAccounts"
 
   tags = {
-    Publishers = "airlock;accepted-import-sa"
+    Publishers = "airlock;approved-import-sa"
   }
 
   depends_on = [

--- a/templates/workspaces/base/terraform/airlock/storage_accounts.tf
+++ b/templates/workspaces/base/terraform/airlock/storage_accounts.tf
@@ -11,6 +11,11 @@ resource "azurerm_storage_account" "sa_import_approved" {
   # This is true ONLY when Hierarchical Namespace is DISABLED
   is_hns_enabled = false
 
+  network_rules {
+    default_action = var.enable_local_debugging ? "Allow" : "Deny"
+    bypass         = ["AzureServices"]
+  }
+
   tags = {
     description = "airlock;import;approved"
   }
@@ -58,6 +63,11 @@ resource "azurerm_storage_account" "sa_export_internal" {
   # This is true ONLY when Hierarchical Namespace is DISABLED
   is_hns_enabled = false
 
+  network_rules {
+    default_action = var.enable_local_debugging ? "Allow" : "Deny"
+    bypass         = ["AzureServices"]
+  }
+
   tags = {
     description = "airlock;export;internal"
   }
@@ -100,6 +110,11 @@ resource "azurerm_storage_account" "sa_export_inprogress" {
   # This is true ONLY when Hierarchical Namespace is DISABLED
   is_hns_enabled = false
 
+  network_rules {
+    default_action = var.enable_local_debugging ? "Allow" : "Deny"
+    bypass         = ["AzureServices"]
+  }
+
   tags = {
     description = "airlock;export;inprogress"
   }
@@ -141,6 +156,11 @@ resource "azurerm_storage_account" "sa_export_rejected" {
   # Important! we rely on the fact that the blob craeted events are issued when the creation of the blobs are done.
   # This is true ONLY when Hierarchical Namespace is DISABLED
   is_hns_enabled = false
+
+  network_rules {
+    default_action = var.enable_local_debugging ? "Allow" : "Deny"
+    bypass         = ["AzureServices"]
+  }
 
   tags = {
     description = "airlock;export;rejected"

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -41,7 +41,7 @@ module "airlock" {
   location               = var.location
   tre_id                 = var.tre_id
   ws_resource_group_name = azurerm_resource_group.ws.name
-  enable_local_debugging = true
+  enable_local_debugging = var.enable_local_debugging
   services_subnet_id     = module.network.services_subnet_id
   short_workspace_id     = local.short_workspace_id
 


### PR DESCRIPTION
 Fixes #2014 

## What is being addressed

The storage containers for the airlock, which resides inside the ws, were not restricted

## How is this addressed

- Added network rule
