### PR TITLE
Enable workspace upgrade

### DIFF
--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-base
-version: 0.7.5
+version: 0.7.6
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -182,44 +182,43 @@ install:
         - name: sp_id
 
 upgrade:
-  # TODO: https://github.com/microsoft/AzureTRE/issues/2847
-  # - terraform:
-  #     description: "Deploy workspace"
-  #     vars:
-  #       tre_id: "{{ bundle.parameters.tre_id }}"
-  #       tre_resource_id: "{{ bundle.parameters.id }}"
-  #       location: "{{ bundle.parameters.azure_location }}"
-  #       address_spaces: "{{ bundle.parameters.address_spaces }}"
-  #       shared_storage_quota: "{{ bundle.parameters.shared_storage_quota }}"
-  #       enable_local_debugging: "{{ bundle.parameters.enable_local_debugging }}"
-  #       register_aad_application: "{{ bundle.parameters.register_aad_application }}"
-  #       create_aad_groups: "{{ bundle.parameters.create_aad_groups }}"
-  #       auth_client_id: "{{ bundle.credentials.auth_client_id }}"
-  #       auth_client_secret: "{{ bundle.credentials.auth_client_secret }}"
-  #       auth_tenant_id: "{{ bundle.credentials.auth_tenant_id }}"
-  #       workspace_owner_object_id: "{{ bundle.parameters.workspace_owner_object_id }}"
-  #       client_id: "{{ bundle.parameters.client_id }}"
-  #       client_secret: "{{ bundle.parameters.client_secret }}"
-  #       scope_id: "{{ bundle.parameters.scope_id }}"
-  #       sp_id: "{{ bundle.parameters.sp_id }}"
-  #       app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
-  #       app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
-  #       app_role_id_workspace_airlock_manager: "{{ bundle.parameters.app_role_id_workspace_airlock_manager }}"
-  #       aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
-  #       app_service_plan_sku: "{{ bundle.parameters.app_service_plan_sku }}"
-  #       enable_airlock: "{{ bundle.parameters.enable_airlock }}"
-  #     backendConfig:
-  #       resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
-  #       storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
-  #       container_name: "{{ bundle.parameters.tfstate_container_name }}"
-  #       key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.id }}"
-  #     outputs:
-  #       - name: app_role_id_workspace_owner
-  #       - name: app_role_id_workspace_researcher
-  #       - name: app_role_id_workspace_airlock_manager
-  #       - name: client_id
-  #       - name: scope_id
-  #       - name: sp_id
+  - terraform:
+      description: "Deploy workspace"
+      vars:
+        tre_id: "{{ bundle.parameters.tre_id }}"
+        tre_resource_id: "{{ bundle.parameters.id }}"
+        location: "{{ bundle.parameters.azure_location }}"
+        address_spaces: "{{ bundle.parameters.address_spaces }}"
+        shared_storage_quota: "{{ bundle.parameters.shared_storage_quota }}"
+        enable_local_debugging: "{{ bundle.parameters.enable_local_debugging }}"
+        register_aad_application: "{{ bundle.parameters.register_aad_application }}"
+        create_aad_groups: "{{ bundle.parameters.create_aad_groups }}"
+        auth_client_id: "{{ bundle.credentials.auth_client_id }}"
+        auth_client_secret: "{{ bundle.credentials.auth_client_secret }}"
+        auth_tenant_id: "{{ bundle.credentials.auth_tenant_id }}"
+        workspace_owner_object_id: "{{ bundle.parameters.workspace_owner_object_id }}"
+        client_id: "{{ bundle.parameters.client_id }}"
+        client_secret: "{{ bundle.parameters.client_secret }}"
+        scope_id: "{{ bundle.parameters.scope_id }}"
+        sp_id: "{{ bundle.parameters.sp_id }}"
+        app_role_id_workspace_owner: "{{ bundle.parameters.app_role_id_workspace_owner }}"
+        app_role_id_workspace_researcher: "{{ bundle.parameters.app_role_id_workspace_researcher }}"
+        app_role_id_workspace_airlock_manager: "{{ bundle.parameters.app_role_id_workspace_airlock_manager }}"
+        aad_redirect_uris_b64: "{{ bundle.parameters.aad_redirect_uris }}"
+        app_service_plan_sku: "{{ bundle.parameters.app_service_plan_sku }}"
+        enable_airlock: "{{ bundle.parameters.enable_airlock }}"
+      backendConfig:
+        resource_group_name: "{{ bundle.parameters.tfstate_resource_group_name }}"
+        storage_account_name: "{{ bundle.parameters.tfstate_storage_account_name }}"
+        container_name: "{{ bundle.parameters.tfstate_container_name }}"
+        key: "{{ bundle.parameters.tre_id }}-ws-{{ bundle.parameters.id }}"
+      outputs:
+        - name: app_role_id_workspace_owner
+        - name: app_role_id_workspace_researcher
+        - name: app_role_id_workspace_airlock_manager
+        - name: client_id
+        - name: scope_id
+        - name: sp_id
   - az:
       description: "AAD Application Admin Login"
       arguments:
