### PR TITLE
Automatically validate all resources have tre_id tag via TFLint

### DIFF
--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -30,3 +30,8 @@ rule "terraform_naming_convention" {
 rule "terraform_standard_module_structure" {
   enabled = true
 }
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags = ["tre_id"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ FEATURES:
 * Added filtering and sorting to Airlock UI ([#2511](https://github.com/microsoft/AzureTRE/pull/2730))
 * Added title field to Airlock requests ([#2503](https://github.com/microsoft/AzureTRE/pull/2731))
 * New Create Review VM functionality for Airlock Reviews ([#2738](https://github.com/microsoft/AzureTRE/pull/2759) & [#2737](https://github.com/microsoft/AzureTRE/pull/2740))
-* Adding missing costs resource tags tflint rule [#2774](https://github.com/microsoft/AzureTRE/pull/2774)
+* Automatically validate all resources have tre_id tag via TFLint [#2774](https://github.com/microsoft/AzureTRE/pull/2774)
 
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 * Added filtering and sorting to Airlock UI ([#2511](https://github.com/microsoft/AzureTRE/pull/2730))
 * Added title field to Airlock requests ([#2503](https://github.com/microsoft/AzureTRE/pull/2731))
 * New Create Review VM functionality for Airlock Reviews ([#2738](https://github.com/microsoft/AzureTRE/pull/2759) & [#2737](https://github.com/microsoft/AzureTRE/pull/2740))
+* Adding missing costs resource tags tflint rule [#2774](https://github.com/microsoft/AzureTRE/pull/2774)
 
 ENHANCEMENTS:
 * Add cran support to nexus, open port 80 for the workspace nsg and update the firewall config to allow let's encrypt CRLs ([#2694](https://github.com/microsoft/AzureTRE/pull/2694))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 FEATURES:
 * Display workspace and shared services total costs for admin role in UI [#2738](https://github.com/microsoft/AzureTRE/pull/2772)
+* Automatically validate all resources have tre_id tag via TFLint [#2774](https://github.com/microsoft/AzureTRE/pull/2774)
 
 ENHANCEMENTS:
 
@@ -19,7 +20,7 @@ FEATURES:
 * Added filtering and sorting to Airlock UI ([#2511](https://github.com/microsoft/AzureTRE/pull/2730))
 * Added title field to Airlock requests ([#2503](https://github.com/microsoft/AzureTRE/pull/2731))
 * New Create Review VM functionality for Airlock Reviews ([#2738](https://github.com/microsoft/AzureTRE/pull/2759) & [#2737](https://github.com/microsoft/AzureTRE/pull/2740))
-* Automatically validate all resources have tre_id tag via TFLint [#2774](https://github.com/microsoft/AzureTRE/pull/2774)
+
 
 
 ENHANCEMENTS:

--- a/templates/workspaces/base/terraform/storage.tf
+++ b/templates/workspaces/base/terraform/storage.tf
@@ -4,7 +4,6 @@ resource "azurerm_storage_account" "stg" {
   location                 = azurerm_resource_group.ws.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
-  tags                     = local.tre_workspace_tags
 
   lifecycle { ignore_changes = [tags] }
 }

--- a/templates/workspaces/base/terraform/storage.tf
+++ b/templates/workspaces/base/terraform/storage.tf
@@ -4,6 +4,7 @@ resource "azurerm_storage_account" "stg" {
   location                 = azurerm_resource_group.ws.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
+  tags                     = local.tre_workspace_tags
 
   lifecycle { ignore_changes = [tags] }
 }


### PR DESCRIPTION
# Resolves #2429 

## What is being addressed

Verify that all TF Resources have costs tags in PR

## How is this addressed

- add ```tflint``` ```azurerm_resource_missing_tags``` rule which checks for ```tre_id``` tag on all taggable resources
- a proof that the rule works:
[https://github.com/microsoft/AzureTRE/actions/runs/3307525543/jobs/5459224687](https://github.com/microsoft/AzureTRE/actions/runs/3307525543/jobs/5459224687)
![image](https://user-images.githubusercontent.com/3179107/197399963-79e3b9a4-38dc-4dcd-925b-d0f8f800524a.png)

