### PR TITLE
Fix firewall log categories

### DIFF
--- a/templates/shared_services/firewall/porter.yaml
+++ b/templates/shared_services/firewall/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-firewall
-version: 1.0.0
+version: 1.0.2
 description: "An Azure TRE Firewall shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/shared_services/firewall/terraform/locals.tf
+++ b/templates/shared_services/firewall/terraform/locals.tf
@@ -2,9 +2,13 @@ locals {
   core_resource_group_name = "rg-${var.tre_id}"
   firewall_name            = "fw-${var.tre_id}"
   firewall_diagnostic_categories_enabled = [
-    "AZFWApplicationRule",
-    "AZFWNetworkRule",
-    "AZFWDnsProxy",
+    "AzureFirewallApplicationRule",
+    "AzureFirewallNetworkRule",
+    "AzureFirewallDnsProxy",
+    # These are for resource specific table settings that are still in preview
+    # "AZFWApplicationRule",
+    # "AZFWNetworkRule",
+    # "AZFWDnsProxy",
   ]
   tre_shared_service_tags = {
     tre_id                = var.tre_id


### PR DESCRIPTION
Resolves #3155 

## What is being addressed

Firewall logs were not present in every situation

## How is this addressed

- Revert back to the legacy diagnostic log categories as the new ones require turning on a preview feature on the subscription level. We should wait until it's not complicated to opt-in.