### PR TITLE
Specify json output in az commands

### DIFF
--- a/devops/scripts/control_tre.sh
+++ b/devops/scripts/control_tre.sh
@@ -49,7 +49,7 @@ if [[ "$1" == *"start"* ]]; then
 
   az vmss list --resource-group "${core_rg_name}" --query "[].name" -o tsv |
   while read -r vmss_name; do
-    if [[ "$(az vmss list-instances --resource-group "${core_rg_name}" --name "${vmss_name}" --expand instanceView | \
+    if [[ "$(az vmss list-instances --resource-group "${core_rg_name}" --name "${vmss_name}" --expand instanceView --output json | \
       jq 'select(.[].instanceView.statuses[].code=="PowerState/deallocated") | length')" -gt 0 ]]; then
       echo "Starting VMSS ${vmss_name}"
       az vmss start --resource-group "${core_rg_name}" --name "${vmss_name}" &
@@ -91,7 +91,7 @@ elif [[ "$1" == *"stop"* ]]; then
 
   az vmss list --resource-group "${core_rg_name}" --query "[].name" -o tsv |
   while read -r vmss_name; do
-    if [[ "$(az vmss list-instances --resource-group "${core_rg_name}" --name "${vmss_name}" --expand instanceView | \
+    if [[ "$(az vmss list-instances --resource-group "${core_rg_name}" --name "${vmss_name}" --expand instanceView --output json | \
       jq 'select(.[].instanceView.statuses[].code=="PowerState/running") | length')" -gt 0 ]]; then
       echo "Deallocating VMSS ${vmss_name}"
       az vmss deallocate --resource-group "${core_rg_name}" --name "${vmss_name}" &

--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -100,19 +100,19 @@ tre_id=${core_tre_rg#"rg-"}
 # purge keyvault if possible (makes it possible to reuse the same tre_id later)
 # this has to be done before we delete the resource group since we might not wait for it to complete
 keyvault_name="kv-${tre_id}"
-keyvault=$(az keyvault show --name "${keyvault_name}" --resource-group "${core_tre_rg}" || echo 0)
+keyvault=$(az keyvault show --name "${keyvault_name}" --resource-group "${core_tre_rg}" -o json || echo 0)
 if [ "${keyvault}" != "0" ]; then
-  secrets=$(az keyvault secret list --vault-name "${keyvault_name}" | jq -r '.[].id')
+  secrets=$(az keyvault secret list --vault-name "${keyvault_name}" -o json | jq -r '.[].id')
   for secret_id in ${secrets}; do
     az keyvault secret delete --id "${secret_id}"
   done
 
-  keys=$(az keyvault key list --vault-name "${keyvault_name}" | jq -r '.[].id')
+  keys=$(az keyvault key list --vault-name "${keyvault_name}" -o json | jq -r '.[].id')
   for key_id in ${keys}; do
     az keyvault key delete --id "${key_id}"
   done
 
-  certificates=$(az keyvault certificate list --vault-name "${keyvault_name}" | jq -r '.[].id')
+  certificates=$(az keyvault certificate list --vault-name "${keyvault_name}" -o json | jq -r '.[].id')
   for certificate_id in ${certificates}; do
     az keyvault certificate delete --id "${certificate_id}"
   done
@@ -127,7 +127,7 @@ if [ "${keyvault}" != "0" ]; then
 fi
 
 # Delete the vault if purge protection is not on.
-if [[ $(az keyvault list --resource-group "${core_tre_rg}" --query "[?properties.enablePurgeProtection==``null``] | length (@)") != 0 ]]; then
+if [[ $(az keyvault list --resource-group "${core_tre_rg}" --query "[?properties.enablePurgeProtection==``null``] | length (@)" -o tsv) != 0 ]]; then
   echo "Deleting keyvault: ${keyvault_name}"
   az keyvault delete --name "${keyvault_name}" --resource-group "${core_tre_rg}"
 

--- a/devops/scripts/load_env.sh
+++ b/devops/scripts/load_env.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
 
-if [ ! -f $1 ]; then
-  if [ -z $USE_ENV_VARS_NOT_FILES ]; then
-    echo -e "\e[31m»»» 💥 Unable to find $1 file, please create file and try again!"
+if [ ! -f "$1" ]; then
+  if [ -z "${USE_ENV_VARS_NOT_FILES:-}" ]; then
+    echo -e "\e[31m»»» 💥 Unable to find $1 file, please create file and try again!\e[0m"
     #exit
   fi
 else
-  export $(egrep -v '^#' $1 | xargs)
+  # doesn't work with quotes
+  # shellcheck disable=SC2046
+  export $(grep -v -e '^[[:space:]]*$' -e '^#' "$1" | xargs)
 fi

--- a/devops/scripts/load_env.sh
+++ b/devops/scripts/load_env.sh
@@ -14,3 +14,5 @@ else
   # shellcheck disable=SC2046
   export $(grep -v -e '^[[:space:]]*$' -e '^#' "$1" | xargs)
 fi
+
+set +o nounset

--- a/devops/scripts/load_terraform_env.sh
+++ b/devops/scripts/load_terraform_env.sh
@@ -14,3 +14,5 @@ else
   # shellcheck disable=SC2046
   export $(grep -v -e '^[[:space:]]*$' -e '^#' "$1"  | sed 's/.*=/TF_VAR_\L&/' | xargs)
 fi
+
+set +o nounset

--- a/devops/scripts/load_terraform_env.sh
+++ b/devops/scripts/load_terraform_env.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-set -e
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
 
-if [ ! -f $1 ]; then
-  if [ -z $USE_ENV_VARS_NOT_FILES ]; then
-    echo -e "\e[31m»»» 💥 Unable to find $1 file, please create file and try again!"
+if [ ! -f "$1" ]; then
+  if [ -z "${USE_ENV_VARS_NOT_FILES:-}" ]; then
+    echo -e "\e[31m»»» 💥 Unable to find $1 file, please create file and try again!\e[0m"
     #exit
   fi
 else
-  export $(egrep -v '^#' $1 | sed 's/.*=/TF_VAR_\L&/' | xargs)
+  # doesn't work with quotes
+  # shellcheck disable=SC2046
+  export $(grep -v -e '^[[:space:]]*$' -e '^#' "$1"  | sed 's/.*=/TF_VAR_\L&/' | xargs)
 fi


### PR DESCRIPTION
# Resolves #2412 Resolves #2315

## What is being addressed

Az commands might not work as expected if the user has set a default output other than json.

## How is this addressed

- specify the desired out in control_tre and destroy_env... scripts
- unrelated: fix the output color when an env file isn't found