### PR TITLE
Enabling http2 + requesting client cert

### DIFF
--- a/templates/core/terraform/airlock/airlock_processor.tf
+++ b/templates/core/terraform/airlock/airlock_processor.tf
@@ -31,13 +31,16 @@ resource "azurerm_storage_account" "sa_airlock_processor_func_app" {
 }
 
 resource "azurerm_linux_function_app" "airlock_function_app" {
-  name                      = local.airlock_function_app_name
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = true
-  virtual_network_subnet_id = var.airlock_processor_subnet_id
-  service_plan_id           = azurerm_service_plan.airlock_plan.id
-  storage_account_name      = azurerm_storage_account.sa_airlock_processor_func_app.name
+  name                       = local.airlock_function_app_name
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  https_only                 = true
+  http2_enabled              = true
+  client_certificate_enabled = true
+  client_certificate_mode    = "Required"
+  virtual_network_subnet_id  = var.airlock_processor_subnet_id
+  service_plan_id            = azurerm_service_plan.airlock_plan.id
+  storage_account_name       = azurerm_storage_account.sa_airlock_processor_func_app.name
   # consider moving to a managed identity here
   storage_account_access_key = azurerm_storage_account.sa_airlock_processor_func_app.primary_access_key
   tags                       = var.tre_core_tags

--- a/templates/core/terraform/api-webapp.tf
+++ b/templates/core/terraform/api-webapp.tf
@@ -23,6 +23,9 @@ resource "azurerm_linux_web_app" "api" {
   location                        = azurerm_resource_group.core.location
   service_plan_id                 = azurerm_service_plan.core.id
   https_only                      = true
+  http2_enabled                   = true
+  client_certificate_enabled      = true
+  client_certificate_mode         = "Required"
   key_vault_reference_identity_id = azurerm_user_assigned_identity.id.id
   virtual_network_subnet_id       = module.network.web_app_subnet_id
   tags                            = local.tre_core_tags


### PR DESCRIPTION
## What is being addressed

Enabling HTTP2 + requesting client certificate for the airlock function and api app service

## How is this addressed

- Enabled http2 and requesting client cert as described here:
- https://learn.microsoft.com/en-us/azure/app-service/app-service-web-configure-tls-mutual-auth
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app#client_certificate_enabled
