### PR TITLE
Workspace app service SKU as top level parameter

### DIFF
--- a/templates/workspaces/base/parameters.json
+++ b/templates/workspaces/base/parameters.json
@@ -111,6 +111,12 @@
       "source": {
         "env": "AAD_REDIRECT_URIS"
       }
+    },
+    {
+      "name": "app_service_plan_sku",
+      "source": {
+        "env": "APP_SERVICE_PLAN_SKU"
+      }
     }
   ]
 }

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-base
-version: 0.3.10
+version: 0.3.11
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -93,6 +93,10 @@ parameters:
     type: string
     description: "List of redirect URIs in {name:value} format"
     default: "W10=" # b64 for []
+  - name: app_service_plan_sku
+    type: string
+    description: "The SKU used when deploying an Azure App Service Plan"
+    default: "P1v3"
 
 outputs:
   - name: app_role_id_workspace_owner
@@ -144,6 +148,7 @@ install:
         app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
         app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
         aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
+        app_service_plan_sku: "{{ bundle.parameters.app_service_plan_sku }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
@@ -178,6 +183,7 @@ upgrade:
         app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
         app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
         aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
+        app_service_plan_sku: "{{ bundle.parameters.app_service_plan_sku }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
@@ -228,6 +234,7 @@ uninstall:
         app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
         app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
         aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
+        app_service_plan_sku: "{{ bundle.parameters.app_service_plan_sku }}"
       backendConfig:
         resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
         storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -124,6 +124,7 @@ mixins:
   - exec
   - terraform:
       clientVersion: 1.1.7
+      initFile: providers.tf
   - az
 
 install:

--- a/templates/workspaces/base/template_schema.json
+++ b/templates/workspaces/base/template_schema.json
@@ -47,6 +47,14 @@
             }
           }
         }
+      },
+      "app_service_plan_sku": {
+        "$id": "#/properties/app_service_plan_sku",
+        "type": "string",
+        "enum": ["P1v3", "P1v2"],
+        "default": "P1v3",
+        "title": "App Service Plan SKU",
+        "description": "The SKU that will be used when deploying an Azure App Service Plan."
       }
     }
 }

--- a/templates/workspaces/base/terraform/keyvault.tf
+++ b/templates/workspaces/base/terraform/keyvault.tf
@@ -1,3 +1,5 @@
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_key_vault" "kv" {
   name                     = local.keyvault_name
   location                 = azurerm_resource_group.ws.location

--- a/templates/workspaces/base/terraform/providers.tf
+++ b/templates/workspaces/base/terraform/providers.tf
@@ -34,9 +34,6 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_subscription" "current" {}
-data "azurerm_client_config" "current" {}
-
 provider "azuread" {
   client_id     = var.auth_client_id
   client_secret = var.auth_client_secret

--- a/templates/workspaces/base/terraform/variables.tf
+++ b/templates/workspaces/base/terraform/variables.tf
@@ -32,7 +32,6 @@ variable "deploy_app_service_plan" {
 
 variable "app_service_plan_sku" {
   type        = string
-  default     = "P1v3"
   description = "App Service Plan SKU"
 }
 


### PR DESCRIPTION
Fixes #2085 

## What is being addressed

Sometimes we like to change the default AppService Plan SKU that is deployed (like due to Azure capacity issues).

## How is this addressed

- Add the sku param in all places so that the api (and ui) will pick it up
- reference the providers.tf file in porter's TF mixin for better caching

