### PR TITLE
Move Github secrets to variables

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -160,8 +160,8 @@ runs:
           -e ENABLE_SWAGGER="${{ inputs.ENABLE_SWAGGER }}" \
           -e SWAGGER_UI_CLIENT_ID="${{ inputs.SWAGGER_UI_CLIENT_ID }}" \
           -e TF_VAR_swagger_ui_client_id="${{ inputs.SWAGGER_UI_CLIENT_ID }}" \
-          -e TF_VAR_core_address_space="${{ inputs.core_address_space }}" \
-          -e TF_VAR_tre_address_space="${{ inputs.tre_address_space }}" \
+          -e TF_VAR_core_address_space="${{ (inputs.CORE_ADDRESS_SPACE != '' && inputs.CORE_ADDRESS_SPACE) || '10.0.0.0/22' }}" \
+          -e TF_VAR_tre_address_space="${{ (inputs.TRE_ADDRESS_SPACE != '' && inputs.TRE_ADDRESS_SPACE) || '10.0.0.0/16'  }}" \
           -e API_CLIENT_ID="${{ inputs.API_CLIENT_ID }}" \
           -e AAD_TENANT_ID="${{ inputs.AAD_TENANT_ID }}" \
           -e TRE_ID="${{ inputs.TRE_ID }}" \

--- a/.github/workflows/deploy_tre_branch.yml
+++ b/.github/workflows/deploy_tre_branch.yml
@@ -58,17 +58,15 @@ jobs:
       prHeadSha: ${{ github.sha }}
       e2eTestsCustomSelector: ${{ github.event.inputs.e2eTestsCustomSelector }}
       environmentName: ${{ github.event.inputs.environment }}
+      DEVCONTAINER_TAG: ${{ needs.prepare-not-main.outputs.refid }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ format('tre{0}', needs.prepare-not-main.outputs.refid) }}
-      DEVCONTAINER_TAG: ${{ needs.prepare-not-main.outputs.refid }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
       API_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET }}
       APPLICATION_ADMIN_CLIENT_ID: ${{ secrets.APPLICATION_ADMIN_CLIENT_ID }}
       APPLICATION_ADMIN_CLIENT_SECRET: ${{ secrets.APPLICATION_ADMIN_CLIENT_SECRET }}
-      CORE_ADDRESS_SPACE: ${{ secrets.CORE_ADDRESS_SPACE }}
-      LOCATION: ${{ secrets.LOCATION }}
       MGMT_RESOURCE_GROUP_NAME: ${{ format('rg-tre{0}-mgmt', needs.prepare-not-main.outputs.refid) }}
       MS_TEAMS_WEBHOOK_URI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
       MGMT_STORAGE_ACCOUNT_NAME: ${{ format('tre{0}mgmt', needs.prepare-not-main.outputs.refid) }}
@@ -78,12 +76,5 @@ jobs:
       TEST_WORKSPACE_APP_SECRET: ${{ secrets.TEST_WORKSPACE_APP_SECRET }}
       TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
       TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-      TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
-      TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
-      ENABLE_SWAGGER: ${{ secrets.ENABLE_SWAGGER }}
       TRE_ID: ${{ format('tre{0}', needs.prepare-not-main.outputs.refid) }}
       CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME }}
-      TF_LOG: ${{ secrets.TF_LOG }}
-      CORE_APP_SERVICE_PLAN_SKU: ${{ secrets.CORE_APP_SERVICE_PLAN_SKU }}
-      WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ secrets.WORKSPACE_APP_SERVICE_PLAN_SKU }}
-      RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE: ${{ secrets.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE }}

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -27,14 +27,15 @@ on:  # yamllint disable-line rule:truthy
         description: The name of the Github Action's environment this will deploy into
         type: string
         required: true
+      DEVCONTAINER_TAG:
+        description: ""
+        type: string
+        required: true
     secrets:
       AAD_TENANT_ID:
         description: ""
         required: true
       ACR_NAME:
