### PR TITLE
Add ARM_ENVIRONMENT as an environment variable in porter's installation containers

### DIFF
--- a/templates/shared_services/admin-vm/parameters.json
+++ b/templates/shared_services/admin-vm/parameters.json
@@ -39,6 +39,12 @@
       "source": {
         "env": "ADMIN_JUMPBOX_VM_SKU"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/admin-vm/porter.yaml
+++ b/templates/shared_services/admin-vm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-admin-vm
-version: 0.3.0
+version: 0.3.1
 description: "An admin vm shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -36,6 +36,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: admin_jumpbox_vm_sku
     env: ADMIN_JUMPBOX_VM_SKU
     type: string

--- a/templates/shared_services/airlock_notifier/parameters.json
+++ b/templates/shared_services/airlock_notifier/parameters.json
@@ -69,6 +69,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/airlock_notifier/porter.yaml
+++ b/templates/shared_services/airlock_notifier/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-airlock-notifier
-version: 0.4.1
+version: 0.4.2
 description: "A shared service notifying on Airlock Operations"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -58,6 +58,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 mixins:
   - exec

--- a/templates/shared_services/certs/parameters.json
+++ b/templates/shared_services/certs/parameters.json
@@ -51,6 +51,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/certs/porter.yaml
+++ b/templates/shared_services/certs/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-certs
-version: 0.4.1
+version: 0.4.2
 description: "An Azure TRE shared service to generate certificates for a specified internal domain using Letsencrypt"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -38,6 +38,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: domain_prefix
     type: string
     description: "The FQDN prefix (prepended to {TRE_ID}.{LOCATION}.cloudapp.azure.com) to generate certificate for"

--- a/templates/shared_services/cyclecloud/parameters.json
+++ b/templates/shared_services/cyclecloud/parameters.json
@@ -39,6 +39,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/cyclecloud/porter.yaml
+++ b/templates/shared_services/cyclecloud/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-cyclecloud
-version: 0.4.1
+version: 0.4.2
 description: "An Azure TRE Shared Service Template for Azure Cyclecloud"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -42,6 +42,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 outputs:
   - name: connection_uri

--- a/templates/shared_services/databricks-auth/parameters.json
+++ b/templates/shared_services/databricks-auth/parameters.json
@@ -33,6 +33,12 @@
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/databricks-auth/porter.yaml
+++ b/templates/shared_services/databricks-auth/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-databricks-private-auth
-version: 0.0.6
+version: 0.0.7
 description: "An Azure TRE shared service for Azure Databricks autnetication."
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -38,6 +38,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 outputs:
   - name: databricks_workspace_name

--- a/templates/shared_services/gitea/parameters.json
+++ b/templates/shared_services/gitea/parameters.json
@@ -39,6 +39,12 @@
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/gitea/porter.yaml
+++ b/templates/shared_services/gitea/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-gitea
-version: 0.5.0
+version: 0.5.1
 description: "A Gitea shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -47,6 +47,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 mixins:
   - terraform:

--- a/templates/shared_services/sonatype-nexus-vm/parameters.json
+++ b/templates/shared_services/sonatype-nexus-vm/parameters.json
@@ -45,6 +45,12 @@
       "source": {
         "env": "SSL_CERT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/shared_services/sonatype-nexus-vm/porter.yaml
+++ b/templates/shared_services/sonatype-nexus-vm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-sonatype-nexus
-version: 2.3.0
+version: 2.3.1
 description: "A Sonatype Nexus shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -39,6 +39,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: ssl_cert_name
     type: string
     default: "nexus-ssl"

--- a/templates/workspace_services/azureml/parameters.json
+++ b/templates/workspace_services/azureml/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/azureml/porter.yaml
+++ b/templates/workspace_services/azureml/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-azureml
-version: 0.7.27
+version: 0.7.28
 description: "An Azure TRE service for Azure Machine Learning"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -59,6 +59,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 outputs:
   - name: azureml_workspace_name

--- a/templates/workspace_services/azureml/user_resources/aml_compute/parameters.json
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/parameters.json
@@ -57,6 +57,12 @@
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/azureml/user_resources/aml_compute/porter.yaml
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-user-resource-aml-compute-instance
-version: 0.5.3
+version: 0.5.4
 description: "Azure Machine Learning Compute Instance"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -49,6 +49,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 mixins:
   - exec

--- a/templates/workspace_services/databricks/parameters.json
+++ b/templates/workspace_services/databricks/parameters.json
@@ -51,6 +51,12 @@
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/databricks/porter.yaml
+++ b/templates/workspace_services/databricks/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-databricks
-version: 0.1.72
+version: 0.1.73
 description: "An Azure TRE service for Azure Databricks."
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -44,6 +44,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 outputs:
   - name: databricks_workspace_name

--- a/templates/workspace_services/gitea/parameters.json
+++ b/templates/workspace_services/gitea/parameters.json
@@ -57,6 +57,12 @@
       "source": {
         "env": "AAD_AUTHORITY_URL"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/gitea/porter.yaml
+++ b/templates/workspace_services/gitea/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-service-gitea
-version: 0.7.1
+version: 0.7.2
 description: "A Gitea workspace service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -56,6 +56,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: aad_authority_url
     type: string
     default: "https://login.microsoftonline.com"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/parameters.json
@@ -69,6 +69,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-export-reviewvm
-version: 0.1.3
+version: 0.1.4
 description: "An Azure TRE User Resource Template for reviewing Airlock export requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -61,6 +61,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: os_image
     type: string
     default: "Server 2019 Data Science VM"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/parameters.json
@@ -75,6 +75,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-import-reviewvm
-version: 0.2.3
+version: 0.2.4
 description: "An Azure TRE User Resource Template for reviewing Airlock import requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -70,6 +70,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: os_image
     type: string
     default: "Server 2019 Data Science VM"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/parameters.json
@@ -81,6 +81,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 0.6.3
+version: 0.6.4
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -85,6 +85,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: os_image
     type: string
     default: "Ubuntu 18.04 Data Science VM"

--- a/templates/workspace_services/health-services/parameters.json
+++ b/templates/workspace_services/health-services/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "AAD_AUTHORITY_URL"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/health-services/porter.yaml
+++ b/templates/workspace_services/health-services/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-service-health
-version: 0.1.1
+version: 0.1.2
 description: "An Azure Data Health Services workspace service"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -53,6 +53,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: deploy_fhir
     type: boolean
     default: false

--- a/templates/workspace_services/innereye/parameters.json
+++ b/templates/workspace_services/innereye/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/innereye/porter.yaml
+++ b/templates/workspace_services/innereye/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-innereye
-version: 0.5.1
+version: 0.5.2
 description: "An Azure TRE service for InnerEye Deep Learning"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -51,6 +51,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 mixins:
   - exec

--- a/templates/workspace_services/mlflow/parameters.json
+++ b/templates/workspace_services/mlflow/parameters.json
@@ -51,6 +51,12 @@
       "source": {
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/mlflow/porter.yaml
+++ b/templates/workspace_services/mlflow/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-mlflow
-version: 0.6.4
+version: 0.6.5
 description: "An Azure TRE service for MLflow machine learning lifecycle"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -55,6 +55,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
 
 outputs:
   - name: internal_connection_uri

--- a/templates/workspace_services/mysql/parameters.json
+++ b/templates/workspace_services/mysql/parameters.json
@@ -57,6 +57,12 @@
       "source": {
         "env": "WORKSPACE_ID"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspace_services/mysql/porter.yaml
+++ b/templates/workspace_services/mysql/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-service-mysql
-version: 0.3.3
+version: 0.3.4
 description: "A MySQL workspace service"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -41,6 +41,10 @@ parameters:
     env: ARM_USE_MSI
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: sql_sku
     type: string
     default: "GP | 5GB 2vCores"

--- a/templates/workspaces/airlock-import-review/parameters.json
+++ b/templates/workspaces/airlock-import-review/parameters.json
@@ -129,6 +129,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspaces/airlock-import-review/porter.yaml
+++ b/templates/workspaces/airlock-import-review/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-airlock-import-review
-version: 0.9.1
+version: 0.9.2
 description: "A workspace to do Airlock Data Import Reviews for Azure TRE"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -54,6 +54,10 @@ parameters:
   - name: arm_use_msi
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: enable_local_debugging
     type: boolean
     default: false

--- a/templates/workspaces/unrestricted/parameters.json
+++ b/templates/workspaces/unrestricted/parameters.json
@@ -141,6 +141,12 @@
       "source": {
         "env": "AZ_CLOUD_ENVIRONMENT"
       }
+    },
+    {
+      "name": "arm_environment",
+      "source": {
+        "env": "ARM_ENVIRONMENT"
+      }
     }
   ]
 }

--- a/templates/workspaces/unrestricted/porter.yaml
+++ b/templates/workspaces/unrestricted/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-unrestricted
-version: 0.8.2
+version: 0.8.3
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -54,6 +54,10 @@ parameters:
   - name: arm_use_msi
     type: boolean
     default: false
+  - name: arm_environment
+    env: ARM_ENVIRONMENT
+    type: string
+    default: "public"
   - name: shared_storage_quota
     type: integer
     default: 50


### PR DESCRIPTION
# Resolves #3309 

## What is being addressed

Added ARM_ENVIRONMENT as a porter parameter so it will be added as an environment variables in porter's bundle installation containers.

**NOTE:**
the parameter was added to all templates except for: firewall, workspace-base, guac-service, guac-windows-vm.
As for these, the parameter will be added in the integration's PR