### PR TITLE
Workspace azmonitor depends on airlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
       One way to accomplish this is with the Swagger endpoint (/api/docs).
       ![Force-update a service](./docs/assets/firewall-policy-migrate1.png)
 
-      If this endpoint is not on in your deployment - include `enable_swagger` in your `config.yaml` (see the sample file), or temporarly via the API resource on azure (named `api-YOUR_TRE-ID`) -> Configuration -> `ENABLE_SWAGGER` item.
+      If this endpoint is not working in your deployment - include `enable_swagger` in your `config.yaml` (see the sample file), or temporarly activate it via the API resource on azure (named `api-YOUR_TRE-ID`) -> Configuration -> `ENABLE_SWAGGER` item.
       ![Update API setting](./docs/assets/firewall-policy-migrate2.png)
   
   
-  :warning: Any custom rules you have added manually will be **lost** and you'll need to add it back after the upgrade has been completed.
+  :warning: Any custom rules you have added manually will be **lost** and you'll need to add them back after the upgrade has been completed.
 
 FEATURES:
 * Add Azure Databricks as workspace service [#1857](https://github.com/microsoft/AzureTRE/pull/1857)
@@ -41,6 +41,7 @@ BUG FIXES:
 * Reauth CLI if TRE endpoint has changed [#3137](https://github.com/microsoft/AzureTRE/pull/3137)
 * Added Migration for Airlock requests that were created prior to version 0.5.0 ([#3152](https://github.com/microsoft/AzureTRE/pull/3152))
 * Temporarly use the remote bundle for `check-params` target [#3149](https://github.com/microsoft/AzureTRE/pull/3149)
+* Workspace module dependency to resolve _AnotherOperationInProgress_ errors [#TBD](https://github.com/microsoft/AzureTRE/pull/TBD)
 
 COMPONENTS:
 

--- a/e2e_tests/requirements.txt
+++ b/e2e_tests/requirements.txt
@@ -5,3 +5,4 @@ pytest-asyncio==0.20.3
 starlette
 pytest-timeout==2.1.0
 pytest-xdist==3.0.2
+backoff==2.2.1

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 1.0.1
+version: 1.0.2
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -80,5 +80,6 @@ module "azure_monitor" {
   enable_local_debugging                   = var.enable_local_debugging
   depends_on = [
     module.network,
+    module.airlock
   ]
 }


### PR DESCRIPTION
## What is being addressed

Sometimes a conflict will occur when a workspace is being deleted. The source of this is networking changed done inside the airlock and az-monitor modules of the bundle.
This should be handled by terraform without manual intervention, but since it seem to not happen like that...

## How is this addressed

- Add a dependency so that az-monitor and airlock will not run together
- [small] add a retry in the e2e to handle transient api connection errors
