### PR TITLE
PRs build mkdocs in strict mode

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --strict --force

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -35,6 +35,8 @@ jobs:
               - 'templates/core/**/*'
             core_version:
               - 'templates/core/version.txt'
+            docs:
+              - 'docs/**/*'
 
       - name: Terraform format check
         if: ${{ steps.filter.outputs.terraform == 'true' }}
@@ -75,3 +77,9 @@ jobs:
           VALIDATE_DOCKERFILE_HADOLINT: true
           VALIDATE_TSX: true
           VALIDATE_TYPESCRIPT_ES: true
+
+      - name: Docs validation
+        if: ${{ steps.filter.outputs.docs == 'true' }}
+        run: |
+          pip install -r docs/requirements.txt
+          mkdocs build --strict


### PR DESCRIPTION
# Resolves #2680 

## What is being addressed

1. Docs are published without **strict** mode which can results in links to missing docs
1. Our docs aren't built as part of the PR validation

## How is this addressed

- When publishing docs, use strict mode
- In PR, when linting, also build docs (if changed) in strict mode to detect problematic links