-        description: ""
-        required: true
-      DEVCONTAINER_TAG:
         description: ""
         required: true
       API_CLIENT_ID:
@@ -47,12 +48,6 @@ on:  # yamllint disable-line rule:truthy
         description: ""
         required: true
       APPLICATION_ADMIN_CLIENT_SECRET:
-        description: ""
-        required: true
-      CORE_ADDRESS_SPACE:
-        description: ""
-        required: true
-      LOCATION:
         description: ""
         required: true
       MGMT_RESOURCE_GROUP_NAME:
@@ -82,36 +77,15 @@ on:  # yamllint disable-line rule:truthy
       TEST_ACCOUNT_CLIENT_SECRET:
         description: ""
         required: true
-      TERRAFORM_STATE_CONTAINER_NAME:
-        description: ""
-        required: false
-      TRE_ADDRESS_SPACE:
-        description: ""
-        required: true
-      ENABLE_SWAGGER:
-        description: ""
-        required: false
       TRE_ID:
         description: ""
         required: true
       CI_CACHE_ACR_NAME:
         description: ""
         required: false
-      TF_LOG:
-        description: ""
-        required: false
       AZURE_CREDENTIALS:
         description: ""
         required: true
-      CORE_APP_SERVICE_PLAN_SKU:
-        description: ""
-        required: false
-      WORKSPACE_APP_SERVICE_PLAN_SKU:
-        description: ""
-        required: false
-      RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE:
-        description: "Inputs"
-        required: false
 
 # This will prevent multiple runs of this entire workflow.
 # We should NOT cancel in progress runs as that can destabilize the environment.
@@ -122,6 +96,8 @@ jobs:
     name: Deploy Management
     runs-on: ubuntu-latest
     environment: ${{ inputs.environmentName }}
+    outputs:
+      MS_TEAMS_SECRET_DEFINED: ${{ steps.check_required_values.outputs.MS_TEAMS_SECRET_DEFINED }}
     steps:
       - name: Show inputs
         run: |
@@ -132,7 +108,8 @@ jobs:
           echo "ciGitRef    : ${{ inputs.ciGitRef }}"
           echo "environment : ${{ inputs.environmentName }}"
 
-      - name: Check required secrets
+      - name: Check required values
+        id: check_required_values
         # since this is a resuable workflow, required=true secrets will always have a value but it can be empty.
         run: |
           if [ "${{ secrets.AAD_TENANT_ID }}" == '' ]; then
@@ -140,9 +117,6 @@ jobs:
           fi
           if [ "${{ secrets.ACR_NAME }}" == '' ]; then
             echo "Missing secret: ACR_NAME" && exit 1
-          fi
-          if [ "${{ secrets.DEVCONTAINER_TAG }}" == '' ]; then
-            echo "Missing secret: DEVCONTAINER_TAG" && exit 1
           fi
           if [ "${{ secrets.API_CLIENT_ID }}" == '' ]; then
             echo "Missing secret: API_CLIENT_ID" && exit 1
@@ -155,12 +129,6 @@ jobs:
           fi
           if [ "${{ secrets.APPLICATION_ADMIN_CLIENT_SECRET }}" == '' ]; then
             echo "Missing secret: APPLICATION_ADMIN_CLIENT_SECRET" && exit 1
-          fi
-          if [ "${{ secrets.CORE_ADDRESS_SPACE }}" == '' ]; then
-            echo "Missing secret: CORE_ADDRESS_SPACE" && exit 1
-          fi
-          if [ "${{ secrets.LOCATION }}" == '' ]; then
-            echo "Missing secret: LOCATION" && exit 1
           fi
           if [ "${{ secrets.MGMT_RESOURCE_GROUP_NAME }}" == '' ]; then
             echo "Missing secret: MGMT_RESOURCE_GROUP_NAME" && exit 1
@@ -186,15 +154,25 @@ jobs:
           if [ "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}" == '' ]; then
             echo "Missing secret: TEST_ACCOUNT_CLIENT_SECRET" && exit 1
           fi
