### PR TITLE
Provision AppInsights in a workspace with AzAPI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ BUG FIXES:
 * Temporarily use the remote bundle for `check-params` target [#3149](https://github.com/microsoft/AzureTRE/pull/3149)
 * Workspace module dependency to resolve _AnotherOperationInProgress_ errors [#3194](https://github.com/microsoft/AzureTRE/pull/3194)
 * Skip Certs shared service E2E on Friday & Saturday due to LetsEncrypt limits [#3203](https://github.com/microsoft/AzureTRE/pull/3203)
-* Create Workspace AppInsights via AzAPI provider due to an issue with AzureRM [#TBD](https://github.com/microsoft/AzureTRE/pull/TBD)
+* Create Workspace AppInsights via AzAPI provider due to an issue with AzureRM [#3207](https://github.com/microsoft/AzureTRE/pull/3207)
 
 COMPONENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,10 @@ ENHANCEMENTS:
 BUG FIXES:
 * Reauth CLI if TRE endpoint has changed [#3137](https://github.com/microsoft/AzureTRE/pull/3137)
 * Added Migration for Airlock requests that were created prior to version 0.5.0 ([#3152](https://github.com/microsoft/AzureTRE/pull/3152))
-* Temporarly use the remote bundle for `check-params` target [#3149](https://github.com/microsoft/AzureTRE/pull/3149)
+* Temporarily use the remote bundle for `check-params` target [#3149](https://github.com/microsoft/AzureTRE/pull/3149)
 * Workspace module dependency to resolve _AnotherOperationInProgress_ errors [#3194](https://github.com/microsoft/AzureTRE/pull/3194)
 * Skip Certs shared service E2E on Friday & Saturday due to LetsEncrypt limits [#3203](https://github.com/microsoft/AzureTRE/pull/3203)
+* Create Workspace AppInsights via AzAPI provider due to an issue with AzureRM [#TBD](https://github.com/microsoft/AzureTRE/pull/TBD)
 
 COMPONENTS:
 
@@ -116,8 +117,8 @@ COMPONENTS:
 ## 0.7.0 (November 17, 2022)
 
 **BREAKING CHANGES & MIGRATIONS**:
-* The airlock request object has changed. Make sure you have ran the db migration step after deploying the new API image and UI (which runs automatically in `make all`/`make tre-deploy` but can be manually invoked with `make db-migrate`) so that existing requests in your DB are migrated to the new model.
-* Also the model for creating new airlock requests with the API has changed slightly; this is updated in the UI and CLI but if you have written custom tools ensure you are POSTing to `/requests` with the following model:
+* The airlock request object has changed. Make sure you have ran the DB migration step after deploying the new API image and UI (which runs automatically in `make all`/`make tre-deploy` but can be manually invoked with `make db-migrate`) so that existing requests in your DB are migrated to the new model.
+* Also the model for creating new airlock requests with the API has changed slightly; this is updated in the UI and CLI but if you have written custom tools ensure you POST to `/requests` with the following model:
 ```json
 {
     "type": "'import' or 'export'",
@@ -199,7 +200,7 @@ FEATURES:
 
 ENHANCEMENTS:
 * Add cran support to nexus, open port 80 for the workspace nsg and update the firewall config to allow let's encrypt CRLs ([#2694](https://github.com/microsoft/AzureTRE/pull/2694))
-* Upgrade Github Actions versions ([#2731](https://github.com/microsoft/AzureTRE/pull/2744))
+* Upgrade GitHub Actions versions ([#2731](https://github.com/microsoft/AzureTRE/pull/2744))
 * Install TRE CLI inside the devcontainer image (rather than via a post-create step) ([#2757](https://github.com/microsoft/AzureTRE/pull/2757))
 * Upgrade Terraform to 1.3.2 ([#2758](https://github.com/microsoft/AzureTRE/pull/2758))
 * `tre` CLI: added `raw` output option, improved `airlock-requests` handling, more consistent exit codes on error, added examples to CLI README.md
@@ -274,8 +275,8 @@ COMPONENTS:
 
 **BREAKING CHANGES & MIGRATIONS**:
 
-* Github Actions deployments use a single ACR instead of two. Github secrets might need updating, see PR for details. ([#2654](https://github.com/microsoft/AzureTRE/pull/2654))
-* Align Github Action secret names. Existing Github environments must be updated, see PR for details. ([#2655](https://github.com/microsoft/AzureTRE/pull/2655))
+* GitHub Actions deployments use a single ACR instead of two. GitHub secrets might need updating, see PR for details. ([#2654](https://github.com/microsoft/AzureTRE/pull/2654))
+* Align GitHub Action secret names. Existing GitHub environments must be updated, see PR for details. ([#2655](https://github.com/microsoft/AzureTRE/pull/2655))
 * Add workspace creator as an owner of the workspace enterprise application ([#2627](https://github.com/microsoft/AzureTRE/pull/2627)). **Migration** if the `AUTO_WORKSPACE_APP_REGISTRATION` is set, the `Directory.Read.All` MS Graph API permission permission needs granting to the Application Registration identified by `APPLICATION_ADMIN_CLIENT_ID`.
 * Add support for setting AppService plan SKU in GitHub Actions. Previous environment variable names of `API_APP_SERVICE_PLAN_SKU_SIZE` and `APP_SERVICE_PLAN_SKU` have been renamed to `CORE_APP_SERVICE_PLAN_SKU` and `WORKSPACE_APP_SERVICE_PLAN_SKU` ([#2684](https://github.com/microsoft/AzureTRE/pull/2684))
 * Reworked how status update messages are handled by the API, to enforce ordering and run the queue subscription in a dedicated thread. Since sessions are now enabled for the status update queue, a `tre-deploy` is required, which will re-create the queue. ([#2700](https://github.com/microsoft/AzureTRE/pull/2700))
@@ -317,7 +318,6 @@ COMPONENTS:
 | devops | 0.4.2 |
 | core | 0.4.36 |
 | porter-hello | 0.1.0 |
-| tre-workspace-base-sl-test | 0.3.19 |
 | tre-workspace-base | 0.4.0 |
 | tre-workspace-unrestricted | 0.2.0 |
 | tre-workspace-airlock-import-review | 0.4.0 |
@@ -410,7 +410,7 @@ COMPONENTS:
 
 FEATURES:
 
-* MySql workspace service ([#2476](https://github.com/microsoft/AzureTRE/pull/2476))
+* MySQL workspace service ([#2476](https://github.com/microsoft/AzureTRE/pull/2476))
 
 ENHANCEMENTS:
 

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 1.0.2
+version: 1.1.0
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/base/terraform/.terraform.lock.hcl
+++ b/templates/workspaces/base/terraform/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "1.3.0"
+  constraints = ">= 1.3.0, 1.3.0"
+  hashes = [
+    "h1:b4PzksrgRiHgOTVXIMTODOAlsvdj3uWSdCvA7lw+9ik=",
+    "zh:0923b297c5b71ed584e5f3a0b2393e80244076e85102a90438159833353274b0",
+    "zh:11fa2922aa98ca55beaf7cc33c7edbde81bbd405fdfea2955276c7f5a8537240",
+    "zh:14af830fb6091d084bfc2711c8e9c7bf05aa3c56fe8fd8e2fb4eddeb345be88d",
+    "zh:25258425ecbffbdf09b0c8131d2c680cddd19b504e0036ee5f83972dcae7df0a",
+    "zh:2922b535fe4d4f0963189548f2f8360a0aaf951fd411354f2269a111d8a0c1ad",
+    "zh:32c9360305e00c25d0f9d0a84dfbdbad8da2465be769a9c1f11f132c0225358e",
+    "zh:4ddd3ee23c340d5000839d8d30ba7f94e695476d63075f95cfb041e67d8f6ef6",
+    "zh:5c1514392a5c3dd51084aa70cb6c4dcc8b027c4508b5e4eb9f8c3990fd403213",
+    "zh:6b3ecac7099ab86c007b5ad636bd029f5e5f3e9bd06b0f74c82f0451a7995ecc",
+    "zh:6cb7081745b378e910e0cf09fb5717a2ad35e629ce3e07415d6682c1c1407872",
+    "zh:7107eda5125c1b983380f1f6418c592fb7fb2eb5b589ad0e08f6c47341f36318",
+    "zh:c6fa7af32a7a47d23a85e0eea4d4cbb065378ae75aed8c9c628fb625b04bc619",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.20.0"
   constraints = ">= 2.20.0, 2.20.0"

--- a/templates/workspaces/base/terraform/azure-monitor/azure-monitor.tf
+++ b/templates/workspaces/base/terraform/azure-monitor/azure-monitor.tf
@@ -63,24 +63,53 @@ resource "azurerm_monitor_private_link_scoped_service" "ampls_log_anaytics" {
 
 # Application Insights
 
-resource "azurerm_application_insights" "workspace" {
-  name                                = "appi-${var.tre_id}-ws-${local.short_workspace_id}"
-  location                            = var.location
-  resource_group_name                 = var.resource_group_name
-  workspace_id                        = azurerm_log_analytics_workspace.workspace.id
-  application_type                    = "web"
-  internet_ingestion_enabled          = var.enable_local_debugging ? true : false
-  force_customer_storage_for_profiler = true
-  tags                                = var.tre_workspace_tags
+# TODO: switch from the azapi implementation to azurerm when resolved https://github.com/microsoft/AzureTRE/issues/3200
+# resource "azurerm_application_insights" "workspace" {
+#   name                                = local.app_insights_name
+#   location                            = var.location
+#   resource_group_name                 = var.resource_group_name
+#   workspace_id                        = azurerm_log_analytics_workspace.workspace.id
+#   application_type                    = "web"
+#   internet_ingestion_enabled          = var.enable_local_debugging ? true : false
+#   force_customer_storage_for_profiler = true
+#   tags                                = var.tre_workspace_tags
 
-  lifecycle { ignore_changes = [tags] }
+#   lifecycle { ignore_changes = [tags] }
+# }
+
+resource "azapi_resource" "appinsights" {
+  type      = "Microsoft.Insights/components@2020-02-02"
+  name      = local.app_insights_name
+  parent_id = var.resource_group_id
+  location  = var.location
+  tags      = var.tre_workspace_tags
+
+  body = jsonencode({
+    kind = "web"
+    properties = {
+      Application_Type                = "web"
+      Flow_Type                       = "Bluefield"
+      Request_Source                  = "rest"
+      IngestionMode                   = "LogAnalytics"
+      WorkspaceResourceId             = azurerm_log_analytics_workspace.workspace.id
+      ForceCustomerStorageForProfiler = true
+      publicNetworkAccessForIngestion = var.enable_local_debugging ? "Enabled" : "Disabled"
+    }
+  })
+
+  response_export_values = [
+    "id",
+    "properties.ConnectionString",
+  ]
 }
 
 resource "azurerm_monitor_private_link_scoped_service" "ampls_app_insights" {
   name                = "ampls-app-insights-service"
   resource_group_name = var.resource_group_name
   scope_name          = azurerm_monitor_private_link_scope.workspace.name
-  linked_resource_id  = azurerm_application_insights.workspace.id
+
+  # linked_resource_id  = azurerm_application_insights.workspace.id
+  linked_resource_id = jsondecode(azapi_resource.appinsights.output).id
 }
 
 resource "azurerm_private_endpoint" "azure_monitor_private_endpoint" {
@@ -119,10 +148,16 @@ resource "azurerm_private_endpoint" "azure_monitor_private_endpoint" {
 # We don't really need this, but if not present the RG will not be empty and won't be destroyed
 # TODO: remove when this is resolved: https://github.com/hashicorp/terraform-provider-azurerm/issues/18026
 resource "azurerm_monitor_action_group" "failure_anomalies" {
-  name                = "${azurerm_application_insights.workspace.name}-failure-anomalies-action-group"
+  name                = "${local.app_insights_name}-failure-anomalies-action-group"
   resource_group_name = var.resource_group_name
   short_name          = "Failures"
   tags                = var.tre_workspace_tags
+  depends_on = [
+    # azurerm_application_insights.workspace
+    azapi_resource.appinsights
+  ]
+
+  lifecycle { ignore_changes = [tags] }
 }
 
 # We don't really need this, but if not present the RG will not be empty and won't be destroyed
@@ -131,12 +166,17 @@ resource "azurerm_monitor_smart_detector_alert_rule" "failure_anomalies" {
   name                = "Failure Anomalies - ${local.app_insights_name}"
   resource_group_name = var.resource_group_name
   severity            = "Sev3"
-  scope_resource_ids  = [azurerm_application_insights.workspace.id]
-  frequency           = "PT1M"
-  detector_type       = "FailureAnomaliesDetector"
-  tags                = var.tre_workspace_tags
+  scope_resource_ids = [
+    # azurerm_application_insights.workspace.id
+    jsondecode(azapi_resource.appinsights.output).id
+  ]
+  frequency     = "PT1M"
+  detector_type = "FailureAnomaliesDetector"
+  tags          = var.tre_workspace_tags
 
   action_group {
     ids = [azurerm_monitor_action_group.failure_anomalies.id]
   }
+
+  lifecycle { ignore_changes = [tags] }
 }

--- a/templates/workspaces/base/terraform/azure-monitor/outputs.tf
+++ b/templates/workspaces/base/terraform/azure-monitor/outputs.tf
@@ -1,5 +1,7 @@
 output "app_insights_connection_string" {
-  value = azurerm_application_insights.workspace.connection_string
+  # value = azurerm_application_insights.workspace.connection_string
+  value     = jsondecode(azapi_resource.appinsights.output).properties.ConnectionString
+  sensitive = true
 }
 
 output "log_analytics_workspace_id" {

--- a/templates/workspaces/base/terraform/azure-monitor/providers.tf
+++ b/templates/workspaces/base/terraform/azure-monitor/providers.tf
@@ -5,5 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.8.0"
     }
+
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.3.0"
+    }
   }
 }

--- a/templates/workspaces/base/terraform/azure-monitor/variables.tf
+++ b/templates/workspaces/base/terraform/azure-monitor/variables.tf
@@ -1,6 +1,7 @@
 variable "tre_id" {}
 variable "location" {}
 variable "resource_group_name" {}
+variable "resource_group_id" {}
 variable "tre_workspace_tags" {}
 variable "workspace_subnet_id" {}
 variable "azure_monitor_dns_zone_id" {}

--- a/templates/workspaces/base/terraform/providers.tf
+++ b/templates/workspaces/base/terraform/providers.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/null"
       version = "=3.2.1"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "=1.3.0"
+    }
   }
 
   backend "azurerm" {}
@@ -38,4 +42,7 @@ provider "azuread" {
   client_id     = var.auth_client_id
   client_secret = var.auth_client_secret
   tenant_id     = var.auth_tenant_id
+}
+
+provider "azapi" {
 }

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -69,6 +69,7 @@ module "azure_monitor" {
   tre_id                                   = var.tre_id
   location                                 = var.location
   resource_group_name                      = azurerm_resource_group.ws.name
+  resource_group_id                        = azurerm_resource_group.ws.id
   tre_resource_id                          = var.tre_resource_id
   tre_workspace_tags                       = local.tre_workspace_tags
   workspace_subnet_id                      = module.network.services_subnet_id


### PR DESCRIPTION
## What is being addressed

AzureRM provider fails provision AppInsights from time to time. See #3200 

## How is this addressed

- Move to the AzAPI provider to provision AppInsights directly with a REST call. This is a temp fix until the AzureRM provider will resolve the underlining issue.