### PR TITLE
[temp fix] Delay between system topics creation

### DIFF
--- a/templates/core/terraform/airlock/eventgrid_topics.tf
+++ b/templates/core/terraform/airlock/eventgrid_topics.tf
@@ -135,6 +135,20 @@ resource "azurerm_role_assignment" "servicebus_sender_import_inprogress_blob_cre
   ]
 }
 
+# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+resource "null_resource" "wait_for_import_inprogress_blob_created" {
+  provisioner "local-exec" {
+    command    = "bash -c \"sleep 60s\""
+    on_failure = fail
+  }
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  depends_on = [azurerm_eventgrid_system_topic.import_inprogress_blob_created]
+}
+
 
 resource "azurerm_eventgrid_system_topic" "import_rejected_blob_created" {
   name                   = local.import_rejected_sys_topic_name
@@ -152,7 +166,8 @@ resource "azurerm_eventgrid_system_topic" "import_rejected_blob_created" {
   })
 
   depends_on = [
-    azurerm_storage_account.sa_import_rejected
+    azurerm_storage_account.sa_import_rejected,
+    null_resource.wait_for_import_inprogress_blob_created
   ]
 
   lifecycle { ignore_changes = [tags] }
@@ -166,6 +181,20 @@ resource "azurerm_role_assignment" "servicebus_sender_import_rejected_blob_creat
   depends_on = [
     azurerm_eventgrid_system_topic.import_rejected_blob_created
   ]
+}
+
+# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+resource "null_resource" "wait_for_import_rejected_blob_created" {
+  provisioner "local-exec" {
+    command    = "bash -c \"sleep 60s\""
+    on_failure = fail
+  }
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  depends_on = [azurerm_eventgrid_system_topic.import_rejected_blob_created]
 }
 
 
@@ -185,7 +214,8 @@ resource "azurerm_eventgrid_system_topic" "export_approved_blob_created" {
   })
 
   depends_on = [
-    azurerm_storage_account.sa_export_approved
+    azurerm_storage_account.sa_export_approved,
+    null_resource.wait_for_import_rejected_blob_created
   ]
 
   lifecycle { ignore_changes = [tags] }

--- a/templates/core/terraform/airlock/eventgrid_topics.tf
+++ b/templates/core/terraform/airlock/eventgrid_topics.tf
@@ -135,7 +135,7 @@ resource "azurerm_role_assignment" "servicebus_sender_import_inprogress_blob_cre
   ]
 }
 
-# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+# TEMPPORARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
 resource "null_resource" "wait_for_import_inprogress_blob_created" {
   provisioner "local-exec" {
     command    = "bash -c \"sleep 60s\""
@@ -183,7 +183,7 @@ resource "azurerm_role_assignment" "servicebus_sender_import_rejected_blob_creat
   ]
 }
 
-# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+# TEMPPORARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
 resource "null_resource" "wait_for_import_rejected_blob_created" {
   provisioner "local-exec" {
     command    = "bash -c \"sleep 60s\""

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-base
-version: 0.3.12
+version: 0.3.13
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/base/terraform/airlock/eventgrid_topics.tf
+++ b/templates/workspaces/base/terraform/airlock/eventgrid_topics.tf
@@ -37,6 +37,20 @@ resource "azurerm_role_assignment" "servicebus_sender_import_approved_blob_creat
   ]
 }
 
+# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+resource "null_resource" "wait_for_import_approved_blob_created" {
+  provisioner "local-exec" {
+    command    = "bash -c \"sleep 60s\""
+    on_failure = fail
+  }
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  depends_on = [azurerm_eventgrid_system_topic.import_approved_blob_created]
+}
+
 resource "azurerm_eventgrid_system_topic" "export_inprogress_blob_created" {
   name                   = local.export_inprogress_sys_topic_name
   location               = var.location
@@ -56,7 +70,8 @@ resource "azurerm_eventgrid_system_topic" "export_inprogress_blob_created" {
   }
 
   depends_on = [
-    azurerm_storage_account.sa_export_inprogress
+    azurerm_storage_account.sa_export_inprogress,
+    null_resource.wait_for_import_approved_blob_created
   ]
 
   lifecycle { ignore_changes = [tags] }
@@ -71,6 +86,21 @@ resource "azurerm_role_assignment" "servicebus_sender_export_inprogress_blob_cre
     azurerm_eventgrid_system_topic.export_inprogress_blob_created
   ]
 }
+
+# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+resource "null_resource" "wait_for_export_inprogress_blob_created" {
+  provisioner "local-exec" {
+    command    = "bash -c \"sleep 60s\""
+    on_failure = fail
+  }
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  depends_on = [azurerm_eventgrid_system_topic.export_inprogress_blob_created]
+}
+
 
 resource "azurerm_eventgrid_system_topic" "export_rejected_blob_created" {
   name                   = local.export_rejected_sys_topic_name
@@ -91,7 +121,8 @@ resource "azurerm_eventgrid_system_topic" "export_rejected_blob_created" {
   }
 
   depends_on = [
-    azurerm_storage_account.sa_export_rejected
+    azurerm_storage_account.sa_export_rejected,
+    null_resource.wait_for_export_inprogress_blob_created
   ]
 
   lifecycle { ignore_changes = [tags] }
@@ -106,6 +137,7 @@ resource "azurerm_role_assignment" "servicebus_sender_export_rejected_blob_creat
     azurerm_eventgrid_system_topic.export_rejected_blob_created
   ]
 }
+
 
 ## Subscriptions
 resource "azurerm_eventgrid_event_subscription" "import_approved_blob_created" {

--- a/templates/workspaces/base/terraform/airlock/eventgrid_topics.tf
+++ b/templates/workspaces/base/terraform/airlock/eventgrid_topics.tf
@@ -37,7 +37,7 @@ resource "azurerm_role_assignment" "servicebus_sender_import_approved_blob_creat
   ]
 }
 
-# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+# TEMPPORARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
 resource "null_resource" "wait_for_import_approved_blob_created" {
   provisioner "local-exec" {
     command    = "bash -c \"sleep 60s\""
@@ -87,7 +87,7 @@ resource "azurerm_role_assignment" "servicebus_sender_export_inprogress_blob_cre
   ]
 }
 
-# TEMPRARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
+# TEMPPORARY MITIGATION. Should be removed with https://github.com/microsoft/AzureTRE/issues/2164
 resource "null_resource" "wait_for_export_inprogress_blob_created" {
   provisioner "local-exec" {
     command    = "bash -c \"sleep 60s\""


### PR DESCRIPTION
## What is being addressed

As part of a temporary mitigation of #2164 we need to add 1 minute delay between two event grid system topics provisioning actions.
