### PR TITLE
UI - Remove tilde from Azure CLI command path

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.32.1",

--- a/ui/app/src/components/shared/airlock/AirlockRequestFilesSection.tsx
+++ b/ui/app/src/components/shared/airlock/AirlockRequestFilesSection.tsx
@@ -71,9 +71,9 @@ export const AirlockRequestFilesSection: React.FunctionComponent<AirlockRequestF
 
     let cliCommand = "";
     if (props.request.status === AirlockRequestStatus.Draft) {
-      cliCommand = `az storage blob upload --file <~/path/to/file> --name <filename.filetype> --account-name ${containerDetails.StorageAccountName} --type block --container-name ${containerDetails.containerName} --sas-token "${containerDetails.sasToken}"`
+      cliCommand = `az storage blob upload --file </path/to/file> --name <filename.filetype> --account-name ${containerDetails.StorageAccountName} --type block --container-name ${containerDetails.containerName} --sas-token "${containerDetails.sasToken}"`
     } else {
-      cliCommand = `az storage blob download-batch --destination <~/destination/path/for/file> --source ${containerDetails.containerName} --account-name ${containerDetails.StorageAccountName} --sas-token "${containerDetails.sasToken}"`
+      cliCommand = `az storage blob download-batch --destination </destination/path/for/file> --source ${containerDetails.containerName} --account-name ${containerDetails.StorageAccountName} --sas-token "${containerDetails.sasToken}"`
     }
 
     return cliCommand;


### PR DESCRIPTION
# Resolves #3225 

## What is being addressed

Removed the tilde from the path in Airlock's Azure CLI command

from:
`az storage blob download-batch --destination <~/destination/path/for/file> ...`

to:
`az storage blob download-batch --destination </destination/path/for/file> ...`
