### PR TITLE
Skip certs e2e on Fri/Sat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ BUG FIXES:
 * Added Migration for Airlock requests that were created prior to version 0.5.0 ([#3152](https://github.com/microsoft/AzureTRE/pull/3152))
 * Temporarly use the remote bundle for `check-params` target [#3149](https://github.com/microsoft/AzureTRE/pull/3149)
 * Workspace module dependency to resolve _AnotherOperationInProgress_ errors [#3194](https://github.com/microsoft/AzureTRE/pull/3194)
-* Skip Certs shared service E2E on Friday & Saterday due to LetsEncrypt limits [#3203](https://github.com/microsoft/AzureTRE/pull/3203)
+* Skip Certs shared service E2E on Friday & Saturday due to LetsEncrypt limits [#3203](https://github.com/microsoft/AzureTRE/pull/3203)
 
 COMPONENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ BUG FIXES:
 * Reauth CLI if TRE endpoint has changed [#3137](https://github.com/microsoft/AzureTRE/pull/3137)
 * Added Migration for Airlock requests that were created prior to version 0.5.0 ([#3152](https://github.com/microsoft/AzureTRE/pull/3152))
 * Temporarly use the remote bundle for `check-params` target [#3149](https://github.com/microsoft/AzureTRE/pull/3149)
-* Workspace module dependency to resolve _AnotherOperationInProgress_ errors [#TBD](https://github.com/microsoft/AzureTRE/pull/TBD)
+* Workspace module dependency to resolve _AnotherOperationInProgress_ errors [#3194](https://github.com/microsoft/AzureTRE/pull/3194)
+* Skip Certs shared service E2E on Friday & Saterday due to LetsEncrypt limits [#3203](https://github.com/microsoft/AzureTRE/pull/3203)
 
 COMPONENTS:
 

--- a/e2e_tests/test_shared_services.py
+++ b/e2e_tests/test_shared_services.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+from datetime import date
 
 from resources.resource import disable_and_delete_resource, post_resource
 from helpers import get_shared_service_by_name
@@ -139,6 +140,7 @@ async def test_create_shared_service(template_name, verify) -> None:
 
 @pytest.mark.shared_services
 @pytest.mark.timeout(60 * 60)
+@pytest.mark.skipif(date.today().weekday() in [4, 5], reason="LetsEncrypt limits to 5 times a week. Skipping on FRI & SAT.")
 async def test_create_certs_nexus_shared_service(verify) -> None:
     await disable_and_delete_shared_service_if_exists(strings.NEXUS_SHARED_SERVICE, verify)
     await disable_and_delete_shared_service_if_exists(strings.CERTS_SHARED_SERVICE, verify)


### PR DESCRIPTION
Resolves #3202 

## What is being addressed

Certs provisioning in E2E will fail the nightly run twice a week due to letsencrypt limits.

## How is this addressed

- Skip the test of Friday and Saturday
