### PR TITLE
Add E2E test for swagger

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -172,7 +172,7 @@ jobs:
       TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
       TERRAFORM_STATE_CONTAINER_NAME: ${{ secrets.TERRAFORM_STATE_CONTAINER_NAME }}
       TRE_ADDRESS_SPACE: ${{ secrets.TRE_ADDRESS_SPACE }}
-      ENABLE_SWAGGER: ${{ secrets.ENABLE_SWAGGER }}
+      ENABLE_SWAGGER: true
       TRE_ID: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}
       CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME }}
       TF_LOG: ${{ secrets.TF_LOG }}

--- a/e2e_tests/resources/strings.py
+++ b/e2e_tests/resources/strings.py
@@ -1,6 +1,7 @@
 PONG = "pong"
 
 API_HEALTH = "/api/health"
+API_SWAGGER_ROOT = "/api/docs"
 API_WORKSPACE_TEMPLATES = "/api/workspace-templates"
 API_WORKSPACES = "/api/workspaces"
 API_WORKSPACE_SERVICE_TEMPLATES = "/api/workspace-service-templates"

--- a/e2e_tests/test_provisioned_health_api.py
+++ b/e2e_tests/test_provisioned_health_api.py
@@ -19,3 +19,11 @@ async def test_health() -> None:
             {"service": "Service Bus", "status": "OK", "message": ""},
             {"service": "Resource Processor", "status": "OK", "message": ""},
         ]
+
+
+@pytest.mark.smoke
+async def test_swagger_root() -> None:
+    async with AsyncClient(verify=False) as client:
+        url = f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_SWAGGER_ROOT}"
+        response = await client.get(url)
+        assert response.status_code == 200

--- a/e2e_tests/test_workspace_services.py
+++ b/e2e_tests/test_workspace_services.py
@@ -4,6 +4,7 @@ import config
 from helpers import check_aad_auth_redirect
 from resources.resource import disable_and_delete_resource, post_resource
 from resources import strings
+from httpx import AsyncClient
 
 pytestmark = pytest.mark.asyncio
 
@@ -21,6 +22,13 @@ workspace_services = [
 @pytest.mark.timeout(75 * 60)
 async def test_create_guacamole_service_into_base_workspace(verify, setup_test_workspace) -> None:
     workspace_path, workspace_id, workspace_owner_token = setup_test_workspace
+
+    # Check that the workspace level swagger is functioning.
+    # This isn't particulary related to the guacamole tests but there's no point in creating a seperate workspace just for this test.
+    url = f'/api{workspace_path}/docs'
+    async with AsyncClient(verify=verify) as client:
+        response = await client.get(url)
+        assert response.status_code == 200
 
     service_payload = {
         "templateName": strings.GUACAMOLE_SERVICE,


### PR DESCRIPTION
Resolves #1880

## What is being addressed

Add tests that check that swagger (/docs) is functioning on root and workspace level.