### PR TITLE
Disable network policies for private endpoints

### DIFF
--- a/templates/core/terraform/network/network.tf
+++ b/templates/core/terraform/network/network.tf
@@ -27,7 +27,7 @@ resource "azurerm_subnet" "app_gw" {
   virtual_network_name                          = azurerm_virtual_network.core.name
   resource_group_name                           = var.resource_group_name
   address_prefixes                              = [local.app_gw_subnet_address_prefix]
-  private_endpoint_network_policies_enabled     = true
+  private_endpoint_network_policies_enabled     = false
   private_link_service_network_policies_enabled = true
   depends_on                                    = [azurerm_subnet.azure_firewall]
 }
@@ -37,7 +37,7 @@ resource "azurerm_subnet" "web_app" {
   virtual_network_name                          = azurerm_virtual_network.core.name
   resource_group_name                           = var.resource_group_name
   address_prefixes                              = [local.web_app_subnet_address_prefix]
-  private_endpoint_network_policies_enabled     = true
+  private_endpoint_network_policies_enabled     = false
   private_link_service_network_policies_enabled = true
   depends_on                                    = [azurerm_subnet.app_gw]
 
@@ -57,7 +57,7 @@ resource "azurerm_subnet" "shared" {
   resource_group_name  = var.resource_group_name
   address_prefixes     = [local.shared_services_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled = true
+  private_endpoint_network_policies_enabled = false
   depends_on                                = [azurerm_subnet.web_app]
 }
 
@@ -67,7 +67,7 @@ resource "azurerm_subnet" "resource_processor" {
   resource_group_name  = var.resource_group_name
   address_prefixes     = [local.resource_processor_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled = true
+  private_endpoint_network_policies_enabled = false
   depends_on                                = [azurerm_subnet.shared]
 }
 
@@ -77,7 +77,7 @@ resource "azurerm_subnet" "airlock_processor" {
   resource_group_name  = var.resource_group_name
   address_prefixes     = [local.airlock_processor_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled = true
+  private_endpoint_network_policies_enabled = false
   depends_on                                = [azurerm_subnet.resource_processor]
 
   delegation {
@@ -100,7 +100,7 @@ resource "azurerm_subnet" "airlock_notification" {
   resource_group_name  = var.resource_group_name
   address_prefixes     = [local.airlock_notifications_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled = true
+  private_endpoint_network_policies_enabled = false
   depends_on                                = [azurerm_subnet.airlock_processor]
 
   delegation {
@@ -119,7 +119,7 @@ resource "azurerm_subnet" "airlock_storage" {
   resource_group_name  = var.resource_group_name
   address_prefixes     = [local.airlock_storage_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled = true
+  private_endpoint_network_policies_enabled = false
   depends_on                                = [azurerm_subnet.airlock_notification]
 }
 
@@ -129,7 +129,7 @@ resource "azurerm_subnet" "airlock_events" {
   resource_group_name  = var.resource_group_name
   address_prefixes     = [local.airlock_events_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled = true
+  private_endpoint_network_policies_enabled = false
   depends_on                                = [azurerm_subnet.airlock_events]
 
   # Eventgrid CAN'T send messages over private endpoints, hence we need to allow service endpoints to the service bus

--- a/templates/workspaces/base/terraform/network/network.tf
+++ b/templates/workspaces/base/terraform/network/network.tf
@@ -14,7 +14,7 @@ resource "azurerm_subnet" "services" {
   resource_group_name  = var.ws_resource_group_name
   address_prefixes     = [local.services_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled     = true
+  private_endpoint_network_policies_enabled     = false
   private_link_service_network_policies_enabled = true
 
   # Eventgrid CAN'T send messages over private endpoints, hence we need to allow service endpoints to the service bus
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "webapps" {
   resource_group_name  = var.ws_resource_group_name
   address_prefixes     = [local.webapps_subnet_address_prefix]
   # notice that private endpoints do not adhere to NSG rules
-  private_endpoint_network_policies_enabled     = true
+  private_endpoint_network_policies_enabled     = false
   private_link_service_network_policies_enabled = true
 
   delegation {


### PR DESCRIPTION
# Resolves #2667 

## What is being addressed

It seems that in https://github.com/microsoft/AzureTRE/pull/2608, a degradation was introduced: API can no longer connect to Services subnet in Workspaces, thus creation of Airlock export links is broken.

It seems that we do not yet intend enabling network policies for private endpoints, so in this PR I'm disabling all of them. 

I have tested that disabling network policies on Services subnet in a Workspace fixes the problem of creating export Airlock requests. 