-          if [ "${{ secrets.TRE_ADDRESS_SPACE }}" == '' ]; then
-            echo "Missing secret: TRE_ADDRESS_SPACE" && exit 1
-          fi
           if [ "${{ secrets.TRE_ID }}" == '' ]; then
             echo "Missing secret: TRE_ID" && exit 1
           fi
           if [ "${{ secrets.AZURE_CREDENTIALS }}" == '' ]; then
             echo "Missing secret: AZURE_CREDENTIALS" && exit 1
           fi
+
+          if [ "${{ inputs.DEVCONTAINER_TAG }}" == '' ]; then
+            echo "Missing input: DEVCONTAINER_TAG" && exit 1
+          fi
+
+          if [ "${{ secrets.LOCATION }}" == '' ]; then
+            echo "Missing variable: LOCATION" && exit 1
+          fi
+
+          if [ "${{ secrets.MS_TEAMS_WEBHOOK_URI }}" == '' ]; then
+            echo "MS_TEAMS_SECRET_DEFINED=false" >> $GITHUB_OUTPUT;
+          else
+            echo "MS_TEAMS_SECRET_DEFINED=false" >> $GITHUB_OUTPUT;
 
       - name: Report check status start
         if: inputs.prHeadSha != ''
@@ -241,29 +219,29 @@ jobs:
 
           docker_cache=()
           if [ "${{ steps.ci_cache_cr_login.outcome }}" = "success" ]; then
-            docker_cache+=(--cache-from "$CI_CACHE_ACR_URI/tredev:${{ secrets.DEVCONTAINER_TAG }}")
+            docker_cache+=(--cache-from "$CI_CACHE_ACR_URI/tredev:${{ inputs.DEVCONTAINER_TAG }}")
             docker_cache+=(--cache-from "$CI_CACHE_ACR_URI/tredev:latest")
           fi
 
           docker build . "${docker_cache[@]}" \
-            -t "tredev:${{ secrets.DEVCONTAINER_TAG }}" -f ".devcontainer/Dockerfile" \
+            -t "tredev:${{ inputs.DEVCONTAINER_TAG }}" -f ".devcontainer/Dockerfile" \
             --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg USER_UID="${USER_UID}" --build-arg USER_GID="${USER_GID}"
 
-          docker image tag tredev:${{ secrets.DEVCONTAINER_TAG }} \
-            $CI_CACHE_ACR_URI/tredev:${{ secrets.DEVCONTAINER_TAG }}
+          docker image tag tredev:${{ inputs.DEVCONTAINER_TAG }} \
+            $CI_CACHE_ACR_URI/tredev:${{ inputs.DEVCONTAINER_TAG }}
 
       - name: Deploy management
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make bootstrap mgmt-deploy"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
-          TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
-          MGMT_RESOURCE_GROUP_NAME: "${{ secrets.MGMT_RESOURCE_GROUP_NAME }}"
+          TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
+          MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
 
       - name: ACR Login
@@ -278,7 +256,7 @@ jobs:
           (exit \$ec)
 
       - name: Push cached devcontainer
-        run: docker image push ${{ env.CI_CACHE_ACR_URI }}/tredev:${{ secrets.DEVCONTAINER_TAG }}
+        run: docker image push ${{ env.CI_CACHE_ACR_URI }}/tredev:${{ inputs.DEVCONTAINER_TAG }}
 
   build_core_images:
     # used to build images used by core infrastructure
