### PR TITLE
Secure Access to Shared Services in workspace ot TREAdmin and Owner

### DIFF
--- a/ui/app/src/components/workspaces/WorkspaceProvider.tsx
+++ b/ui/app/src/components/workspaces/WorkspaceProvider.tsx
@@ -16,6 +16,8 @@ import { SharedService } from '../../models/sharedService';
 import { SharedServices } from '../shared/SharedServices';
 import { SharedServiceItem } from '../shared/SharedServiceItem';
 import { Airlock } from '../shared/airlock/Airlock';
+import { SecuredByRole } from '../shared/SecuredByRole';
+import { RoleName, WorkspaceRoleName } from '../../models/roleNames';
 
 export const WorkspaceProvider: React.FunctionComponent = () => {
   const apiCall = useAuthApiCall();
@@ -126,11 +128,11 @@ export const WorkspaceProvider: React.FunctionComponent = () => {
                         updateWorkspaceService={(ws: WorkspaceService) => updateWorkspaceService(ws)}
                         removeWorkspaceService={(ws: WorkspaceService) => removeWorkspaceService(ws)} />
                     } />
-                    <Route path="shared-services" element={
-                      <SharedServices readonly={true} />
+                   <Route path="shared-services" element={
+                      <SecuredByRole element={<SharedServices />} allowedRoles={[RoleName.TREAdmin,WorkspaceRoleName.WorkspaceOwner]} errorString={"You must be a TRE Admin to access this area"}/>
                     } />
-                    <Route path="shared-services/:sharedServiceId/*" element={
-                      <SharedServiceItem readonly={true} />
+                   <Route path="shared-services/:sharedServiceId/*" element={
+                      <SecuredByRole element={<SharedServiceItem />} allowedRoles={[RoleName.TREAdmin,WorkspaceRoleName.WorkspaceOwner]} errorString={"You must be a TRE Admin to access this area"}/>
                     } />
                     <Route path="requests/*" element={
                       <Airlock/>


### PR DESCRIPTION
# Resolves #2545 

## What is being addressed

Shared services are not shown in main root navigation if not TREAdmin, but still are shown in Workspace level
Update will secure Shared service in workspace scope similar to Root layout

## How is this addressed

- Added <SecuredByRole> wrapper to navigation links, added permission to WorkspaceOwner as they need to connect to Shared Services - external-url type
