### PR TITLE
AML isolatedNetwork fix

### DIFF
--- a/templates/workspace_services/azureml/porter.yaml
+++ b/templates/workspace_services/azureml/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-azureml
-version: 0.7.26
+version: 0.7.27
 description: "An Azure TRE service for Azure Machine Learning"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/azureml/terraform/compute.tf
+++ b/templates/workspace_services/azureml/terraform/compute.tf
@@ -40,7 +40,7 @@ resource "azapi_resource" "compute_cluster" {
       computeType      = "AmlCompute"
       properties = {
         enableNodePublicIp          = false
-        isolatedNetwork             = true
+        isolatedNetwork             = false  # isolatedNetwork = true for internal MS usage only
         osType                      = "Linux"
         remoteLoginPortPublicAccess = "Disabled"
         scaleSettings = {

--- a/templates/workspace_services/azureml/terraform/compute.tf
+++ b/templates/workspace_services/azureml/terraform/compute.tf
@@ -40,7 +40,7 @@ resource "azapi_resource" "compute_cluster" {
       computeType      = "AmlCompute"
       properties = {
         enableNodePublicIp          = false
-        isolatedNetwork             = false  # isolatedNetwork = true for internal MS usage only
+        isolatedNetwork             = false # isolatedNetwork = true for internal MS usage only
         osType                      = "Linux"
         remoteLoginPortPublicAccess = "Disabled"
         scaleSettings = {


### PR DESCRIPTION
Following an IcM, the `isolatedNetwork` parameter in the AML compute cluster terraform should be reserved for MS internal usage only (and is not really related to the compute being on an isolated network), so have switched that back to `false`.