### PR TITLE
Replace firewall rule with private endpoint in Airlock

### DIFF
--- a/templates/workspaces/base/terraform/airlock/data.tf
+++ b/templates/workspaces/base/terraform/airlock/data.tf
@@ -23,3 +23,8 @@ data "azurerm_servicebus_topic" "blob_created" {
   resource_group_name = local.core_resource_group_name
   namespace_name      = data.azurerm_servicebus_namespace.airlock_sb.name
 }
+
+data "azurerm_storage_account" "export_approved" {
+  name                = local.export_approved_storage_name
+  resource_group_name = local.core_resource_group_name
+}

--- a/templates/workspaces/base/terraform/airlock/locals.tf
+++ b/templates/workspaces/base/terraform/airlock/locals.tf
@@ -19,6 +19,8 @@ locals {
   export_rejected_storage_name = lower(replace("stalexrej${substr(local.workspace_resource_name_suffix, -8, -1)}", "-", ""))
   # STorage AirLock EXport BLOCKED
   export_blocked_storage_name = lower(replace("stalexblocked${substr(local.workspace_resource_name_suffix, -8, -1)}", "-", ""))
+  # STorage AirLock EXPort APProved
+  export_approved_storage_name = lower(replace("stalexapp${var.tre_id}", "-", ""))
 
   airlock_blob_data_contributor = [
     azurerm_storage_account.sa_import_approved.id,

--- a/templates/workspaces/base/terraform/airlock/storage_accounts.tf
+++ b/templates/workspaces/base/terraform/airlock/storage_accounts.tf
@@ -125,11 +125,6 @@ resource "azurerm_storage_account" "sa_export_inprogress" {
 
 resource "azurerm_storage_account_network_rules" "sa_export_inprogress_rules" {
   storage_account_id = azurerm_storage_account.sa_export_inprogress.id
-
-  # When the Airlock procssor tried to copy data from the export in-progress SA to the Export approved SA, its not using the PE, as the destination is public, hence, allowing this subnet is mandatory
-  # It might be possible to add PE to this storage instead of opening the fw to this subnet: https://github.com/microsoft/AzureTRE/issues/2098
-  virtual_network_subnet_ids = [var.airlock_processor_subnet_id]
-
   default_action = var.enable_local_debugging ? "Allow" : "Deny"
   bypass         = ["AzureServices"]
 }

--- a/templates/workspaces/base/terraform/airlock/storage_accounts.tf
+++ b/templates/workspaces/base/terraform/airlock/storage_accounts.tf
@@ -270,3 +270,25 @@ resource "azurerm_role_assignment" "api_sa_data_contributor" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = data.azurerm_user_assigned_identity.api_id.principal_id
 }
+
+resource "azurerm_private_endpoint" "export_approved_pe" {
+  name                = "pe-sa-export-approved-blob-${var.tre_id}"
+  location            = var.location
+  resource_group_name = var.ws_resource_group_name
+  subnet_id           = var.services_subnet_id
+  tags                = var.tre_workspace_tags
+
+  lifecycle { ignore_changes = [tags] }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group-sa-export-approved"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.blobcore.id]
+  }
+
+  private_service_connection {
+    name                           = "psc-sa-export-approved-${var.short_workspace_id}"
+    private_connection_resource_id = data.azurerm_storage_account.export_approved.id
+    is_manual_connection           = false
+    subresource_names              = ["Blob"]
+  }
+}


### PR DESCRIPTION
Resolves #2098 

## What is being addressed

Replaced the firewall rule that allowed airlock processor to access the `export in progress` storage account with a private endpoint for the `export approved` storage account in the `services` subnet of the workspace.

## How is this addressed

- Removed the firewall rule from the `export in progress` storage account
- Added a private endpoint in services subnet (in the workspace's VNet) for the `export approved` storage account