@@ -236,10 +235,7 @@ upgrade:
       flags:
         workspace-api-client-id: "{{ bundle.parameters.client_id }}"
         aad-redirect-uris-b64: "{{ bundle.parameters.aad_redirect_uris }}"
-        # always update with the script since we don't run TF for upgrade
-        # might need to change when https://github.com/microsoft/AzureTRE/issues/2114 is resolved.
-        register-aad-application: "false"
-        # register-aad-application: "{{ bundle.parameters.register_aad_application }}"
+        register-aad-application: "{{ bundle.parameters.register_aad_application }}"
 
 uninstall:
   - terraform:

--- a/templates/workspaces/base/terraform/keyvault.tf
+++ b/templates/workspaces/base/terraform/keyvault.tf
@@ -136,20 +136,17 @@ resource "azurerm_key_vault_secret" "client_id" {
   ]
 }
 
-# TODO: https://github.com/microsoft/AzureTRE/issues/2847
-# data "azurerm_key_vault_secret" "client_secret" {
-#   count        = var.client_secret == local.redacted_senstive_value ? 1 : 0
-#   name         = "workspace-client-secret"
-#   key_vault_id = azurerm_key_vault.kv.id
-# }
+data "azurerm_key_vault_secret" "client_secret" {
+  count        = var.client_secret == local.redacted_senstive_value ? 1 : 0
+  name         = "workspace-client-secret"
+  key_vault_id = azurerm_key_vault.kv.id
+}
 
 # This secret only gets written if Terraform is not responsible for
 # registering the AAD Application
 resource "azurerm_key_vault_secret" "client_secret" {
   name = "workspace-client-secret"
-  # TODO: https://github.com/microsoft/AzureTRE/issues/2847
-  # value        = var.client_secret == local.redacted_senstive_value ? data.azurerm_key_vault_secret.client_secret[0].value : var.client_secret
-  value        = var.client_secret
+  value        = var.client_secret == local.redacted_senstive_value ? data.azurerm_key_vault_secret.client_secret[0].value : var.client_secret
   key_vault_id = azurerm_key_vault.kv.id
   count        = var.register_aad_application ? 0 : 1
   tags         = local.tre_workspace_tags

--- a/templates/workspaces/base/terraform/keyvault.tf
+++ b/templates/workspaces/base/terraform/keyvault.tf
@@ -145,7 +145,7 @@ data "azurerm_key_vault_secret" "client_secret" {
 # This secret only gets written if Terraform is not responsible for
 # registering the AAD Application
 resource "azurerm_key_vault_secret" "client_secret" {
-  name = "workspace-client-secret"
+  name         = "workspace-client-secret"
   value        = var.client_secret == local.redacted_senstive_value ? data.azurerm_key_vault_secret.client_secret[0].value : var.client_secret
   key_vault_id = azurerm_key_vault.kv.id
   count        = var.register_aad_application ? 0 : 1


### PR DESCRIPTION
# Resolves #2847 

## What is being addressed

Workspace upgrade has been disabled due to a bug with the client_secret value. Since that has been resolved we can reenable the upgrade.

## How is this addressed

- Uncomment the terraform step in the bundle upgrade action
- Redirect URLs script gets the parameter of `register_aad_application` which turns it off in the case where terraform handles the AAD application