### PR TITLE
TRE URL to relative path

### DIFF
--- a/devops/scripts/build_deploy_ui.sh
+++ b/devops/scripts/build_deploy_ui.sh
@@ -14,7 +14,7 @@ ui_version=$(jq -r '.version' package.json)
 jq --arg rootClientId "${SWAGGER_UI_CLIENT_ID}" \
   --arg rootTenantId "${AAD_TENANT_ID}" \
   --arg treApplicationId "api://${API_CLIENT_ID}" \
-  --arg treUrl "https://${FQDN}/api" \
+  --arg treUrl "/api" \
   --arg treId "${TRE_ID}" \
   --arg version "${ui_version}" \
   '.rootClientId = $rootClientId | .rootTenantId = $rootTenantId | .treApplicationId = $treApplicationId | .treUrl = $treUrl | .treId = $treId | .version = $version' ./src/config.source.json > ./src/config.json


### PR DESCRIPTION
During deployment of the UI, sets the `treUrl` config setting to `/api` instead of the `FQDN` returned from the app gateway deployment. 

Since the UI is routed under the same host name as the API through app gateway, we can (and should) use the relative URL. This also solves for custom domain name scenarios. 