### PR TITLE
remove admin firewall rules

### DIFF
--- a/templates/shared_services/firewall/porter.yaml
+++ b/templates/shared_services/firewall/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-firewall
-version: 1.0.0
+version: 1.0.3
 description: "An Azure TRE Firewall shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/shared_services/firewall/terraform/rules.tf
+++ b/templates/shared_services/firewall/terraform/rules.tf
@@ -122,37 +122,6 @@ resource "azurerm_firewall_policy_rule_collection_group" "core" {
     action   = "Allow"
 
     rule {
-      name = "admin-resources"
-      protocols {
-        port = "443"
-        type = "Https"
-      }
-      protocols {
-        port = "80"
-        type = "Http"
-      }
-      destination_fqdns = [
-        "go.microsoft.com",
-        "*.azureedge.net",
-        "*github.com",
-        "*powershellgallery.com",
-        "git-scm.com",
-        "*githubusercontent.com",
-        "*core.windows.net",
-        "aka.ms",
-        "management.azure.com",
-        "graph.microsoft.com",
-        "login.microsoftonline.com",
-        "aadcdn.msftauth.net",
-        "graph.windows.net",
-        "keyserver.ubuntu.com",
-        "packages.microsoft.com",
-        "download.docker.com"
-      ]
-      source_ip_groups = [data.azurerm_ip_group.shared.id]
-    }
-
-    rule {
       name = "nexus-bootstrap"
       protocols {
         port = "443"


### PR DESCRIPTION
# Resolves #3286 

## What is being addressed

The firewall shared service includes exceptions for domains previously used by the admin-vm but we don't seem to need them anymore.

## How is this addressed

- Remove redundant rules.