### PR TITLE
Add a unique step id for each OperationStep

### DIFF
--- a/api_app/db/repositories/operations.py
+++ b/api_app/db/repositories/operations.py
@@ -39,13 +39,13 @@ class OperationRepository(BaseRepository):
     def create_main_step(self, resource_template: dict, action: str, resource_id: str, status: Status, message: str) -> OperationStep:
         return OperationStep(
             id=str(uuid.uuid4()),
-            stepId="main",
+            stepIdFromTemplate="main",
             stepTitle=f"Main step for {resource_id}",
             resourceId=resource_id,
             resourceTemplateName=resource_template["name"],
             resourceType=resource_template["resourceType"],
             resourceAction=action,
-            parentResourceId=resource_id,
+            templateResourceId=resource_id,
             status=status,
             message=message,
             updatedWhen=self.get_timestamp())
@@ -135,7 +135,7 @@ class OperationRepository(BaseRepository):
 
                         steps.append(OperationStep(
                             id=str(uuid.uuid4()),
-                            stepId=step["stepId"],
+                            stepIdFromTemplate=step["stepId"],
                             stepTitle=step["stepTitle"],
                             resourceId=resource_for_step.id,
                             resourceTemplateName=resource_for_step.templateName,
@@ -144,7 +144,7 @@ class OperationRepository(BaseRepository):
                             status=resource_for_step_status,
                             message=resource_for_step_message,
                             updatedWhen=self.get_timestamp(),
-                            parentResourceId=resource_id
+                            templateResourceId=resource_id
                         ))
         return steps
 

