### PR TITLE
Guacamole validates scope uri input value

### DIFF
--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-service-guacamole
-version: 0.3.8
+version: 0.3.9
 description: "An Azure TRE service for Guacamole"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/guacamole/template_schema.json
+++ b/templates/workspace_services/guacamole/template_schema.json
@@ -44,7 +44,8 @@
       "$id": "#/properties/workspace_identifier_uri",
       "type": "string",
       "title": "Workspace Identifier URI (Scope)",
-      "description": "The audience/scope/identifier uri of the workspace in AAD"
+      "description": "The audience/scope/identifier uri of the workspace in AAD",
+      "pattern": "^api:\/\/[a-zA-Z0-9_.-]*"
     }
   },
   "pipeline": {

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -16,4 +16,10 @@ variable "guac_drive_path" {}
 variable "guac_disable_download" {}
 variable "is_exposed_externally" {}
 variable "tre_resource_id" {}
-variable "workspace_identifier_uri" {}
+variable "workspace_identifier_uri" {
+  type = string
+  validation {
+    condition = can(regex("^api://[a-zA-Z0-9_.-]*", var.workspace_identifier_uri))
+    error_message = "Uri should be in the form of: api://some-chars-and-or-numbers."
+  }
+}

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -19,7 +19,7 @@ variable "tre_resource_id" {}
 variable "workspace_identifier_uri" {
   type = string
   validation {
-    condition = can(regex("^api://[a-zA-Z0-9_.-]*", var.workspace_identifier_uri))
+    condition     = can(regex("^api://[a-zA-Z0-9_.-]*", var.workspace_identifier_uri))
     error_message = "Uri should be in the form of: api://some-chars-and-or-numbers."
   }
 }


### PR DESCRIPTION
Fixes #2158 

## What is being addressed

We know an application scope uri (used for AAD authentication) should start with api:// and we can validate it to save errors.

## How is this addressed

- Include a pattern definition in the template schema to be picked up by the UI
- Include a regex validator on the TF level to raise an error on the plan phase 

In addition:
- Fix some tags issues
- Remove docker username & password as they aren't in use anyway. Fixes #1940 
- Remove reptation in TF
