### PR TITLE
Fix issue with newline in quoted param

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -75,8 +75,11 @@ fi
 locks=$(az group lock list -g "${core_tre_rg}" --query [].id -o tsv | tr -d \')
 if [ -n "${locks:-}" ]
 then
-  echo "Deleting locks..."
-  az resource lock delete --ids "${locks}"
+  for lock in $locks
+  do
+    echo "Deleting lock ${lock}..."
+    az resource lock delete --ids "${lock}"
+  done
 fi
 
 delete_resource_diagnostic() {


### PR DESCRIPTION
When there are multiple locks, the ids need to be passed as separate parameters, but the quoted string treated as a single, newline separated value.

This currently works in the GitHub cleanup workflow as we only have a single lock because stateful_resources_locked is false (thanks to @tamirkamara for figuring this out!)