@@ -304,7 +282,7 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make ${{ matrix.target }}"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
@@ -327,10 +305,10 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make tre-start"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          TRE_ID: "${{ secrets.TRE_ID }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
 
   deploy_tre:
     name: Deploy TRE
@@ -350,37 +328,37 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "TF_VAR_ci_git_ref=${{ inputs.ciGitRef }} TF_LOG=${{ secrets.TF_LOG }} make deploy-core"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
           AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
-          TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
+          TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
           MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
-          CORE_ADDRESS_SPACE: ${{ secrets.CORE_ADDRESS_SPACE }}
-          TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
-          ENABLE_SWAGGER: ${{ secrets.ENABLE_SWAGGER }}
+          CORE_ADDRESS_SPACE: ${{ vars.CORE_ADDRESS_SPACE }}
+          TRE_ADDRESS_SPACE: ${{ vars.TRE_ADDRESS_SPACE }}
+          ENABLE_SWAGGER: ${{ vars.ENABLE_SWAGGER }}
           SWAGGER_UI_CLIENT_ID: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
           API_CLIENT_SECRET: "${{ secrets.API_CLIENT_SECRET }}"
           APPLICATION_ADMIN_CLIENT_ID: "${{ secrets.APPLICATION_ADMIN_CLIENT_ID }}"
           APPLICATION_ADMIN_CLIENT_SECRET: "${{ secrets.APPLICATION_ADMIN_CLIENT_SECRET }}"
-          STATEFUL_RESOURCES_LOCKED: "${{ github.ref == 'refs/heads/main' && inputs.prRef == '' && true || false }}"
-          CORE_APP_SERVICE_PLAN_SKU: ${{ secrets.CORE_APP_SERVICE_PLAN_SKU }}
-          RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE: ${{ secrets.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE }}
+          STATEFUL_RESOURCES_LOCKED: ${{ github.ref == 'refs/heads/main' && inputs.prRef == '' && true || false }}
+          CORE_APP_SERVICE_PLAN_SKU: ${{ vars.CORE_APP_SERVICE_PLAN_SKU }}
+          RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE: ${{ vars.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE }}
 
       - name: API Healthcheck
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make api-healthcheck"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
 
   publish_bundles:
     name: Publish Bundles
@@ -430,7 +408,7 @@ jobs:
           COMMAND: >-
             for i in {1..3}; do make bundle-build bundle-publish DIR=${{ matrix.BUNDLE_DIR }}
             && ec=0 && break || ec=\$? && sleep 30; done; (exit \$ec)
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           ACR_NAME: ${{ secrets.ACR_NAME }}
@@ -473,7 +451,7 @@ jobs:
           COMMAND: >-
             for i in {1..3}; do make bundle-build bundle-publish DIR=${{ matrix.BUNDLE_DIR }}
             && ec=0 && break || ec=\$? && sleep 30; done; (exit \$ec)
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           ACR_NAME: ${{ secrets.ACR_NAME }}
@@ -514,7 +492,7 @@ jobs:
           COMMAND: >-
             for i in {1..3}; do make bundle-register DIR=${{ matrix.BUNDLE_DIR }}
             && ec=0 && break || ec=\$? && sleep 10; done; (exit \$ec)
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
@@ -523,8 +501,8 @@ jobs:
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: "${{ secrets.LOCATION }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
 
   register_bundles:
@@ -567,7 +545,7 @@ jobs:
           COMMAND: >-
             for i in {1..3}; do make bundle-register DIR=${{ matrix.BUNDLE_DIR }}
             && ec=0 && break || ec=\$? && sleep 10; done; (exit \$ec)
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
@@ -576,8 +554,8 @@ jobs:
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: "${{ secrets.LOCATION }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
 
   register_user_resource_bundles:
@@ -615,7 +593,7 @@ jobs:
           COMMAND: >-
             for i in {1..3}; do make bundle-register DIR=${{ matrix.BUNDLE_DIR }}
             && ec=0 && break || ec=\$? && sleep 10; done; (exit \$ec)
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           ACR_NAME: ${{ secrets.ACR_NAME }}
@@ -624,8 +602,8 @@ jobs:
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: "${{ secrets.LOCATION }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
           WORKSPACE_SERVICE_NAME: ${{ matrix.WORKSPACE_SERVICE_NAME }}
 
@@ -647,7 +625,7 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make deploy-shared-service DIR=./templates/shared_services/firewall/ BUNDLE_TYPE=shared_service"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
@@ -655,14 +633,14 @@ jobs:
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: "${{ secrets.LOCATION }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
 
       - name: State Store Migrations
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make db-migrate"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
@@ -670,9 +648,9 @@ jobs:
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
-          TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
+          TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
           MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
 
@@ -693,14 +671,14 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make build-and-deploy-ui"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
           API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
           AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
-          LOCATION: ${{ secrets.LOCATION }}
-          TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
+          TRE_ID: ${{ secrets.TRE_ID }}
+          LOCATION: ${{ vars.LOCATION }}
+          TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
           MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
           SWAGGER_UI_CLIENT_ID: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
@@ -724,10 +702,10 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make test-e2e-smoke"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          LOCATION: "${{ secrets.LOCATION }}"
+          LOCATION: ${{ vars.LOCATION }}
           API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
           AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
@@ -735,9 +713,9 @@ jobs:
           TEST_WORKSPACE_APP_SECRET: "${{ secrets.TEST_WORKSPACE_APP_SECRET }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
           IS_API_SECURED: false
-          WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ secrets.WORKSPACE_APP_SERVICE_PLAN_SKU }}
+          WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ vars.WORKSPACE_APP_SERVICE_PLAN_SKU }}
 
       - name: Upload Test Results
         if: always()
