### PR TITLE
Pin platform in docker images

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,8 @@
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
 ARG VARIANT="3.8"
-FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-bullseye
+ARG TARGETPLATFORM="linux/amd64"
+FROM --platform="${TARGETPLATFORM}" mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-bullseye
 
 # This will be set to true when running in VSCode
 ARG INTERACTIVE="false"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
 ARG VARIANT="3.8"
-FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-bullseye
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-bullseye
 
 # This will be set to true when running in VSCode
 ARG INTERACTIVE="false"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
     }
   },
   "runArgs": [
+    "--platform=linux/amd64",
     "--network",
     "host"
   ],
@@ -27,7 +28,8 @@
   ],
   "remoteUser": "vscode",
   "containerEnv": {
-    "DOCKER_BUILDKIT": "1"
+    "DOCKER_BUILDKIT": "1",
+    "DOCKER_DEFAULT_PLATFORM": "amd64"
   },
   "remoteEnv": {
     // this is used for SuperLinter

--- a/airlock_processor/Dockerfile
+++ b/airlock_processor/Dockerfile
@@ -1,6 +1,6 @@
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-appservice
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8 as base
+FROM --platform=linux/amd64 mcr.microsoft.com/azure-functions/python:3.0-python3.8 as base
 COPY requirements.txt /
 RUN pip install --no-cache-dir -r /requirements.txt
 

--- a/api_app/Dockerfile
+++ b/api_app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye as base
+FROM --platform=linux/amd64 python:3.8-slim-bullseye as base
 COPY requirements.txt /.
 RUN pip3 install --no-cache-dir -r requirements.txt
 

--- a/resource_processor/vmss_porter/Dockerfile
+++ b/resource_processor/vmss_porter/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.8-slim-bullseye
+FROM --platform=linux/amd64 python:3.8-slim-bullseye
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/templates/shared_services/gitea/docker/Dockerfile
+++ b/templates/shared_services/gitea/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG GITEA_TAG=1.15
 ARG CERTIFICATE_URL=https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem
 
-FROM gitea/gitea:${GITEA_TAG}
+FROM --platform=linux/amd64 gitea/gitea:${GITEA_TAG}
 # need to pass args to stage
 ARG CERTIFICATE_URL
 RUN wget -nv -O /usr/local/share/ca-certificates/mysql.crt.pem ${CERTIFICATE_URL} && update-ca-certificates

--- a/templates/workspace_services/gitea/docker/Dockerfile
+++ b/templates/workspace_services/gitea/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG GITEA_TAG=1.17.3
 ARG CERTIFICATE_URL=https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem
 
-FROM gitea/gitea:${GITEA_TAG}
+FROM --platform=linux/amd64 gitea/gitea:${GITEA_TAG}
 # need to pass args to stage
 ARG CERTIFICATE_URL
 RUN wget -q -O /usr/local/share/ca-certificates/mysql.crt.pem ${CERTIFICATE_URL} && update-ca-certificates

--- a/templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile
+++ b/templates/workspace_services/guacamole/guacamole-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-jdk-11 AS client_build
+FROM --platform=linux/amd64 maven:3-jdk-11 AS client_build
 
 COPY ./guacamole-auth-azure/pom.xml /pom.xml
 COPY ./guacamole-auth-azure/src /src

--- a/templates/workspace_services/mlflow/mlflow-server/docker/Dockerfile
+++ b/templates/workspace_services/mlflow/mlflow-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-bullseye
+FROM --platform=linux/amd64 python:3.8-bullseye
 
 # Install MLflow Python Packages
 RUN pip install --no-cache-dir psycopg2==2.9.5 mlflow==2.0.1 azure-storage-blob==12.14.1


### PR DESCRIPTION
# Resolves #2969 

## What is being addressed

When updating the devcontainer in the deployment repo (for the v0.8.0 release) I found it wouldn't build on my arm based mac. This seemed to be due – in the first instance – to the pinned [docker-cli version](https://github.com/microsoft/AzureTRE/blob/5ab90df8554e95dc54075c7e1283d85fa47df5c2/.devcontainer/Dockerfile#L41). This PR therefore pins the platform in all the Dockerfiles to amd64, as that seems to be the default for dev and the RP for the time being?


## How is this addressed

- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
- Update documentation
- Update CHANGELOG.md if needed
- Increment template version if needed, for guidelines see [Authoring templates - versioning](https://microsoft.github.io/AzureTRE/tre-workspace-authors/authoring-workspace-templates/#versioning)
