### PR TITLE
RP_BUNDLE multiple values fix

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -185,6 +185,7 @@ runs:
             && inputs.CORE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
           -e WORKSPACE_APP_SERVICE_PLAN_SKU="${{ (inputs.WORKSPACE_APP_SERVICE_PLAN_SKU != ''
             && inputs.WORKSPACE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
+          -e TF_VAR_rp_bundle_values='{"tre_test_custom_val_1": "Value 1", "tre_test_custom_val_2": "Value 2"}' \
           -e TF_VAR_resource_processor_number_processes_per_instance="${{ (inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE != ''
             && inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE) || 5  }}" \
           -e E2E_TESTS_NUMBER_PROCESSES="${{ inputs.E2E_TESTS_NUMBER_PROCESSES }}" \

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -59,7 +59,7 @@ resource_processor:
 # to use as a source of bundle parameter values
 # For example, to specify your image_gallery_id for use in VM user resources with custom VM images:
 # yamllint disable-line rule:line-length
-#   rp_bundle_values: {"image_gallery_id":"/subscriptions/<subscription-id>/resourceGroups/<your-rg>/providers/Microsoft.Compute/galleries/<your-gallery-name>"}
+#  rp_bundle_values: '{"custom_key_1":"custom_value_1","image_gallery_id":"/subscriptions/<subscription-id>/resourceGroups/<your-rg>/providers/Microsoft.Compute/galleries/<your-gallery-name>"}'
 
 developer_settings:
   # Locks will not be added to stateful resources so they can be easily removed

--- a/core/terraform/resource_processor/vmss_porter/variables.tf
+++ b/core/terraform/resource_processor/vmss_porter/variables.tf
@@ -30,5 +30,5 @@ variable "rp_bundle_values" {
 }
 
 locals {
-  rp_bundle_values_formatted = join("\n", [for key in keys(var.rp_bundle_values) : "RP_BUNDLE_${key}=${var.rp_bundle_values[key]}"])
+  rp_bundle_values_formatted = join("\n      ", [for key in keys(var.rp_bundle_values) : "RP_BUNDLE_${key}=${var.rp_bundle_values[key]}"])
 }


### PR DESCRIPTION
# Resolves #3341 

- Adds appropriate spaces to fix the autogenerated cloud_config.yaml file.
- Added some arbritrary rp_bundle values to the build in this repo to ensure it breaks in future if var handling changes 