@@ -766,10 +744,10 @@ jobs:
         uses: ./.github/actions/devcontainer_run_command
         with:
           COMMAND: "make test-e2e-custom SELECTOR='${{ inputs.e2eTestsCustomSelector }}'"
-          DEVCONTAINER_TAG: ${{ secrets.DEVCONTAINER_TAG }}
+          DEVCONTAINER_TAG: ${{ inputs.DEVCONTAINER_TAG }}
           CI_CACHE_ACR_NAME: ${{ secrets.CI_CACHE_ACR_NAME}}
           AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-          LOCATION: "${{ secrets.LOCATION }}"
+          LOCATION: ${{ vars.LOCATION }}
           API_CLIENT_ID: "${{ secrets.API_CLIENT_ID }}"
           AAD_TENANT_ID: "${{ secrets.AAD_TENANT_ID }}"
           TEST_APP_ID: "${{ secrets.TEST_APP_ID }}"
@@ -777,9 +755,9 @@ jobs:
           TEST_WORKSPACE_APP_SECRET: "${{ secrets.TEST_WORKSPACE_APP_SECRET }}"
           TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-          TRE_ID: "${{ secrets.TRE_ID }}"
+          TRE_ID: ${{ secrets.TRE_ID }}
           IS_API_SECURED: false
-          WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ secrets.WORKSPACE_APP_SERVICE_PLAN_SKU }}
+          WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ vars.WORKSPACE_APP_SERVICE_PLAN_SKU }}
 
       - name: Upload Test Results
         if: always()
@@ -790,7 +768,7 @@ jobs:
 
   summary:
     name: Summary
-    needs: [e2e_tests_smoke, e2e_tests_custom]
+    needs: [e2e_tests_smoke, e2e_tests_custom, deploy_management]
     runs-on: ubuntu-latest
     if: always()
     environment: ${{ inputs.environmentName }}
@@ -817,6 +795,7 @@ jobs:
           MS_TEAMS_WEBHOOK_URI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
         # notify only if failure
         if: |
+          needs.deploy_management.outputs.MS_TEAMS_SECRET_DEFINED == 'true'
           env.WORKFLOW_CONCLUSION == 'failure' &&
           env.MS_TEAMS_WEBHOOK_URI != '' &&
           (github.ref == 'refs/heads/main' && inputs.prRef == '')

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -150,17 +150,15 @@ jobs:
         (needs.pr_comment.outputs.command == 'run-tests-shared-services' && 'shared_services') ||
         (needs.pr_comment.outputs.command == 'run-tests' && '') }}
       environmentName: CICD
