### PR TITLE
TRE CLI in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -97,3 +97,8 @@ RUN echo "export HISTFILE=$HOME/commandhistory/.bash_history" >> "$HOME/.bashrc"
 # Install github-cli
 COPY ./.devcontainer/scripts/gh.sh /tmp/
 RUN if [ "${INTERACTIVE}" = "true" ]; then /tmp/gh.sh; fi
+
+# Install tre-cli
+COPY ./cli /tmp/cli
+WORKDIR /tmp/cli
+RUN make install-cli

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -101,4 +101,4 @@ RUN if [ "${INTERACTIVE}" = "true" ]; then /tmp/gh.sh; fi
 # Install tre-cli
 COPY ./cli /tmp/cli
 WORKDIR /tmp/cli
-RUN make install-cli
+RUN make install-cli && echo -e "\n# Set up tre completion\nsource <(_TRE_COMPLETE=bash_source tre)" >> ~/.bashrc

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -3,7 +3,3 @@ set -e
 
 # docker socket fixup
 sudo bash ./devops/scripts/set_docker_sock_permission.sh
-
-# install tre CLI
-(cd ./cli/ && make install-cli)  && echo -e "\n# Set up tre completion\nsource <(_TRE_COMPLETE=bash_source tre)" >> ~/.bashrc
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,24 @@
 # Put files here that you don't want copied into your bundle's invocation image
 .gitignore
 Dockerfile.tmpl
+
+.bash_history
+.mypy_cache
+.pytest_cache
+
+__pycache__
+.env
+*.env
+
+docs
+!docs/requirements.txt
+
+cli/build
+cli/dist
+*.egg-info/
+
+.terraform
+tfplan*
+*.log
+
+templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure/target

--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -175,6 +175,4 @@ runs:
           -e WORKSPACE_APP_SERVICE_PLAN_SKU="${{ (inputs.WORKSPACE_APP_SERVICE_PLAN_SKU != ''
             && inputs.WORKSPACE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
           '${{ inputs.CI_CACHE_ACR_NAME }}.azurecr.io/tredev:${{ inputs.DEVCONTAINER_TAG }}' \
-        bash -c "(cd cli/ && make install-cli) && ${{ inputs.COMMAND }}"
-        # Above command installs tre CLI (done via postCreateCommand in VS Code)
-        # If we switch to https://github.com/devcontainers/ci this would no longer be needed
+        bash -c "${{ inputs.COMMAND }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ FEATURES:
 ENHANCEMENTS:
 * Add cran support to nexus, open port 80 for the workspace nsg and update the firewall config to allow let's encrypt CRLs ([#2694](https://github.com/microsoft/AzureTRE/pull/2694))
 * Upgrade Github Actions versions ([#2731](https://github.com/microsoft/AzureTRE/pull/2744))
-* Install TRE CLI inside the devcontainer image (rather than via a post-create step) ([#2757](https://github.com/microsoft/AzureTRE/pull/TBD))
+* Install TRE CLI inside the devcontainer image (rather than via a post-create step) ([#2757](https://github.com/microsoft/AzureTRE/pull/2757))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ FEATURES:
 ENHANCEMENTS:
 * Add cran support to nexus, open port 80 for the workspace nsg and update the firewall config to allow let's encrypt CRLs ([#2694](https://github.com/microsoft/AzureTRE/pull/2694))
 * Upgrade Github Actions versions ([#2731](https://github.com/microsoft/AzureTRE/pull/2744))
-* Install TRE CLI inside the devcontainer image (rather than via a post-create step) ([#TBD](https://github.com/microsoft/AzureTRE/pull/TBD))
+* Install TRE CLI inside the devcontainer image (rather than via a post-create step) ([#2757](https://github.com/microsoft/AzureTRE/pull/TBD))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ FEATURES:
 ENHANCEMENTS:
 * Add cran support to nexus, open port 80 for the workspace nsg and update the firewall config to allow let's encrypt CRLs ([#2694](https://github.com/microsoft/AzureTRE/pull/2694))
 * Upgrade Github Actions versions ([#2731](https://github.com/microsoft/AzureTRE/pull/2744))
+* Install TRE CLI inside the devcontainer image (rather than via a post-create step) ([#TBD](https://github.com/microsoft/AzureTRE/pull/TBD))
 
 BUG FIXES:
 


### PR DESCRIPTION
## What is being addressed

We currently install the TRE CLI on every "create" of the container. In the CI this method creates some noise as every time we execute a container command we also need to install the CLI.

## How is this addressed

- Install the TRE CLI inside the devcontainer image, much like we do for most other tools used.
