### PR TITLE
Remove shared service name prefix

### DIFF
--- a/devops/scripts/deploy_shared_service.sh
+++ b/devops/scripts/deploy_shared_service.sh
@@ -73,11 +73,12 @@ for index in "${!property_names[@]}"; do
 done
 
 echo "Not currently deployed - deploying..."
+display_name="${template_name#tre-shared-service-}"
 if ! deploy_result=$(cat << EOF | tre shared-services new --definition-file -
 {
     "templateName": "${template_name}",
     "properties": {
-        "display_name": "Shared service '${template_name}'",
+        "display_name": "${display_name}",
         "description": "Automatically deployed '${template_name}'"
         ${additional_props}
     }


### PR DESCRIPTION
## What is being addressed

A previous change introduced a prefix for the shared service display_name when deployed via script/cli. This PR fixes that back so that the firewall (for example) shared service will be listed as just "firewall" with nothing extra.
