### PR TITLE
Fixed substitution for list of strings

### DIFF
--- a/api_app/service_bus/substitutions.py
+++ b/api_app/service_bus/substitutions.py
@@ -59,7 +59,10 @@ def recurse_object(obj: dict, primary_resource_dict: dict) -> dict:
     for prop in obj:
         if isinstance(obj[prop], list):
             for i in range(0, len(obj[prop])):
-                obj[prop][i] = recurse_object(obj[prop][i], primary_resource_dict)
+                if isinstance(obj[prop][i], list) or isinstance(obj[prop][i], dict):
+                    obj[prop][i] = recurse_object(obj[prop][i], primary_resource_dict)
+                else:
+                    obj[prop][i] = substitute_value(obj[prop][i], primary_resource_dict)
         if isinstance(obj[prop], dict):
             obj[prop] = recurse_object(obj[prop])
         else:

--- a/api_app/tests_ma/test_service_bus/test_substitutions.py
+++ b/api_app/tests_ma/test_service_bus/test_substitutions.py
@@ -1,5 +1,6 @@
 import copy
 import pytest
+from models.domain.resource_template import PipelineStep, PipelineStepProperty
 from service_bus.substitutions import substitute_properties, substitute_value
 
 pytestmark = pytest.mark.asyncio
@@ -29,29 +30,75 @@ def test_substitution(primary_resource):
     assert val == "I think template name is the best template, and 7 is a good version!"
 
 
-def test_simple_substitution(simple_pipeline_step, primary_resource, resource_to_update):
-    obj = substitute_properties(simple_pipeline_step, primary_resource, resource_to_update)
+def test_simple_substitution(
+    simple_pipeline_step, primary_resource, resource_to_update
+):
+    obj = substitute_properties(
+        simple_pipeline_step, primary_resource, resource_to_update
+    )
 
-    assert obj['just_text'] == 'Updated by 123'
-    assert obj['just_text_2'] == 'No substitution, just a fixed string here'
-    assert obj['just_text_3'] == 'Multiple substitutions -> 123 and template name'
+    assert obj["just_text"] == "Updated by 123"
+    assert obj["just_text_2"] == "No substitution, just a fixed string here"
+    assert obj["just_text_3"] == "Multiple substitutions -> 123 and template name"
+
+
+def test_substitution_list_strings(primary_resource, resource_to_update):
+    pipeline_step_with_list_strings = PipelineStep(
+        properties=[
+            PipelineStepProperty(
+                name="obj_list_strings",
+                type="string",
+                value={
+                    "name": "nrc_guacamole_svc_{{ resource.id }}",
+                    "action": "Allow",
+                    "rules": [
+                        {
+                            "name": "AllowAzureAD",
+                            "description": "AAD access for authNZ",
+                            "source_addresses": "",
+                            "destination_addresses": ["AzureActiveDirectory"],
+                            "destination_ports": ["*", "{{resource.id}}"],
+                            "protocols": ["TCP"],
+                        }
+                    ],
+                },
+            )
+        ]
+    )
+    obj = substitute_properties(
+        pipeline_step_with_list_strings, primary_resource, resource_to_update
+    )
+
+    assert obj["obj_list_strings"]["rules"][0]["destination_ports"] == ["*", "123"]
 
 
 def test_substitution_props(pipeline_step, primary_resource, resource_to_update):
     obj = substitute_properties(pipeline_step, primary_resource, resource_to_update)
 
-    assert obj["rule_collections"][0]["rules"][0]["target_fqdns"] == ["*pypi.org", "files.pythonhosted.org", "security.ubuntu.com"]
-    assert obj["rule_collections"][0]["rules"][0]["source_addresses"] == ["172.0.0.1", "192.168.0.1"]
-    assert obj["rule_collections"][0]["rules"][0]["protocols"][1]["type"] == "MyCoolProtocol"
+    assert obj["rule_collections"][0]["rules"][0]["target_fqdns"] == [
+        "*pypi.org",
+        "files.pythonhosted.org",
+        "security.ubuntu.com",
+    ]
+    assert obj["rule_collections"][0]["rules"][0]["source_addresses"] == [
+        "172.0.0.1",
+        "192.168.0.1",
+    ]
+    assert (
+        obj["rule_collections"][0]["rules"][0]["protocols"][1]["type"]
+        == "MyCoolProtocol"
+    )
     assert obj["rule_collections"][0]["rules"][0]["description"] == "Deployed by 123"
 
 
-def test_substitution_array_append_remove(pipeline_step, primary_resource, resource_to_update):
+def test_substitution_array_append_remove(
+    pipeline_step, primary_resource, resource_to_update
+):
 
     # do the first substitution, and assert there's a single rule collection
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "append"
-    step.properties[0].value['name'] = "object 1"
+    step.properties[0].value["name"] = "object 1"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 1
 
