### PR TITLE
Consolidate http status assertion in E2Es

### DIFF
--- a/e2e_tests/test_shared_service_templates.py
+++ b/e2e_tests/test_shared_service_templates.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 from starlette import status
 
 import config
-from helpers import get_auth_header, get_template
+from helpers import assert_status, get_auth_header, get_template
 from resources import strings
 from helpers import get_admin_token
 
@@ -34,4 +34,4 @@ async def test_get_shared_service_templates(template_name, verify) -> None:
 async def test_get_shared_service_template(template_name, verify) -> None:
     admin_token = await get_admin_token(verify)
     async with get_template(template_name, strings.API_SHARED_SERVICE_TEMPLATES, admin_token, verify) as response:
-        assert (response.status_code == status.HTTP_200_OK), f"GET Request for {template_name} failed"
+        assert_status(response, [status.HTTP_200_OK], f"Failed to GET template: {template_name}")

--- a/e2e_tests/test_workspace_service_templates.py
+++ b/e2e_tests/test_workspace_service_templates.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 from starlette import status
 
 import config
-from helpers import get_auth_header, get_template
+from helpers import assert_status, get_auth_header, get_template
 from resources import strings
 from helpers import get_admin_token
 
@@ -35,6 +35,7 @@ async def test_get_workspace_service_template(template_name, verify) -> None:
     admin_token = await get_admin_token(verify)
     async with get_template(template_name, strings.API_WORKSPACE_SERVICE_TEMPLATES, admin_token, verify) as response:
         assert (response.status_code == status.HTTP_200_OK), f"GET Request for {template_name} failed"
+        assert_status(response, [status.HTTP_200_OK], f"Failed to GET {template_name}")
 
 
 @pytest.mark.smoke
@@ -58,4 +59,4 @@ async def test_create_workspace_service_templates(verify) -> None:
         admin_token = await get_admin_token(verify)
         response = await client.post(f"https://{config.TRE_ID}.{config.RESOURCE_LOCATION}.cloudapp.azure.com{strings.API_WORKSPACE_SERVICE_TEMPLATES}", headers=get_auth_header(admin_token), json=payload)
 
-        assert (response.status_code == status.HTTP_201_CREATED or response.status_code == status.HTTP_409_CONFLICT), "The workspace service template creation service returned unexpected response."
+        assert_status(response, [status.HTTP_201_CREATED, status.HTTP_409_CONFLICT], "Failed to create workspace service template")

--- a/e2e_tests/test_workspace_templates.py
+++ b/e2e_tests/test_workspace_templates.py
@@ -33,4 +33,4 @@ async def test_get_workspace_templates(template_name, verify) -> None:
 async def test_get_workspace_template(template_name, verify) -> None:
     admin_token = await get_admin_token(verify)
     async with get_template(template_name, strings.API_WORKSPACE_TEMPLATES, admin_token, verify) as response:
-        assert_status(response, [status.HTTP_200_OK], f"Failed to create template: {template_name}")
+        assert_status(response, [status.HTTP_200_OK], f"Failed to GET template: {template_name}")

--- a/e2e_tests/test_workspace_templates.py
+++ b/e2e_tests/test_workspace_templates.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 from starlette import status
 
 import config
-from helpers import get_auth_header, get_template
+from helpers import assert_status, get_auth_header, get_template
 from resources import strings
 from helpers import get_admin_token
 
@@ -33,4 +33,4 @@ async def test_get_workspace_templates(template_name, verify) -> None:
 async def test_get_workspace_template(template_name, verify) -> None:
     admin_token = await get_admin_token(verify)
     async with get_template(template_name, strings.API_WORKSPACE_TEMPLATES, admin_token, verify) as response:
-        assert (response.status_code == status.HTTP_200_OK), f"GET Request for {template_name} creation failed"
+        assert_status(response, [status.HTTP_200_OK], f"Failed to create template: {template_name}")


### PR DESCRIPTION
## What is being addressed

On some of the E2E tests an assertion has been made over the http status code without logging the message that came with it. This made it hard to understand the exact error.

## How is this addressed

- Build a single method to handle all http status checks that will also print out the text in case of an error.