### PR TITLE
Remove auth private endpoint from databricks workspace service

### DIFF
--- a/templates/workspace_services/databricks/porter.yaml
+++ b/templates/workspace_services/databricks/porter.yaml
@@ -56,11 +56,6 @@ outputs:
     applyTo:
       - install
       - upgrade
-  - name: internal_connection_uri
-    type: string
-    applyTo:
-      - install
-      - upgrade
   - name: databricks_storage_account_name
     type: string
     applyTo:
@@ -123,7 +118,6 @@ install:
       outputs:
         - name: databricks_workspace_name
         - name: connection_uri
-        - name: internal_connection_uri
         - name: databricks_storage_account_name
         - name: dbfs_blob_storage_domain
         - name: metastore_addresses
@@ -150,7 +144,6 @@ upgrade:
       outputs:
         - name: databricks_workspace_name
         - name: connection_uri
-        - name: internal_connection_uri
         - name: databricks_storage_account_name
         - name: dbfs_blob_storage_domain
         - name: metastore_addresses

--- a/templates/workspace_services/databricks/porter.yaml
+++ b/templates/workspace_services/databricks/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-databricks
-version: 0.1.71
+version: 0.1.72
 description: "An Azure TRE service for Azure Databricks."
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/databricks/terraform/main.tf
+++ b/templates/workspace_services/databricks/terraform/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_databricks_workspace" "databricks" {
   managed_resource_group_name           = local.managed_resource_group_name
   infrastructure_encryption_enabled     = true
   public_network_access_enabled         = var.is_exposed_externally
-  network_security_group_rules_required = var.is_exposed_externally ? "AllRules" : "NoAzureDatabricksRules"
+  network_security_group_rules_required = "NoAzureDatabricksRules"
   tags                                  = local.tre_workspace_service_tags
 
   lifecycle { ignore_changes = [tags] }

--- a/templates/workspace_services/databricks/terraform/network.tf
+++ b/templates/workspace_services/databricks/terraform/network.tf
@@ -187,27 +187,27 @@ resource "azurerm_private_endpoint" "databricks_control_plane_private_endpoint" 
   }
 }
 
-resource "azurerm_private_endpoint" "databricks_auth_private_endpoint" {
-  name                = "pe-adb-auth-${local.service_resource_name_suffix}"
-  location            = data.azurerm_resource_group.ws.location
-  resource_group_name = data.azurerm_resource_group.ws.name
-  subnet_id           = data.azurerm_subnet.services.id
-  tags                = local.tre_workspace_service_tags
+# resource "azurerm_private_endpoint" "databricks_auth_private_endpoint" {
+#   name                = "pe-adb-auth-${local.service_resource_name_suffix}"
+#   location            = data.azurerm_resource_group.ws.location
+#   resource_group_name = data.azurerm_resource_group.ws.name
+#   subnet_id           = data.azurerm_subnet.services.id
+#   tags                = local.tre_workspace_service_tags
 
-  lifecycle { ignore_changes = [tags] }
+#   lifecycle { ignore_changes = [tags] }
 
-  private_service_connection {
-    name                           = "private-service-connection-databricks-auth-${local.service_resource_name_suffix}"
-    private_connection_resource_id = azurerm_databricks_workspace.databricks.id
-    is_manual_connection           = false
-    subresource_names              = ["browser_authentication"]
-  }
+#   private_service_connection {
+#     name                           = "private-service-connection-databricks-auth-${local.service_resource_name_suffix}"
+#     private_connection_resource_id = azurerm_databricks_workspace.databricks.id
+#     is_manual_connection           = false
+#     subresource_names              = ["browser_authentication"]
+#   }
 
-  private_dns_zone_group {
-    name                 = "private-dns-zone-group-databricks-auth-${local.service_resource_name_suffix}"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.databricks.id]
-  }
-}
+#   private_dns_zone_group {
+#     name                 = "private-dns-zone-group-databricks-auth-${local.service_resource_name_suffix}"
+#     private_dns_zone_ids = [data.azurerm_private_dns_zone.databricks.id]
+#   }
+# }
 
 resource "azurerm_private_endpoint" "databricks_filesystem_private_endpoint" {
   name                = "pe-adb-fs-${local.service_resource_name_suffix}"

--- a/templates/workspace_services/databricks/terraform/network.tf
+++ b/templates/workspace_services/databricks/terraform/network.tf
@@ -187,28 +187,6 @@ resource "azurerm_private_endpoint" "databricks_control_plane_private_endpoint" 
   }
 }
 
