### PR TITLE
Branch workflow reports status check

### DIFF
--- a/.github/workflows/deploy_tre_branch.yml
+++ b/.github/workflows/deploy_tre_branch.yml
@@ -42,6 +42,7 @@ jobs:
           # Debug output for checking SHA used in checks-action
           echo "git SHA:    $(git rev-parse --abbrev-ref HEAD)"
           echo "git ref:    $(git rev-parse HEAD)"
+          echo "github sha: ${GITHUB_SHA}"
           echo "github ref: ${GITHUB_REF}"
           REFID=$(echo "${GITHUB_REF}" | shasum | cut -c1-8)
           echo "using id of: ${REFID} for GitHub Ref: ${GITHUB_REF}"
@@ -54,6 +55,7 @@ jobs:
     uses: ./.github/workflows/deploy_tre_reusable.yml
     with:
       ciGitRef: ${{ github.ref }}
+      prHeadSha: ${{ github.sha }}
       e2eTestsCustomSelector: ${{ github.event.inputs.e2eTestsCustomSelector }}
       environmentName: ${{ github.event.inputs.environment }}
     secrets:

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -804,6 +804,7 @@ jobs:
           name: "Deploy PR / Run E2E Tests (Smoke)"
           status: "completed"
           conclusion: ${{ env.WORKFLOW_CONCLUSION }}
+          details_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Notify teams channel
         # notify only if failure

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -154,6 +154,7 @@ jobs:
           sha: ${{ inputs.prHeadSha }}
           name: "Deploy PR / Run E2E Tests (Smoke)"
           status: "in_progress"
+          details_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Set up Docker BuildKit
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -146,6 +146,15 @@ jobs:
           # then the default checkout will apply
           ref: ${{ inputs.prRef }}
 
+      - name: Report check status start
+        if: inputs.prHeadSha != ''
+        uses: LouisBrunner/checks-action@v1.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ inputs.prHeadSha }}
+          name: "Deploy PR / Run E2E Tests (Smoke)"
+          status: "in_progress"
+
       - name: Set up Docker BuildKit
         uses: docker/setup-buildx-action@v1
 
@@ -785,7 +794,7 @@ jobs:
       # so the checks aren't automatically associated with the PR
       # If prHeadSha is specified then explicity mark the checks for that SHA
       - name: Report check status
-        if: env.WORKFLOW_CONCLUSION == 'success' && inputs.prHeadSha != ''
+        if: inputs.prHeadSha != ''
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -793,7 +802,7 @@ jobs:
           sha: ${{ inputs.prHeadSha }}
           name: "Deploy PR / Run E2E Tests (Smoke)"
           status: "completed"
-          conclusion: "success"
+          conclusion: ${{ env.WORKFLOW_CONCLUSION }}
 
       - name: Notify teams channel
         # notify only if failure


### PR DESCRIPTION
# Resolves #2122 

## What is being addressed

1. When running the deployment branch workflow, a status check wasn't not being reported and PRs tested like that couldn't have been merged.
2. Looking at a PR, we didn't have an indication that the deployment workflow was running

## How is this addressed

- Branch workflow should pass the "regular" SHA into the reusable workflow. That will in turn report the status check correctly.
- Report status "in progress" when the reusable workflow begins so that the check on the PR will show it.
