### PR TITLE
Lint TRE cost tags

### DIFF
--- a/.github/linters/.tflint_shared_services.hcl
+++ b/.github/linters/.tflint_shared_services.hcl
@@ -1,0 +1,19 @@
+# This is used for TRE tags validation only.
+
+config {
+  module = true
+  force = false
+}
+
+plugin "azurerm" {
+    enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = false
+}
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags = ["tre_id", "tre_shared_service_id"]
+}

--- a/.github/linters/.tflint_user_resources.hcl
+++ b/.github/linters/.tflint_user_resources.hcl
@@ -1,0 +1,19 @@
+# This is used for TRE tags validation only.
+
+config {
+  module = true
+  force = false
+}
+
+plugin "azurerm" {
+    enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = false
+}
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags = ["tre_id", "tre_workspace_id", "tre_workspace_service_id", "tre_user_resource_id"]
+}

--- a/.github/linters/.tflint_workspace_services.hcl
+++ b/.github/linters/.tflint_workspace_services.hcl
@@ -1,0 +1,19 @@
+# This is used for TRE tags validation only.
+
+config {
+  module = true
+  force = false
+}
+
+plugin "azurerm" {
+    enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = false
+}
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags = ["tre_id", "tre_workspace_id", "tre_workspace_service_id"]
+}

--- a/.github/linters/.tflint_workspaces.hcl
+++ b/.github/linters/.tflint_workspaces.hcl
@@ -1,0 +1,19 @@
+# This is used for TRE tags validation only.
+
+config {
+  module = true
+  force = false
+}
+
+plugin "azurerm" {
+    enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = false
+}
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags = ["tre_id", "tre_workspace_id"]
+}

--- a/.github/workflows/build_validation_develop.yml
+++ b/.github/workflows/build_validation_develop.yml
@@ -40,6 +40,15 @@ jobs:
             docs:
               - 'docs/**/*'
 
+            terraform_workspaces:
+              - templates/workspaces/**/terraform/**/*.tf
+
+            terraform_shared_services:
+              - templates/shared_services/**/terraform/**/*.tf
+
+            terraform_workspace_services:
+              - templates/workspace_services/**/terraform/**/*.tf
+
       - name: Terraform format check
         if: ${{ steps.filter.outputs.terraform == 'true' }}
         run: terraform fmt -check -recursive
@@ -62,7 +71,7 @@ jobs:
         # the slim image is 2GB smaller and we don't use the extra stuff
         # Moved this after the Terraform checks above due something similar to this issue:
         # https://github.com/github/super-linter/issues/2433
-        uses: github/super-linter/slim@v4.9.7
+        uses: github/super-linter/slim@v4.10.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
@@ -85,3 +94,48 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
           mkdocs build --strict
+
+      - name: Workspace Tags
+        if: ${{ steps.filter.outputs.terraform_workspaces == 'true' }}
+        uses: github/super-linter/slim@v4.10.0
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_TERRAFORM_TFLINT: true
+          TERRAFORM_TFLINT_CONFIG_FILE: .tflint_workspaces.hcl
+          LINTER_REGEX_INCLUDE: './templates/workspaces/.*'
+
+      - name: Workspace Services Tags
+        if: ${{ steps.filter.outputs.terraform_workspace_services == 'true' }}
+        uses: github/super-linter/slim@v4.10.0
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_TERRAFORM_TFLINT: true
+          TERRAFORM_TFLINT_CONFIG_FILE: .tflint_workspace_services.hcl
+          LINTER_REGEX_INCLUDE: './templates/workspaces/.*'
+          FILTER_REGEX_EXCLUDE: '.*user_resource.*'
+
+      - name: User Resources Tags
+        if: ${{ steps.filter.outputs.terraform_workspace_services == 'true' }}
+        uses: github/super-linter/slim@v4.10.0
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_TERRAFORM_TFLINT: true
+          TERRAFORM_TFLINT_CONFIG_FILE: .tflint_user_resources.hcl
+          LINTER_REGEX_INCLUDE: './templates/workspace_services/.*/user_resources/.*'
+
+      - name: Shared Services Tags
+        if: ${{ steps.filter.outputs.terraform_shared_services == 'true' }}
+        uses: github/super-linter/slim@v4.10.0
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_TERRAFORM_TFLINT: true
+          TERRAFORM_TFLINT_CONFIG_FILE: .tflint_shared_services.hcl
+          LINTER_REGEX_INCLUDE: './templates/shared_services/.*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ ENHANCEMENTS:
 * Added the option to disable Swagger ([#2981](https://github.com/microsoft/AzureTRE/pull/2981))
 * Serverless CosmosDB for new deployments to reduce cost ([#3029](https://github.com/microsoft/AzureTRE/pull/3029))
 * Upgrade Guacamole dependencies ([#3053](https://github.com/microsoft/AzureTRE/pull/3053))
+* Lint TRE cost tags per entity type (workspace, shared service, etc.) ([#3061](https://github.com/microsoft/AzureTRE/pull/3061))
 
 
 BUG FIXES:

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ terraform-destroy:
 lint:
 	$(call target_title, "Linting")
 	@terraform fmt -check -recursive -diff
-	@echo "You might not see much on the screen for a few minutes..."
 	@# LOG_LEVEL=NOTICE reduces noise but it might also seem like the process is stuck - it's not...
 	@docker run --name superlinter --pull=always --rm \
 		-e RUN_LOCAL=true \
@@ -169,7 +168,7 @@ lint:
     -e VALIDATE_TYPESCRIPT_ES=true \
 		-e FILTER_REGEX_INCLUDE=${LINTER_REGEX_INCLUDE} \
 		-v $${LOCAL_WORKSPACE_FOLDER}:/tmp/lint \
-		github/super-linter:slim-v4.9.7
+		github/super-linter:slim-v4.10.0
 
 lint-docs:
 	LINTER_REGEX_INCLUDE='./docs/.*\|./mkdocs.yml' $(MAKE) lint

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 0.6.0
+version: 0.6.1
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
@@ -134,6 +134,7 @@ resource "azurerm_key_vault_secret" "linuxvm_password" {
   name         = local.vm_password_secret_name
   value        = "${random_string.username.result}\n${random_password.password.result}"
   key_vault_id = data.azurerm_key_vault.ws.id
+  tags         = local.tre_user_resources_tags
 }
 
 data "azurerm_storage_account" "stg" {

--- a/templates/workspace_services/mysql/porter.yaml
+++ b/templates/workspace_services/mysql/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-service-mysql
-version: 0.3.0
+version: 0.3.1
 description: "A MySQL workspace service"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/mysql/terraform/mysql.tf
+++ b/templates/workspace_services/mysql/terraform/mysql.tf
@@ -61,4 +61,5 @@ resource "azurerm_key_vault_secret" "db_password" {
   name         = "${azurerm_mysql_server.mysql.name}-administrator-password"
   value        = random_password.password.result
   key_vault_id = data.azurerm_key_vault.ws.id
+  tags         = local.workspace_service_tags
 }


### PR DESCRIPTION
## What is being addressed

We have been checking that each TRE resource has the tre_id tag as that is the common one between all entities (like workspace, workspace service, etc.).
Ideally we should lint each TRE level for its respective tag requirements.

## How is this addressed

- Upgrade SuperLint to 4.10 to include a new TFLint version which is required for complex tags like we do (with a `local` definition)
- Add TFLint definition files for each level that describe the required tags
- Add CI steps to run SuperLinter with the TFLint definitions when needed
- A couple of fix-ups on missing tags