### PR TITLE
CI retries bundle build & publish commands

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -410,7 +410,9 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           # Although porter publish will build automatically, our makefile build target includes logic that should run
-          COMMAND: "make bundle-build bundle-publish DIR=${{ matrix.BUNDLE_DIR }}"
+          COMMAND: >-
+            for i in {1..3}; do make bundle-build bundle-publish DIR=${{ matrix.BUNDLE_DIR }}
+            && break || sleep 30; done
           ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
           ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_URI }}
           ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}
@@ -448,7 +450,9 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           # Although porter publish will build automatically, our makefile build target includes logic that should run
-          COMMAND: "make bundle-build bundle-publish DIR=${{ matrix.BUNDLE_DIR }}"
+          COMMAND: >-
+            for i in {1..3}; do make bundle-build bundle-publish DIR=${{ matrix.BUNDLE_DIR }}
+            && break || sleep 30; done
           ACTIONS_ACR_NAME: ${{ secrets.ACTIONS_ACR_NAME }}
           ACTIONS_ACR_URI: ${{ secrets.ACTIONS_ACR_URI }}
           ACTIONS_ACR_PASSWORD: ${{ secrets.ACTIONS_ACR_PASSWORD }}


### PR DESCRIPTION
# Resolves #2365 

## What is being addressed

Sometimes porter build and/or publish will fail due to a temporary (network?) issue while running in the CI.
This is probably not a CI problem but is observed there due to the frequency of actions.

## How is this addressed

- Retry bundle build & publish in the CI actions