+      DEVCONTAINER_TAG: ${{ needs.pr_comment.outputs.prRefId }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}
-      DEVCONTAINER_TAG: ${{ needs.pr_comment.outputs.prRefId }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS}}
       API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
       API_CLIENT_SECRET: ${{ secrets.API_CLIENT_SECRET }}
       APPLICATION_ADMIN_CLIENT_ID: ${{ secrets.APPLICATION_ADMIN_CLIENT_ID }}
       APPLICATION_ADMIN_CLIENT_SECRET: ${{ secrets.APPLICATION_ADMIN_CLIENT_SECRET }}
-      CORE_ADDRESS_SPACE: ${{ secrets.CORE_ADDRESS_SPACE }}
-      LOCATION: ${{ secrets.LOCATION }}
       MGMT_RESOURCE_GROUP_NAME: ${{ format('rg-tre{0}-mgmt', needs.pr_comment.outputs.prRefId) }}
       MS_TEAMS_WEBHOOK_URI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
       MGMT_STORAGE_ACCOUNT_NAME: ${{ format('tre{0}mgmt', needs.pr_comment.outputs.prRefId) }}
@@ -170,9 +168,5 @@ jobs:
       TEST_WORKSPACE_APP_SECRET: "${{ secrets.TEST_WORKSPACE_APP_SECRET }}"
       TEST_ACCOUNT_CLIENT_ID: "${{ secrets.TEST_ACCOUNT_CLIENT_ID }}"
       TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
-      TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
-      TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
-      ENABLE_SWAGGER: ${{ secrets.ENABLE_SWAGGER }}
       TRE_ID: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}
       CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME }}
-      TF_LOG: ${{ secrets.TF_LOG }}

--- a/docs/tre-admins/setup-instructions/cicd-pre-deployment-steps.md
+++ b/docs/tre-admins/setup-instructions/cicd-pre-deployment-steps.md
@@ -58,28 +58,37 @@ Before you can run the `deploy_tre.yml` workflow there are some one-time configu
 
 ### Configure Core Secrets
 