@@ -61,7 +108,7 @@ def test_substitution_array_append_remove(pipeline_step, primary_resource, resou
     # now append another substitution, and check we've got both rules
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "append"
-    step.properties[0].value['name'] = "object 2"
+    step.properties[0].value["name"] = "object 2"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 2
 
@@ -71,7 +118,7 @@ def test_substitution_array_append_remove(pipeline_step, primary_resource, resou
     # now append another substitution, and check we've got all 3 rules
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "append"
-    step.properties[0].value['name'] = "object 3"
+    step.properties[0].value["name"] = "object 3"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 3
 
@@ -81,11 +128,11 @@ def test_substitution_array_append_remove(pipeline_step, primary_resource, resou
     # now remove object 2...
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "remove"
-    step.properties[0].value['name'] = "object 2"
+    step.properties[0].value["name"] = "object 2"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 2
-    assert obj['rule_collections'][0]['name'] == "object 1"
-    assert obj['rule_collections'][1]['name'] == "object 3"
+    assert obj["rule_collections"][0]["name"] == "object 1"
+    assert obj["rule_collections"][1]["name"] == "object 3"
 
     # the RP makes the change again...
     resource_to_update.properties = obj
@@ -93,10 +140,10 @@ def test_substitution_array_append_remove(pipeline_step, primary_resource, resou
     # now remove object 1...
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "remove"
-    step.properties[0].value['name'] = "object 1"
+    step.properties[0].value["name"] = "object 1"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 1
-    assert obj['rule_collections'][0]['name'] == "object 3"
+    assert obj["rule_collections"][0]["name"] == "object 3"
 
     # the RP makes the change again...
     resource_to_update.properties = obj
@@ -104,7 +151,7 @@ def test_substitution_array_append_remove(pipeline_step, primary_resource, resou
     # now remove object 3...
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "remove"
-    step.properties[0].value['name'] = "object 3"
+    step.properties[0].value["name"] = "object 3"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 0
 
@@ -114,17 +161,19 @@ def test_substitution_array_append_remove(pipeline_step, primary_resource, resou
     # now remove another one, even though the array is empty...
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "remove"
-    step.properties[0].value['name'] = "object 1"
+    step.properties[0].value["name"] = "object 1"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 0
 
 
-def test_substitution_array_append_replace(pipeline_step, primary_resource, resource_to_update):
+def test_substitution_array_append_replace(
+    pipeline_step, primary_resource, resource_to_update
+):
 
     # add object 1
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "append"
-    step.properties[0].value['name'] = "Object 1"
+    step.properties[0].value["name"] = "Object 1"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 1
     assert obj["rule_collections"][0]["name"] == "Object 1"
@@ -135,7 +184,7 @@ def test_substitution_array_append_replace(pipeline_step, primary_resource, reso
     # add object 2
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "append"
-    step.properties[0].value['name'] = "Object 2"
+    step.properties[0].value["name"] = "Object 2"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 2
     assert obj["rule_collections"][1]["name"] == "Object 2"
@@ -146,8 +195,8 @@ def test_substitution_array_append_replace(pipeline_step, primary_resource, reso
     # replace object 1
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "replace"
-    step.properties[0].value['name'] = "Object 1"
-    step.properties[0].value['action'] = "Deny Object 1"
+    step.properties[0].value["name"] = "Object 1"
+    step.properties[0].value["action"] = "Deny Object 1"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 2
     assert obj["rule_collections"][0]["action"] == "Deny Object 1"
@@ -158,19 +207,21 @@ def test_substitution_array_append_replace(pipeline_step, primary_resource, reso
     # replace the next one
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "replace"
-    step.properties[0].value['name'] = "Object 2"
-    step.properties[0].value['action'] = "Deny Object 2"
+    step.properties[0].value["name"] = "Object 2"
+    step.properties[0].value["action"] = "Deny Object 2"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 2
     assert obj["rule_collections"][1]["action"] == "Deny Object 2"
 
 
-def test_substitution_array_replace_not_found(pipeline_step, primary_resource, resource_to_update):
+def test_substitution_array_replace_not_found(
+    pipeline_step, primary_resource, resource_to_update
+):
 
     # try to replace an item not there - it should just append
     step = copy.deepcopy(pipeline_step)
     step.properties[0].arraySubstitutionAction = "replace"
-    step.properties[0].value['name'] = "Object 1"
+    step.properties[0].value["name"] = "Object 1"
     obj = substitute_properties(step, primary_resource, resource_to_update)
     assert len(obj["rule_collections"]) == 1
     assert obj["rule_collections"][0]["name"] == "Object 1"


### PR DESCRIPTION
When doing the substitutions in a pipeline step, an issue was found when the value object contained a list of strings - as each string was being treated as a dict.