### PR TITLE
Add retry when registering bundles in CI

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -339,6 +339,8 @@ jobs:
              BUNDLE_DIR: "./templates/workspace_services/gitea"}
           - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "./templates/workspace_services/mlflow"}
+          - {BUNDLE_TYPE: "workspace_service",
+             BUNDLE_DIR: "./templates/workspace_services/mysql"}
           - {BUNDLE_TYPE: "user_resource",
              BUNDLE_DIR: "./templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm"}
           - {BUNDLE_TYPE: "user_resource",
@@ -425,7 +427,9 @@ jobs:
       - name: Register bundle
         uses: ./.github/actions/devcontainer_run_command
         with:
-          COMMAND: "make bundle-register DIR=${{ matrix.BUNDLE_DIR }}"
+          COMMAND: >-
+            for i in {1..3}; do make bundle-register DIR=${{ matrix.BUNDLE_DIR }}
+            && ec=0 && break || ec=\$? && sleep 10; done; (exit \$ec)
           DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
@@ -461,6 +465,8 @@ jobs:
              BUNDLE_DIR: "./templates/workspace_services/gitea"}
           - {BUNDLE_TYPE: "workspace_service",
              BUNDLE_DIR: "./templates/workspace_services/mlflow"}
+          - {BUNDLE_TYPE: "workspace_service",
+             BUNDLE_DIR: "./templates/workspace_services/mysql"}
 
     environment: ${{ inputs.environmentName }}
     steps:
@@ -474,7 +480,9 @@ jobs:
       - name: Register bundle
         uses: ./.github/actions/devcontainer_run_command
         with:
-          COMMAND: "make bundle-register DIR=${{ matrix.BUNDLE_DIR }}"
+          COMMAND: >-
+            for i in {1..3}; do make bundle-register DIR=${{ matrix.BUNDLE_DIR }}
+            && ec=0 && break || ec=\$? && sleep 10; done; (exit \$ec)
           DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
@@ -520,7 +528,9 @@ jobs:
       - name: Register bundle
         uses: ./.github/actions/devcontainer_run_command
         with:
-          COMMAND: "make bundle-register DIR=${{ matrix.BUNDLE_DIR }}"
+          COMMAND: >-
+            for i in {1..3}; do make bundle-register DIR=${{ matrix.BUNDLE_DIR }}
+            && ec=0 && break || ec=\$? && sleep 10; done; (exit \$ec)
           DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
## What is being addressed

Porter has inconsistent JIT build issues which causes commands like `porter explain` to fail when we parse the results (in `make bundle-check-params`).

## How is this addressed

- While porter are working on the issue, add a retry when registering bundles in the CI (like we do when building bundles due to porter CDN/networking issues)