### PR TITLE
Allow longer timeouts for e2e

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -736,7 +736,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environmentName }}
     needs: [deploy_shared_services, register_bundles, register_user_resource_bundles]
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/e2e_tests/resources/resource.py
+++ b/e2e_tests/resources/resource.py
@@ -55,6 +55,7 @@ async def disable_and_delete_resource(endpoint, access_token, verify):
 
         # delete
         response = await client.delete(full_endpoint, headers=auth_headers, timeout=TIMEOUT)
+        LOGGER.info(f'RESPONSE Status code: {response.status_code} Content: {response.content}')
         assert (response.status_code == status.HTTP_200_OK), "The resource couldn't be deleted"
 
         resource_id = response.json()["operation"]["resourceId"]

--- a/e2e_tests/test_shared_services.py
+++ b/e2e_tests/test_shared_services.py
@@ -91,7 +91,7 @@ shared_service_templates_to_create = [
 
 
 @pytest.mark.shared_services
-@pytest.mark.timeout(55 * 60)
+@pytest.mark.timeout(65 * 60)
 @pytest.mark.parametrize("template_name", shared_service_templates_to_create)
 async def test_create_shared_service(template_name, admin_token, verify) -> None:
     # Check that the shared service hasn't already been created

--- a/e2e_tests/test_workspace_services.py
+++ b/e2e_tests/test_workspace_services.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.extended
-@pytest.mark.timeout(3300)
+@pytest.mark.timeout(75 * 60)
 async def test_create_guacamole_service_into_base_workspace(admin_token, verify) -> None:
 
     payload = {
@@ -71,7 +71,7 @@ async def test_create_guacamole_service_into_base_workspace(admin_token, verify)
 
 
 @pytest.mark.extended_aad
-@pytest.mark.timeout(3300)
+@pytest.mark.timeout(75 * 60)
 async def test_create_guacamole_service_into_aad_workspace(admin_token, verify) -> None:
     """This test will create a Guacamole service but will create a workspace and automatically register the AAD Application"""
 


### PR DESCRIPTION
## What is being addressed

Sometimes E2E would fail due to slower run times on azure.

## How is this addressed

- Higher timeouts
- Additional log to make outputs clearer