### PR TITLE
Increase timeout for e2e tests in CI

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -777,7 +777,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environmentName }}
     needs: [deploy_shared_services, register_bundles, register_user_resource_bundles, build_additional_images]
-    timeout-minutes: 140
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# Resolves issue

## What is being addressed

A recent e2e test run in main took longer than 2 hours 20 minutes: 
https://github.com/microsoft/AzureTRE/runs/7460985823?check_suite_focus=true

I suggest to increase the timeout to 3 hours for now. 
I"m not a fan of tests taking so long. But I would prefer to first get a test run passing in main before fixing the running time 
