### PR TITLE
Remove nexus v1 from e2e

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -433,8 +433,6 @@ jobs:
           - {BUNDLE_TYPE: "shared_service",
              BUNDLE_DIR: "./templates/shared_services/firewall/"}
           - {BUNDLE_TYPE: "shared_service",
-             BUNDLE_DIR: "./templates/shared_services/sonatype-nexus/"}
-          - {BUNDLE_TYPE: "shared_service",
              BUNDLE_DIR: "./templates/shared_services/gitea/"}
     environment: ${{ inputs.environmentName }}
     steps:
@@ -472,8 +470,6 @@ jobs:
         include:
           - {BUNDLE_TYPE: "shared_service",
              BUNDLE_DIR: "./templates/shared_services/firewall"}
-          - {BUNDLE_TYPE: "shared_service",
-             BUNDLE_DIR: "./templates/shared_services/sonatype-nexus"}
           - {BUNDLE_TYPE: "shared_service",
              BUNDLE_DIR: "./templates/shared_services/gitea"}
     environment: ${{ inputs.environmentName }}

--- a/Makefile
+++ b/Makefile
@@ -301,10 +301,6 @@ build-and-deploy-ui:
 prepare-for-e2e:
 	$(call workspace_bundle,base) \
 	&& $(call workspace_service_bundle,guacamole) \
-	&& $(call workspace_service_bundle,azureml) \
-	&& $(call workspace_service_bundle,gitea) \
-	&& $(call workspace_service_bundle,innereye) \
-	&& $(call shared_service_bundle,sonatype-nexus) \
 	&& $(call shared_service_bundle,gitea) \
 	&& $(call user_resource_bundle,guacamole,guacamole-azure-windowsvm) \
 	&& $(call user_resource_bundle,guacamole,guacamole-azure-linuxvm)

--- a/e2e_tests/test_shared_service_templates.py
+++ b/e2e_tests/test_shared_service_templates.py
@@ -10,7 +10,6 @@ from resources import strings
 shared_service_templates = [
     (strings.FIREWALL_SHARED_SERVICE),
     (strings.GITEA_SHARED_SERVICE),
-    (strings.NEXUS_SHARED_SERVICE),
 ]
 
 

--- a/e2e_tests/test_shared_services.py
+++ b/e2e_tests/test_shared_services.py
@@ -87,7 +87,6 @@ async def test_patch_firewall(admin_token, verify):
 
 shared_service_templates_to_create = [
     (strings.GITEA_SHARED_SERVICE),
-    (strings.NEXUS_SHARED_SERVICE),
 ]
 
 


### PR DESCRIPTION
# Resolves #2379 

## What is being addressed

We were testing an old version of nexus despite not using it anymore in VMs

## How is this addressed

- Remove it from E2E