### PR TITLE
Update auth setup doc with required env vars

### DIFF
--- a/docs/tre-admins/setup-instructions/setup-auth-entities.md
+++ b/docs/tre-admins/setup-instructions/setup-auth-entities.md
@@ -2,6 +2,23 @@
 
 Next, you will set the configuration variables for the specific Azure TRE instance:
 
+1. Open the `/devops/.env.sample` file and then save it without the .sample extension. You should now have a file called `.env` located in the `/devops` folder. The file contains configuration variables for the shared management infrastructure which is used to support the deployment of one or more Azure TRE instances.
+
+1. Provide the values for the following variables:
+
+    | Variable | Description |
+    | -------- | ----------- |
+    | `LOCATION` | The [Azure location (region)](https://azure.microsoft.com/global-infrastructure/geographies/#geographies) for all resources. E.g., `westeurope` |
+    | `MGMT_RESOURCE_GROUP_NAME` | The shared resource group for all management resources, including the storage account. |
+    | `MGMT_STORAGE_ACCOUNT_NAME` | The name of the storage account to hold the Terraform state and other deployment artifacts. |
+    | `ACR_NAME` | A globally unique name for the [Azure Container Registry (ACR)](https://docs.microsoft.com/azure/container-registry/) that will be created to store deployment images. |
+    | `ARM_SUBSCRIPTION_ID` | The Azure subscription ID for all resources. |
+
+    !!! tip
+        To retrieve your Azure subscription ID, use the `az` command line interface available in the development container. In the terminal window in Visual Studio Code, type `az login` followed by `az account show` to see your default subscription. Please refer to `az account -help` for further details on how to change your active subscription.
+
+    The rest of the variables can have their default values.
+
 1. Open the `/templates/core/.env.sample` file and then save it without the .sample extension. You should now have a file called `.env` located in the `/templates/core` folder.
 1. Decide on a name for your `TRE_ID`, which is an alphanumeric (with underscores and hyphens allowed) ID for the Azure TRE instance. The value will be used in various Azure resources and AAD application names. It **needs to be globally unique and less than 12 characters in length**. Use only lowercase letters. Choose wisely!
 1. Once you have decided on which AD Tenant paradigm, then you should be able to set `AAD_TENANT_ID`


### PR DESCRIPTION
## What is being addressed

Fixes #2848 by temporarily adding the required setup for the /devops/.env file to the authentication setup doc