### PR TITLE
Address failures in the cli-package workflow

### DIFF
--- a/.github/workflows/cli-package.yml
+++ b/.github/workflows/cli-package.yml
@@ -42,7 +42,7 @@ jobs:
           COMMAND: |
             # Create the python wheel
             cd cli
-            make build-package
+            sudo make build-package
           DEVCONTAINER_TAG: latest
           CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/cli-package.yml
+++ b/.github/workflows/cli-package.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     # environment is used to access the secrets for Azure credentials
     # to sign in to a container registry to re-use a dev container image as a build cache
-    environment: ${{ inputs.environmentName || 'CICD'}}
+    environment: ${{ inputs.environment || 'CICD'}}
 
     steps:
       - name: Checkout (GitHub)

--- a/.github/workflows/cli-package.yml
+++ b/.github/workflows/cli-package.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # environment is used to access the secrets for Azure credentials
+    # to sign in to a container registry to re-use a dev container image as a build cache
+    environment: ${{ inputs.environmentName || 'CICD'}}
 
     steps:
       - name: Checkout (GitHub)
@@ -30,9 +33,9 @@ jobs:
         run: az acr login --name "${{ secrets.ACR_NAME }}"
 
       - name: Build and run dev container task
-        uses: devcontainers/ci@v0.2
+        uses: devcontainers/ci@3dcee0e5dada9275fbd8e4d76ee9de43998be886
         with:
-          imageName: ${{ secrets.ACR_NAME }}.azurecr.io/tredev:latest
+          imageName: ${{ secrets.ACR_NAME }}.azurecr.io/tredev
           runCmd: |
             # Validate installation and showing help output
             cd cli
@@ -41,10 +44,10 @@ jobs:
             tre --help
           push: never
 
-      - name: Build and run dev container task
-        uses: devcontainers/ci@v0.2
+      - name: Create the CLI package
+        uses: devcontainers/ci@3dcee0e5dada9275fbd8e4d76ee9de43998be886
         with:
-          imageName: ${{ secrets.ACR_NAME }}.azurecr.io/tredev:latest
+          imageName: ${{ secrets.ACR_NAME }}.azurecr.io/tredev
           runCmd: |
             # Create the python wheel
             cd cli

--- a/.github/workflows/cli-package.yml
+++ b/.github/workflows/cli-package.yml
@@ -23,37 +23,29 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v2
 
-      - name: Azure Login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: ACR Login
-        id: ci_cache_cr_login
-        run: az acr login --name "${{ secrets.ACR_NAME }}"
-
       - name: Build and run dev container task
-        uses: devcontainers/ci@3dcee0e5dada9275fbd8e4d76ee9de43998be886
+        uses: ./.github/actions/devcontainer_run_command
         with:
-          imageName: ${{ secrets.ACR_NAME }}.azurecr.io/tredev
-          runCmd: |
+          COMMAND: |
             # Validate installation and showing help output
             cd cli
             make pip-install install-cli
             source <(_TRE_COMPLETE=bash_source tre)
             tre --help
-          push: never
+          DEVCONTAINER_TAG: latest
+          CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME}}
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Create the CLI package
-        uses: devcontainers/ci@3dcee0e5dada9275fbd8e4d76ee9de43998be886
+        uses: ./.github/actions/devcontainer_run_command
         with:
-          imageName: ${{ secrets.ACR_NAME }}.azurecr.io/tredev
-          runCmd: |
+          COMMAND: |
             # Create the python wheel
             cd cli
             make build-package
-          push: never
-
+          DEVCONTAINER_TAG: latest
+          CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME}}
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Upload Wheel as artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Resolves cli-package workflow failures

## What is being addressed

Address failures in the cli-package workflow

## How is this addressed

- Add environment to cli-package to enable retrieving secrets
- Convert to devcontainer_run_command as devcontainers/ci runs postCreateCommand which adjusts the docker socket permissions and causes issues
