### PR TITLE
Fix make auth for first run

### DIFF
--- a/templates/core/.env.sample
+++ b/templates/core/.env.sample
@@ -15,10 +15,11 @@ AAD_TENANT_ID=__CHANGE_ME__
 # APPLICATION_ADMIN_CLIENT_ID=<__CHANGE_ME__Generated when you run `make auth`>
 # APPLICATION_ADMIN_CLIENT_SECRET=<__CHANGE_ME__Generated when you run `make auth`>
 
-
-API_CLIENT_ID=<__CHANGE_ME__Generated when you run `make auth`>
-API_CLIENT_SECRET=<__CHANGE_ME__Generated when you run `make auth`>
-SWAGGER_UI_CLIENT_ID=<__CHANGE_ME__Generated when you run `make auth`>
+# These values will be created when you run `make auth`. You can replace these lines.
+# They are mandatory for the running of `make all`
+# API_CLIENT_ID=<__CHANGE_ME__Generated when you run `make auth`>
+# API_CLIENT_SECRET=<__CHANGE_ME__Generated when you run `make auth`>
+# SWAGGER_UI_CLIENT_ID=<__CHANGE_ME__Generated when you run `make auth`>
 
 # The following 2 environment variables are only required
 # if you want to automated bundle registration.


### PR DESCRIPTION
# Fixes #2178

## What is being addressed

3 lines were left in the sample .env that would be generated by `make auth`

## How is this addressed

- Comment them out