### PR TITLE
Docs for TRE version upgrade

### DIFF
--- a/docs/tre-admins/upgrading-tre.md
+++ b/docs/tre-admins/upgrading-tre.md
@@ -5,33 +5,19 @@ This document will cover how AzureTRE is referenced and how to upgrade its versi
 ## Introduction
 
 AzureTRE referenced as an external folder in [AzureTRE deployment repository](https://github.com/microsoft/AzureTRE-Deployment) (which is used as a template for your project in the quick start guide). A specific version of AzureTRE is downloaded as part of devcontainer setup.
- A symlink is then created making it available to reference in the directory itself (it is available only for reference, any changes to it are gitignored)
+
+A symlink is then created making it available to reference in the directory itself (it is available only for reference, any changes to it are gitignored).
 
 ## How to upgrade AzureTRE version
 
-Select AzureTRE version:
-1. In AzureTRE go to releases:
-    ![Go to AzureTRE releases](../assets/using-tre/select_release.png)
-1. Choose a release version
+> Please check the release note before upgrading.
 
-To upgrade AzureTRE version inside [AzureTRE deployment repository](https://github.com/microsoft/AzureTRE-Deployment):
-1. Go to devcontainer.json file
-1. Update the OSS_VERSION param to the desired version.
+To upgrade AzureTRE version inside [AzureTRE deployment repository](https://github.com/microsoft/AzureTRE-Deployment), you need to git pull the latest version.
 
-    ![Upgrade TRE Version](../../assets/using-tre/upgrade_tre_version.png)
-
-
-
-## How to Contribute to our Documentation
-
-If you have any comments or suggestions about our documentation then you can visit our GitHub project and either raise a new issue, or comment on one of the existing ones.
-
-You can find our existing documentation issues on GitHub by clicking on the link below:
-
-[Existing Documentation Issues](https://github.com/microsoft/AzureTRE/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation)
-
-Or, you can raise a new issue by clicking on this link:
-
-[Report an Issue or Make a Suggestion](https://github.com/microsoft/AzureTRE/issues/new/choose)
-
-**Thank you for your patience and support!**
+Use the following git command in your `AzureTRE deployment` folder:
+```
+git remote add upstream https://github.com/microsoft/AzureTRE-Deployment
+git pull upstream main --allow-unrelated-histories
+```
+This will pull the latest version of AzureTRE.
+Now rebuild your container.

--- a/docs/tre-admins/upgrading-tre.md
+++ b/docs/tre-admins/upgrading-tre.md
@@ -14,7 +14,7 @@ A symlink is then created making it available to reference in the directory itse
 
 To upgrade AzureTRE version inside [AzureTRE deployment repository](https://github.com/microsoft/AzureTRE-Deployment), you need to git pull the latest version.
 
-Use the following git command in your `AzureTRE deployment` folder:
+Use the following git command in your own repo that originated from the `AzureTRE-Deployment` template:
 ```sh
 git remote add upstream https://github.com/microsoft/AzureTRE-Deployment
 git pull upstream main --allow-unrelated-histories

--- a/docs/tre-admins/upgrading-tre.md
+++ b/docs/tre-admins/upgrading-tre.md
@@ -15,7 +15,7 @@ A symlink is then created making it available to reference in the directory itse
 To upgrade AzureTRE version inside [AzureTRE deployment repository](https://github.com/microsoft/AzureTRE-Deployment), you need to git pull the latest version.
 
 Use the following git command in your `AzureTRE deployment` folder:
-```
+```sh
 git remote add upstream https://github.com/microsoft/AzureTRE-Deployment
 git pull upstream main --allow-unrelated-histories
 ```


### PR DESCRIPTION
# Resolves #2760 

## Docs change regarding version change

Since the introduction of versions in TRE 0.8.0
The docs now reflect the way to upgrade the TRE Deployment by running the git pull command.