-Configure the following secrets in your github environment -
+Configure the following secrets in your github environment:
 
 | <div style="width: 230px">Secret name</div> | Description |
 | ----------- | ----------- |
 | `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: Alphanumeric, underscores, and hyphens. |
-| `LOCATION` | The Azure location (region) for all resources. E.g. `westeurope` |
 | `MGMT_RESOURCE_GROUP_NAME` | The name of the shared resource group for all Azure TRE core resources. |
 | `MGMT_STORAGE_ACCOUNT_NAME` | The name of the storage account to hold the Terraform state and other deployment artifacts. E.g. `mystorageaccount`. |
 | `ACR_NAME` | A globally unique name for the Azure Container Registry (ACR) that will be created to store deployment images. |
-| `CORE_ADDRESS_SPACE` |  The address space for the Azure TRE core virtual network. E.g. `10.1.0.0/22`. Recommended `/22` or larger.  |
-| `TRE_ADDRESS_SPACE` | The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). E.g. `10.0.0.0/12`|
+
+
+### Configure Core Variables
+
+Configure the following **variables** in your github environment:
+
+| <div style="width: 230px">Variable name</div> | Description |
+| ----------- | ----------- |
+| `LOCATION` | The Azure location (region) for all resources. E.g. `westeurope` |
 | `TERRAFORM_STATE_CONTAINER_NAME` | Optional. The name of the blob container to hold the Terraform state. Default value is `tfstate`. |
+| `CORE_ADDRESS_SPACE` | Optional. The address space for the Azure TRE core virtual network. Default value is `10.0.0.0/22`. |
+| `TRE_ADDRESS_SPACE` | Optional. The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). Default value is `10.0.0.0/16`|
 | `CORE_APP_SERVICE_PLAN_SKU` | Optional. The SKU used for AppService plan for core infrastructure. Default value is `P1v2`. |
 | `WORKSPACE_APP_SERVICE_PLAN_SKU` | Optional. The SKU used for AppService plan used in E2E tests. Default value is `P1v2`. |
 | `RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE` | Optional. The number of processes to instantiate when the Resource Processor starts. Equates to the number of parallel deployment operations possible in your TRE. Defaults to `5`. |
 | `ENABLE_SWAGGER` | Optional. Determines whether the Swagger interface for the API will be available. Default value is `false`. |
 
+
 ### Configure Authentication Secrets
 
 In a previous [Setup Auth configuration](./setup-auth-entities.md) step authentication configuration was added in `config.yaml` file. Go to this file and add those env vars to your github environment:
 
-  | Variable | Description |
+  | Secret Name | Description |
   | -------- | ----------- |
   | `AAD_TENANT_ID` | Tenant id against which auth is performed. |
   | `APPLICATION_ADMIN_CLIENT_ID`| This client will administer AAD Applications for TRE |

--- a/docs/tre-admins/setup-instructions/workflows.md
+++ b/docs/tre-admins/setup-instructions/workflows.md
@@ -117,21 +117,33 @@ The `deploy_tre.yml` workflow sends a notification to a Microsoft Teams channel 
   | ----------- | ----------- |
   | `MS_TEAMS_WEBHOOK_URI` | URI for the Teams channel webhook |
 
-### Configure repository secrets
+### Configure repository/environment secrets
 
-Configure additional repository secrets used in the deployment workflow
+Configure additional secrets used in the deployment workflow:
 
 | <div style="width: 230px">Secret name</div> | Description |
 | ----------- | ----------- |
+| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: Alphanumeric, underscores, and hyphens. |
 | `MGMT_RESOURCE_GROUP_NAME` | The name of the shared resource group for all Azure TRE core resources. |
 | `MGMT_STORAGE_ACCOUNT_NAME` | The name of the storage account to hold the Terraform state and other deployment artifacts. E.g. `mystorageaccount`. |
 | `ACR_NAME` | A globally unique name for the Azure Container Registry (ACR) that will be created to store deployment images. |
-| `CORE_ADDRESS_SPACE` |  The address space for the Azure TRE core virtual network. E.g. `10.1.0.0/22`. Recommended `/22` or larger.  |
-| `TRE_ADDRESS_SPACE` | The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). E.g. `10.0.0.0/12`|
+
+
+### Configure repository/environment variables
+
+Configure variables used in the deployment workflow:
+
+| <div style="width: 230px">Variable name</div> | Description |
+| ----------- | ----------- |
+| `LOCATION` | The Azure location (region) for all resources. E.g. `westeurope` |
 | `TERRAFORM_STATE_CONTAINER_NAME` | Optional. The name of the blob container to hold the Terraform state. Default value is `tfstate`. |
+| `CORE_ADDRESS_SPACE` | Optional. The address space for the Azure TRE core virtual network. Default value is `10.0.0.0/22`. |
+| `TRE_ADDRESS_SPACE` | Optional. The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). Default value is `10.0.0.0/16`|
 | `CORE_APP_SERVICE_PLAN_SKU` | Optional. The SKU used for AppService plan for core infrastructure. Default value is `P1v2`. |
 | `WORKSPACE_APP_SERVICE_PLAN_SKU` | Optional. The SKU used for AppService plan used in E2E tests. Default value is `P1v2`. |
+| `RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE` | Optional. The number of processes to instantiate when the Resource Processor starts. Equates to the number of parallel deployment operations possible in your TRE. Defaults to `5`. |
 | `ENABLE_SWAGGER` | Optional. Determines whether the Swagger interface for the API will be available. Default value is `false`. |
+
 
 ### Deploy the TRE using the workflow
 


### PR DESCRIPTION
Resolves #3070 

## What is being addressed

We store non-secret values in Github Secrets but that can create issues since these values are redacted from logs (try to put a value of 1 and see what happens), and can't be viewed on the website to understand the current configuration.

## How is this addressed

- Move certain values to github variables (new feature)
- Define a default for address spaces as that is usually enough
- Run MS Teams messages only if secret has value (useful for those who don't want to use it)
- Update documentation