### PR TITLE
Temporarily disable airlock e2e test

### DIFF
--- a/e2e_tests/test_airlock.py
+++ b/e2e_tests/test_airlock.py
@@ -13,7 +13,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.airlock
-@pytest.mark.extended
 @pytest.mark.timeout(1200)
 async def test_airlock_import_flow(admin_token, verify) -> None:
 


### PR DESCRIPTION
## What is being addressed

Temporarily disable airlock e2e test as it fails:
[https://github.com/microsoft/AzureTRE/actions/runs/2739858246](https://github.com/microsoft/AzureTRE/actions/runs/2739858246)

## How is this addressed

- remove extended mark from the test
