### PR TITLE
Add bypass for Azure Services in AZMonitor storage for base workspace

### DIFF
--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,6 +1,6 @@
 ---
 name: tre-workspace-base
-version: 0.7.6
+version: 0.7.7
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/base/terraform/azure-monitor/azure-monitor.tf
+++ b/templates/workspaces/base/terraform/azure-monitor/azure-monitor.tf
@@ -22,6 +22,11 @@ resource "azurerm_storage_account" "app_insights" {
   allow_nested_items_to_be_public = false
   tags                            = var.tre_workspace_tags
 
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+  }
+
   lifecycle { ignore_changes = [tags] }
 }
 


### PR DESCRIPTION
# Resolves #2975

## What is being addressed

Azure Monitor storage should include a bypass for Azure Services. This PR does the exact thing done in https://github.com/microsoft/AzureTRE/pull/2976 but for the workspace level.