--- a/api_app/db/repositories/operations.py
+++ b/api_app/db/repositories/operations.py
@@ -38,6 +38,7 @@ class OperationRepository(BaseRepository):
 
     def create_main_step(self, resource_template: dict, action: str, resource_id: str, status: Status, message: str) -> OperationStep:
         return OperationStep(
+            id=str(uuid.uuid4()),
             stepId="main",
             stepTitle=f"Main step for {resource_id}",
             resourceId=resource_id,
@@ -133,6 +134,7 @@ class OperationRepository(BaseRepository):
                         resource_for_step_status, resource_for_step_message = self.get_initial_status(step["resourceAction"])
 
                         steps.append(OperationStep(
+                            id=str(uuid.uuid4()),
                             stepId=step["stepId"],
                             stepTitle=step["stepTitle"],
                             resourceId=resource_for_step.id,

--- a/api_app/models/domain/operation.py
+++ b/api_app/models/domain/operation.py
@@ -43,7 +43,7 @@ class OperationStep(AzureTREModel):
     As each step completes, the next one is processed.
     """
     id: str = Field(title="Id", description="Unique id identifying the step")
-    stepId: str = Field(title="stepId", description="Unique id identifying the step")
+    stepIdFromTemplate: str = Field(title="stepIdFromTemplate", description="Unique id identifying the step")
     stepTitle: Optional[str] = Field(title="stepTitle", description="Human readable title of what the step is for")
     resourceId: Optional[str] = Field(title="resourceId", description="Id of the resource to update")
     resourceTemplateName: Optional[str] = Field("", title="resourceTemplateName", description="Name of the template for the resource under change")
@@ -52,7 +52,7 @@ class OperationStep(AzureTREModel):
     status: Optional[Status] = Field(None, title="Operation step status")
     message: Optional[str] = Field("", title="Additional operation step status information")
     updatedWhen: Optional[float] = Field("", title="POSIX Timestamp for When the operation step was updated")
-    parentResourceId: Optional[str] = Field(title="parentResourceId", description="Id of the parent of the resource to update")
+    templateResourceId: Optional[str] = Field(title="templateResourceId", description="Id of the parent of the resource to update")
 
     def is_success(self) -> bool:
         return self.status in (

--- a/api_app/models/domain/operation.py
+++ b/api_app/models/domain/operation.py
@@ -42,6 +42,7 @@ class OperationStep(AzureTREModel):
     The steps are built up front as the operation is created from the initial user request.
     As each step completes, the next one is processed.
     """
+    id: str = Field(title="Id", description="Unique id identifying the step")
     stepId: str = Field(title="stepId", description="Unique id identifying the step")
     stepTitle: Optional[str] = Field(title="stepTitle", description="Human readable title of what the step is for")
     resourceId: Optional[str] = Field(title="resourceId", description="Id of the resource to update")

--- a/api_app/service_bus/deployment_status_updater.py
+++ b/api_app/service_bus/deployment_status_updater.py
@@ -147,7 +147,7 @@ class DeploymentStatusUpdater():
                 # catch any errors in updating the resource - maybe Cosmos / schema invalid etc, and report them back to the op
                 try:
                     # parent resource is always retrieved via cosmos, hence it is always with redacted sensitive values
-                    parent_resource = await self.resource_repo.get_resource_by_id(next_step.parentResourceId)
+                    parent_resource = await self.resource_repo.get_resource_by_id(next_step.templateResourceId)
                     resource_to_send = await update_resource_for_step(
                         operation_step=next_step,
                         resource_repo=self.resource_repo,
@@ -160,7 +160,7 @@ class DeploymentStatusUpdater():
                         user=operation.user)
 
                     # create + send the message
-                    logging.info(f"Sending next step in operation to deployment queue -> step_id: {next_step.stepId}, action: {next_step.resourceAction}")
+                    logging.info(f"Sending next step in operation to deployment queue -> step_id: {next_step.stepIdFromTemplate}, action: {next_step.resourceAction}")
                     content = json.dumps(resource_to_send.get_resource_request_message_payload(operation_id=operation.id, step_id=next_step.id, action=next_step.resourceAction))
                     await send_deployment_message(content=content, correlation_id=operation.id, session_id=resource_to_send.id, action=next_step.resourceAction)
                 except Exception as e:
@@ -195,12 +195,12 @@ class DeploymentStatusUpdater():
 
         if step.is_failure():
             operation.status = self.get_failure_status_for_action(operation.action)
-            operation.message = f"Multi step pipeline failed on step {step.stepId}"
+            operation.message = f"Multi step pipeline failed on step {step.stepIdFromTemplate}"
 
             # pipeline failed - update the primary resource (from the main step) as failed too
             main_step = None
             for i, step in enumerate(operation.steps):
-                if step.stepId == "main":
+                if step.stepIdFromTemplate == "main":
                     main_step = step
                     break
 

--- a/api_app/service_bus/deployment_status_updater.py
+++ b/api_app/service_bus/deployment_status_updater.py
@@ -102,7 +102,8 @@ class DeploymentStatusUpdater():
 
             current_step_index = 0
             for i, step in enumerate(operation.steps):
-                if step.stepId == message.stepId and step.resourceId == str(message.id):
+                # TODO more simple condition
+                if step.id == message.stepId and step.resourceId == str(message.id):
                     step_to_update = step
                     current_step_index = i
                     if i == (len(operation.steps) - 1):
@@ -160,7 +161,7 @@ class DeploymentStatusUpdater():
 
                     # create + send the message
                     logging.info(f"Sending next step in operation to deployment queue -> step_id: {next_step.stepId}, action: {next_step.resourceAction}")
-                    content = json.dumps(resource_to_send.get_resource_request_message_payload(operation_id=operation.id, step_id=next_step.stepId, action=next_step.resourceAction))
+                    content = json.dumps(resource_to_send.get_resource_request_message_payload(operation_id=operation.id, step_id=next_step.id, action=next_step.resourceAction))
                     await send_deployment_message(content=content, correlation_id=operation.id, session_id=resource_to_send.id, action=next_step.resourceAction)
                 except Exception as e:
                     logging.exception("Unable to send update for resource in pipeline step")

--- a/api_app/service_bus/helpers.py
+++ b/api_app/service_bus/helpers.py
@@ -44,7 +44,7 @@ async def update_resource_for_step(operation_step: OperationStep, resource_repo:
     # step_resource is the resource instance where the step was defined. e.g. 'add firewall rule' step defined in Guacamole template -> the step_resource is the Guacamole ws service.
     # root_resource is theresource on which the user chose to update, i.e. the top most resource in cascaded action or the same resource in a non-cascaded action.
     if step_resource is None:
-        step_resource = await resource_repo.get_resource_by_id(operation_step.parentResourceId)
+        step_resource = await resource_repo.get_resource_by_id(operation_step.templateResourceId)
 
     # If we are handling the root resource, we can leverage the given resource which has non redacted properties
     if root_resource is not None and root_resource.id == step_resource.id:
@@ -73,12 +73,12 @@ async def update_resource_for_step(operation_step: OperationStep, resource_repo:
     # get the template step
     template_step = None
     for step in parent_template.pipeline.dict()[primary_action]:
-        if step["stepId"] == operation_step.stepId:
+        if step["stepId"] == operation_step.stepIdFromTemplate:
             template_step = parse_obj_as(PipelineStep, step)
             break
 
     if template_step is None:
-        raise Exception(f"Cannot find step with id of {operation_step.stepId} in template {step_resource.templateName} for action {primary_action}")
+        raise Exception(f"Cannot find step with id of {operation_step.stepIdFromTemplate} in template {step_resource.templateName} for action {primary_action}")
 
     resource_to_send = await try_update_with_retries(
         num_retries=3,

--- a/api_app/service_bus/resource_request_sender.py
+++ b/api_app/service_bus/resource_request_sender.py
@@ -54,7 +54,7 @@ async def send_resource_request_message(resource: Resource, operations_repo: Ope
         user=user)
 
     # create + send the message
-    content = json.dumps(resource_to_send.get_resource_request_message_payload(operation_id=operation.id, step_id=first_step.stepId, action=first_step.resourceAction))
+    content = json.dumps(resource_to_send.get_resource_request_message_payload(operation_id=operation.id, step_id=first_step.id, action=first_step.resourceAction))
     await send_deployment_message(content=content, correlation_id=operation.id, session_id=first_step.resourceId, action=first_step.resourceAction)
 
     return operation

--- a/api_app/tests_ma/conftest.py
+++ b/api_app/tests_ma/conftest.py
@@ -367,7 +367,8 @@ def multi_step_operation(
         updatedWhen=FAKE_CREATE_TIMESTAMP,
         steps=[
             OperationStep(
-                stepId="pre-step-1",
+                id="random-uuid-1",
+                stepIdFromTemplate="pre-step-1",
                 stepTitle="Title for pre-step-1",
                 resourceAction="upgrade",
                 resourceTemplateName=basic_shared_service_template.name,
@@ -376,10 +377,11 @@ def multi_step_operation(
                 status=Status.AwaitingUpdate,
                 message="This resource is waiting to be updated",
                 updatedWhen=FAKE_CREATE_TIMESTAMP,
-                parentResourceId="59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76"
+                templateResourceId="59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76"
             ),
             OperationStep(
-                stepId="main",
+                id="random-uuid-2",
+                stepIdFromTemplate="main",
                 stepTitle="Main step for 59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
                 resourceAction="install",
                 resourceType=ResourceType.Workspace,
@@ -388,10 +390,11 @@ def multi_step_operation(
                 status=Status.AwaitingDeployment,
                 message="This resource is waiting to be deployed",
                 updatedWhen=FAKE_CREATE_TIMESTAMP,
-                parentResourceId="59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76"
+                templateResourceId="59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76"
             ),
             OperationStep(
-                stepId="post-step-1",
+                id="random-uuid-3",
+                stepIdFromTemplate="post-step-1",
                 stepTitle="Title for post-step-1",
                 resourceAction="upgrade",
                 resourceType=basic_shared_service_template.resourceType,
@@ -400,7 +403,7 @@ def multi_step_operation(
                 status=Status.AwaitingUpdate,
                 message="This resource is waiting to be updated",
                 updatedWhen=FAKE_CREATE_TIMESTAMP,
-                parentResourceId="59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76"
+                templateResourceId="59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76"
             ),
         ],
     )

--- a/api_app/tests_ma/test_api/test_routes/test_resource_helpers.py
+++ b/api_app/tests_ma/test_api/test_routes/test_resource_helpers.py
@@ -97,13 +97,15 @@ def sample_resource_operation(resource_id: str, operation_id: str):
         user=create_test_user(),
         steps=[
             OperationStep(
-                stepId="main",
+                id="random-uuid-1",
+                stepIdFromTemplate="main",
                 stepTitle="Main step for resource-id",
                 resourceAction="install",
                 resourceType=ResourceType.Workspace,
                 resourceTemplateName="template1",
                 resourceId=resource_id,
-                updatedWhen=FAKE_CREATE_TIMESTAMP
+                updatedWhen=FAKE_CREATE_TIMESTAMP,
+                templateResourceId=resource_id
             )
         ]
     )
@@ -270,7 +272,7 @@ class TestResourceHelpers:
     @pytest.mark.asyncio
     async def test_save_and_deploy_masks_secrets(self, send_deployment_message_mock, resource_template_repo, resource_repo, operations_repo, basic_resource_template, resource_history_repo):
         resource = sample_resource_with_secret()
-        step_id = "main"
+        step_id = "random-uuid-1"
         operation_id = str(uuid.uuid4())
         operation = sample_resource_operation(resource_id=resource.id, operation_id=operation_id)
 

--- a/api_app/tests_ma/test_api/test_routes/test_workspaces.py
+++ b/api_app/tests_ma/test_api/test_routes/test_workspaces.py
@@ -136,10 +136,12 @@ def sample_resource_operation(resource_id: str, operation_id: str):
         user=create_test_user(),
         steps=[
             OperationStep(
-                stepId="main",
+                id="random-uuid",
+                stepIdFromTemplate="main",
                 resourceId=resource_id,
                 resourceAction="install",
-                updatedWhen=FAKE_UPDATE_TIMESTAMP
+                updatedWhen=FAKE_UPDATE_TIMESTAMP,
+                templateResourceId=resource_id
             )
         ]
     )

--- a/api_app/tests_ma/test_db/test_repositories/test_operation_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_operation_repository.py
@@ -40,9 +40,10 @@ async def resource_template_repo():
             yield resource_template_repo
 
 
+@patch('uuid.uuid4', side_effect=["random-uuid-1", "random-uuid-2", "random-uuid-3"])
 @patch("db.repositories.operations.OperationRepository.get_timestamp", return_value=FAKE_CREATE_TIMESTAMP)
 @patch("db.repositories.operations.OperationRepository.create_operation_id", return_value=OPERATION_ID)
-async def test_create_operation_steps_from_multi_step_template(_, __, resource_repo, test_user, multi_step_operation, operations_repo, basic_shared_service, resource_template_repo, multi_step_resource_template):
+async def test_create_operation_steps_from_multi_step_template(_, __, ___, resource_repo, test_user, multi_step_operation, operations_repo, basic_shared_service, resource_template_repo, multi_step_resource_template):
 
     expected_op = multi_step_operation
     expected_op.id = OPERATION_ID

--- a/api_app/tests_ma/test_service_bus/test_deployment_status_update.py
+++ b/api_app/tests_ma/test_service_bus/test_deployment_status_update.py
@@ -27,7 +27,7 @@ OPERATION_ID = "0000c8e7-5c42-4fcb-a7fd-294cfc27aa76"
 
 test_sb_message = {
     "operationId": OPERATION_ID,
-    "stepId": "main",
+    "stepId": "random-uuid",
     "id": "59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
     "status": Status.Deployed,
     "message": "test message",
@@ -36,7 +36,7 @@ test_sb_message = {
 
 test_sb_message_with_outputs = {
     "operationId": OPERATION_ID,
-    "stepId": "main",
+    "stepId": "random-uuid",
     "id": "59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
     "status": Status.Deployed,
     "message": "test message",
@@ -48,7 +48,7 @@ test_sb_message_with_outputs = {
 
 test_sb_message_multi_step_1_complete = {
     "operationId": OPERATION_ID,
-    "stepId": "pre-step-1",
+    "stepId": "random-uuid-1",
     "id": "59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
     "status": Status.Updated,
     "message": "upgrade succeeded"
@@ -56,7 +56,7 @@ test_sb_message_multi_step_1_complete = {
 
 test_sb_message_multi_step_3_complete = {
     "operationId": OPERATION_ID,
-    "stepId": "post-step-1",
+    "stepId": "random-uuid-3",
     "id": "59b5c8e7-5c42-4fcb-a7fd-294cfc27aa76",
     "status": Status.Updated,
     "message": "upgrade succeeded"
@@ -96,13 +96,15 @@ def create_sample_operation(resource_id, request_action):
         updatedWhen=FAKE_UPDATE_TIMESTAMP,
         steps=[
             OperationStep(
-                stepId="main",
+                id="random-uuid",
+                stepIdFromTemplate="main",
                 resourceId=resource_id,
                 stepTitle=f"main step for {resource_id}",
                 resourceTemplateName="workspace-base",
                 resourceType=ResourceType.Workspace,
                 resourceAction=request_action,
-                updatedWhen=FAKE_UPDATE_TIMESTAMP
+                updatedWhen=FAKE_UPDATE_TIMESTAMP,
+                templateResourceId=resource_id
             )
         ]
     )

--- a/ui/app/src/components/shared/notifications/NotificationItem.tsx
+++ b/ui/app/src/components/shared/notifications/NotificationItem.tsx
@@ -132,7 +132,7 @@ export const NotificationItem: React.FunctionComponent<NotificationItemProps> = 
                 <Stack horizontal style={{ marginTop: '10px' }}>
                   <Stack.Item grow={5}>
                     {
-                      props.operation.steps && props.operation.steps.length > 0 && !(props.operation.steps.length === 1 && props.operation.steps[0].stepId === 'main') ?
+                      props.operation.steps && props.operation.steps.length > 0 && !(props.operation.steps.length === 1 && props.operation.steps[0].stepIdFromTemplate === 'main') ?
                         <FluentLink title={isExpanded ? 'Show less' : 'Show more'} href="#" onClick={() => { setIsExpanded(!isExpanded) }} style={{ position: 'relative', top: '2px' }}>{isExpanded ? <Icon iconName='ChevronUp' aria-label='Expand Steps' /> : <Icon iconName='ChevronDown' aria-label='Collapse Steps' />}</FluentLink>
                         :
                         ' '
@@ -150,7 +150,7 @@ export const NotificationItem: React.FunctionComponent<NotificationItemProps> = 
                           <li key={i}>
                             <Icon iconName={getIconAndColourForStatus(s.status)[0]} style={{ color: getIconAndColourForStatus(s.status)[1], position: 'relative', top: '2px', marginRight: '10px' }} />
                             {
-                              s.stepId === "main" ?
+                              s.stepIdFromTemplate === "main" ?
                                 <>{notification.resource.properties.display_name}: {props.operation.action}</> :
                                 s.stepTitle
                             }

--- a/ui/app/src/models/operation.ts
+++ b/ui/app/src/models/operation.ts
@@ -17,7 +17,7 @@ export interface Operation {
 }
 
 export interface OperationStep {
-    stepId: string,
+    stepIdFromTemplate: string,
     stepTitle: string,
     resourceId: string,
     resourceTemplateName: string,


### PR DESCRIPTION
# Resolves #3123 
## What is being addressed

Since each stepId in the template object is hard coded, it created clashes when cascade disabling/deleting the same type of object (for example ws service). This PR creates a unique id for each operation step.