### PR TITLE
remove shared service prefix for auto deploy

### DIFF
--- a/devops/scripts/deploy_shared_service.sh
+++ b/devops/scripts/deploy_shared_service.sh
@@ -154,7 +154,8 @@ for index in "${!property_names[@]}"; do
   additional_props="$additional_props, \"$name\": \"$value\""
 done
 
-payload="{ \"templateName\": \"""${template_name}""\", \"properties\": { \"display_name\": \"Shared service ""${template_name}""\", \"description\": \"Automatically deployed ""${template_name}""\"${additional_props} } }"
+display_name="${template_name#tre-shared-service-}"
+payload="{ \"templateName\": \"""${template_name}""\", \"properties\": { \"display_name\": \"""${display_name}""\", \"description\": \"Automatically deployed ""${template_name}""\"${additional_props} } }"
 deploy_result=$(curl -i "${curl_settings[@]}" -X "POST" "${tre_url}/api/shared-services" \
                 -H "accept: application/json" \
                 -H "Content-Type: application/json" \


### PR DESCRIPTION
## What is being addressed

The name of shared services installed by the makefile/script can be more friendly. 
Part of #2323.

## How is this addressed

- Shared services installed by scripts don't include "tre-shared-service" prefix so the name would be just `firewall` (for example)
