### PR TITLE
Main build: Increase timeout for shared services test

### DIFF
--- a/e2e_tests/test_shared_services.py
+++ b/e2e_tests/test_shared_services.py
@@ -92,7 +92,7 @@ shared_service_templates_to_create = [
 
 
 @pytest.mark.shared_services
-@pytest.mark.timeout(30 * 60)
+@pytest.mark.timeout(45 * 60)
 @pytest.mark.parametrize("template_name", shared_service_templates_to_create)
 async def test_create_shared_service(template_name, admin_token, verify) -> None:
     # Check that the shared service hasn't already been created


### PR DESCRIPTION
# Resolves issue https://github.com/microsoft/AzureTRE/issues/2313 

## What is being addressed

The last few tests on main failed partially due to test `test_shared_services.py::test_create_shared_service[tre-shared-service-gitea]`  timing out. 
See e.g. https://github.com/microsoft/AzureTRE/actions/runs/2711014023 

Because it now includes an update step as part of pipeline, and because it first _deletes_ gitea shared service (wonder if we still need that logic?), it takes longer than 30 minutes. 