### PR TITLE
Stop running Terraform in base workspace upgrade (temp fix)

### DIFF
--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-base
-version: 0.3.11
+version: 0.3.12
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -163,39 +163,39 @@ install:
         - name: sp_id
 
 upgrade:
-  - terraform:
-      description: "Upgrade workspace"
-      vars:
-        tre_id: "{{ bundle.parameters.tre_id }}"
-        tre_resource_id: "{{ bundle.parameters.id }}"
-        location: "{{ bundle.parameters.azure_location }}"
-        address_space: "{{ bundle.parameters.address_space }}"
-        shared_storage_quota: "{{ bundle.parameters.shared_storage_quota }}"
-        enable_local_debugging: "{{ bundle.parameters.enable_local_debugging }}"
-        register_aad_application: "{{ bundle.parameters.register_aad_application }}"
-        auth_client_id: "{{ bundle.credentials.auth_client_id }}"
-        auth_client_secret: "{{ bundle.credentials.auth_client_secret }}"
-        auth_tenant_id: "{{ bundle.credentials.auth_tenant_id }}"
-        workspace_owner_object_id: "{{ bundle.parameters.workspace_owner_object_id }}"
-        client_id: "{{ bundle.parameters.client_id }}"
-        client_secret: "{{ bundle.parameters.client_secret }}"
-        scope_id: "{{ bundle.parameters.scope_id }}"
-        sp_id: "{{ bundle.parameters.sp_id }}"
-        app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
-        app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
-        aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
-        app_service_plan_sku: "{{ bundle.parameters.app_service_plan_sku }}"
-      backendConfig:
-        resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
-        storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
-        container_name: "{{ bundle.parameters.tfstate_container_name }}"
-        key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.id }}"
-      outputs:
-        - name: app_role_id_workspace_owner
-        - name: app_role_id_workspace_researcher
-        - name: client_id
-        - name: scope_id
-        - name: sp_id
+  # TODO: fix with https://github.com/microsoft/AzureTRE/issues/2114
+  # - terraform:
+  #     description: "Upgrade workspace"
+  #     vars:
+  #       tre_id: "{{ bundle.parameters.tre_id }}"
+  #       tre_resource_id: "{{ bundle.parameters.id }}"
+  #       location: "{{ bundle.parameters.azure_location }}"
+  #       address_space: "{{ bundle.parameters.address_space }}"
+  #       shared_storage_quota: "{{ bundle.parameters.shared_storage_quota }}"
+  #       enable_local_debugging: "{{ bundle.parameters.enable_local_debugging }}"
+  #       register_aad_application: "{{ bundle.parameters.register_aad_application }}"
+  #       auth_client_id: "{{ bundle.credentials.auth_client_id }}"
+  #       auth_client_secret: "{{ bundle.credentials.auth_client_secret }}"
+  #       auth_tenant_id: "{{ bundle.credentials.auth_tenant_id }}"
+  #       workspace_owner_object_id: "{{ bundle.parameters.workspace_owner_object_id }}"
+  #       client_id: "{{ bundle.parameters.client_id }}"
+  #       client_secret: "{{ bundle.parameters.client_secret }}"
+  #       scope_id: "{{ bundle.parameters.scope_id }}"
+  #       sp_id: "{{ bundle.parameters.sp_id }}"
+  #       app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
+  #       app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
+  #       aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
+  #     backendConfig:
+  #       resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
+  #       storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
+  #       container_name: "{{ bundle.parameters.tfstate_container_name }}"
+  #       key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.id }}"
+  #     outputs:
+  #       - name: app_role_id_workspace_owner
+  #       - name: app_role_id_workspace_researcher
+  #       - name: client_id
+  #       - name: scope_id
+  #       - name: sp_id
   - az:
       description: "AAD Application Admin Login"
       arguments:
@@ -212,7 +212,10 @@ upgrade:
       flags:
         workspace-api-client-id: "{{ bundle.parameters.client_id }}"
         aad-redirect-uris-b64: "{{ bundle.parameters.aad_redirect_uris }}"
-        register-aad-application: "{{ bundle.parameters.register_aad_application }}"
+        # always update with the script since we don't run TF for upgrade
+        # might need to change when https://github.com/microsoft/AzureTRE/issues/2114 is resolved.
+        register-aad-application: "false"
+        # register-aad-application: "{{ bundle.parameters.register_aad_application }}"
 
 uninstall:
   - terraform:


### PR DESCRIPTION
## What is being addressed

As mentioned in #2114, we can't run terraform in subsequent actions (after install) as that removes the secrets from keyvault. This is a temporary fix until we decide on the long term approach.

## How is this addressed

- Comment it the terraform step in the upgrade action
- Force the update redirect-uris script to always run to also do the updates TF used for workspace apps registered by the TRE
