### PR TITLE
Unrestricted Workspace - Fix missing WORKDIR prior to mirroring.

### DIFF
--- a/templates/workspaces/unrestricted/Dockerfile.tmpl
+++ b/templates/workspaces/unrestricted/Dockerfile.tmpl
@@ -32,6 +32,9 @@ RUN  curl -o azuretre.tar.gz -L "https://github.com/microsoft/AzureTRE/archive/r
 
 COPY . $BUNDLE_DIR
 
+# Mirror plugins to prevent network access at runtime
+# Remove when available from https://github.com/getporter/terraform-mixin/issues/90
+WORKDIR $BUNDLE_DIR/terraform
 RUN terraform init -backend=false \
   && terraform providers mirror /usr/local/share/terraform/plugins
 

--- a/templates/workspaces/unrestricted/porter.yaml
+++ b/templates/workspaces/unrestricted/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-unrestricted
-version: 0.1.7
+version: 0.1.8
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre


### PR DESCRIPTION
## What is being addressed
Fixes issue with build of unrestricted workspace, as working directory is incorrect.