### PR TITLE
Uncomment xtrace in delete_vm_extensions.sh

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/delete_vm_extensions.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/delete_vm_extensions.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 # Uncomment this line to see each command for debugging (careful: this will show secrets!)
-# set -o xtrace
+set -o xtrace
 
 
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/delete_vm_extensions.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/delete_vm_extensions.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 # Uncomment this line to see each command for debugging (careful: this will show secrets!)
-# set -o xtrace
+set -o xtrace
 
 
 # Delete any existing VM Extensions befroe a VM gets deleted.


### PR DESCRIPTION
# Resolves issue

## What is being addressed

Trying to investigate what is happening by making the script log what it's doing. 

Contrary to the comment, it should't show any secrets, because none are passed in the script.  It will show the resource group name, though. I hope it won't be a big problem 