### PR TITLE
Disable ftp in airlock app

### DIFF
--- a/templates/core/terraform/airlock/airlock_processor.tf
+++ b/templates/core/terraform/airlock/airlock_processor.tf
@@ -56,18 +56,18 @@ resource "azurerm_linux_function_app" "airlock_function_app" {
   }
 
   app_settings = {
-    "SB_CONNECTION_STRING"                = data.azurerm_servicebus_namespace.airlock_sb.default_primary_connection_string
-    "BLOB_CREATED_TOPIC_NAME"             = azurerm_servicebus_topic.blob_created.name
-    "TOPIC_SUBSCRIPTION_NAME"             = azurerm_servicebus_subscription.airlock_processor.name
-    "EVENT_GRID_TOPIC_URI_SETTING"        = azurerm_eventgrid_topic.step_result.endpoint
-    "EVENT_GRID_TOPIC_KEY_SETTING"        = azurerm_eventgrid_topic.step_result.primary_access_key
-    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = false
-    "AIRLOCK_STATUS_CHANGED_QUEUE_NAME"   = local.status_changed_queue_name
-    "APPINSIGHTS_INSTRUMENTATIONKEY"      = data.azurerm_application_insights.core.instrumentation_key
-    "MANAGED_IDENTITY_CLIENT_ID"          = azurerm_user_assigned_identity.airlock_id.client_id
-    "AZURE_SUBSCRIPTION_ID"               = var.arm_subscription_id
-    "TRE_ID"                              = var.tre_id
-    "WEBSITE_CONTENTOVERVNET"             = 1
+    "SB_CONNECTION_STRING"                  = data.azurerm_servicebus_namespace.airlock_sb.default_primary_connection_string
+    "BLOB_CREATED_TOPIC_NAME"               = azurerm_servicebus_topic.blob_created.name
+    "TOPIC_SUBSCRIPTION_NAME"               = azurerm_servicebus_subscription.airlock_processor.name
+    "EVENT_GRID_TOPIC_URI_SETTING"          = azurerm_eventgrid_topic.step_result.endpoint
+    "EVENT_GRID_TOPIC_KEY_SETTING"          = azurerm_eventgrid_topic.step_result.primary_access_key
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE"   = false
+    "AIRLOCK_STATUS_CHANGED_QUEUE_NAME"     = local.status_changed_queue_name
+    "APPLICATIONINSIGHTS_CONNECTION_STRING" = data.azurerm_application_insights.core.connection_string
+    "MANAGED_IDENTITY_CLIENT_ID"            = azurerm_user_assigned_identity.airlock_id.client_id
+    "AZURE_SUBSCRIPTION_ID"                 = var.arm_subscription_id
+    "TRE_ID"                                = var.tre_id
+    "WEBSITE_CONTENTOVERVNET"               = 1
   }
 
   site_config {
@@ -75,6 +75,7 @@ resource "azurerm_linux_function_app" "airlock_function_app" {
     container_registry_managed_identity_client_id = azurerm_user_assigned_identity.airlock_id.client_id
     container_registry_use_managed_identity       = true
     vnet_route_all_enabled                        = true
+    ftps_state                                    = "disabled"
 
     application_stack {
       docker {
@@ -83,6 +84,10 @@ resource "azurerm_linux_function_app" "airlock_function_app" {
         image_tag    = local.version
       }
     }
+
+    # This is added automatically (by Azure?) when the equivalent is set in app_settings.
+    # Setting it here to save TF from updating every apply.
+    application_insights_connection_string = data.azurerm_application_insights.core.connection_string
   }
 
   lifecycle { ignore_changes = [tags] }

--- a/templates/core/terraform/airlock/airlock_processor.tf
+++ b/templates/core/terraform/airlock/airlock_processor.tf
@@ -75,7 +75,7 @@ resource "azurerm_linux_function_app" "airlock_function_app" {
     container_registry_managed_identity_client_id = azurerm_user_assigned_identity.airlock_id.client_id
     container_registry_use_managed_identity       = true
     vnet_route_all_enabled                        = true
-    ftps_state                                    = "disabled"
+    ftps_state                                    = "Disabled"
 
     application_stack {
       docker {


### PR DESCRIPTION
Fixes #2058 

## What is being addressed

Ftp should be disabled in all app service based apps.

## How is this addressed

- Disable ftp access in Airlock app
- Move the application insights connection string (as instrumentation key will be deprecated soon)