-# resource "azurerm_private_endpoint" "databricks_auth_private_endpoint" {
-#   name                = "pe-adb-auth-${local.service_resource_name_suffix}"
-#   location            = data.azurerm_resource_group.ws.location
-#   resource_group_name = data.azurerm_resource_group.ws.name
-#   subnet_id           = data.azurerm_subnet.services.id
-#   tags                = local.tre_workspace_service_tags
-
-#   lifecycle { ignore_changes = [tags] }
-
-#   private_service_connection {
-#     name                           = "private-service-connection-databricks-auth-${local.service_resource_name_suffix}"
-#     private_connection_resource_id = azurerm_databricks_workspace.databricks.id
-#     is_manual_connection           = false
-#     subresource_names              = ["browser_authentication"]
-#   }
-
-#   private_dns_zone_group {
-#     name                 = "private-dns-zone-group-databricks-auth-${local.service_resource_name_suffix}"
-#     private_dns_zone_ids = [data.azurerm_private_dns_zone.databricks.id]
-#   }
-# }
-
 resource "azurerm_private_endpoint" "databricks_filesystem_private_endpoint" {
   name                = "pe-adb-fs-${local.service_resource_name_suffix}"
   location            = data.azurerm_resource_group.ws.location

--- a/templates/workspace_services/databricks/terraform/outputs.tf
+++ b/templates/workspace_services/databricks/terraform/outputs.tf
@@ -3,11 +3,7 @@ output "databricks_workspace_name" {
 }
 
 output "connection_uri" {
-  value = var.is_exposed_externally ? "https://${azurerm_databricks_workspace.databricks.workspace_url}/aad/auth?has=&Workspace=${data.azurerm_subscription.current.id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.Databricks/workspaces/${local.databricks_workspace_name}&WorkspaceResourceGroupUri=${data.azurerm_subscription.current.id}/resourceGroups/${local.managed_resource_group_name}&l=en-us" : ""
-}
-
-output "internal_connection_uri" {
-  value = var.is_exposed_externally ? "" : "https://${azurerm_databricks_workspace.databricks.workspace_url}/aad/auth?has=&Workspace=${data.azurerm_subscription.current.id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.Databricks/workspaces/${local.databricks_workspace_name}&WorkspaceResourceGroupUri=${data.azurerm_subscription.current.id}/resourceGroups/${local.managed_resource_group_name}&l=en-us"
+  value = "https://${azurerm_databricks_workspace.databricks.workspace_url}/aad/auth?has=&Workspace=${data.azurerm_subscription.current.id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.Databricks/workspaces/${local.databricks_workspace_name}&WorkspaceResourceGroupUri=${data.azurerm_subscription.current.id}/resourceGroups/${local.managed_resource_group_name}&l=en-us"
 }
 
 output "databricks_storage_account_name" {


### PR DESCRIPTION
# Resolves partially #3182 and related to #3122

## What is being addressed

- Removing auth private endpoint from Databricks workspace service as it should be deployed only once per region.
A separate PR will be created to deploy it with Databricks shared service.

- Follow [recommended configuration by Databricks ](https://learn.microsoft.com/en-us/azure/databricks/administration-guide/cloud-configurations/azure/private-link-simplified#--step-3-provision-an-azure-databricks-workspace-and-private-endpoints) see scenario table.

- Consolidating `connection_uri` and `internal_connection_uri` into single output which will be rendered in UI according to `is_exposed_externally`.

## How is this addressed

- Removing auth private endpoint from Databricks workspace service.
- Always return adb connection url as `connection_uri`.
- Set `network_security_group_rules_required` to `NoAzureDatabricksRules` according to [recommended configuration by Databricks ](https://learn.microsoft.com/en-us/azure/databricks/administration-guide/cloud-configurations/azure/private-link-simplified#--step-3-provision-an-azure-databricks-workspace-and-private-endpoints).
