### PR TITLE
Add RP_BUNDLE_VALUES to PR Bot

### DIFF
--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -177,3 +177,4 @@ jobs:
       TRE_ID: ${{ format('tre{0}', needs.pr_comment.outputs.prRefId) }}
       CI_CACHE_ACR_NAME: ${{ secrets.ACR_NAME }}
       TF_LOG: ${{ secrets.TF_LOG }}
+      RP_BUNDLE_VALUES: ${{ secrets.RP_BUNDLE_VALUES }}


### PR DESCRIPTION
## What is being addressed

The `RP_BUNDLE_VALUES` parameter was missing when a deployment was started by the PR bot.
