### PR TITLE
Add workflow default to RP_BUNDLE_VALUES

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -202,8 +202,10 @@ runs:
             && inputs.ENABLE_SWAGGER) || 'false' }}" \
           -e SWAGGER_UI_CLIENT_ID="${{ inputs.SWAGGER_UI_CLIENT_ID }}" \
           -e TF_VAR_swagger_ui_client_id="${{ inputs.SWAGGER_UI_CLIENT_ID }}" \
-          -e TF_VAR_core_address_space="${{ (inputs.CORE_ADDRESS_SPACE != '' && inputs.CORE_ADDRESS_SPACE) || '10.0.0.0/22' }}" \
-          -e TF_VAR_tre_address_space="${{ (inputs.TRE_ADDRESS_SPACE != '' && inputs.TRE_ADDRESS_SPACE) || '10.0.0.0/16' }}" \
+          -e TF_VAR_core_address_space="${{ (inputs.CORE_ADDRESS_SPACE != ''
+            && inputs.CORE_ADDRESS_SPACE) || '10.0.0.0/22' }}" \
+          -e TF_VAR_tre_address_space="${{ (inputs.TRE_ADDRESS_SPACE != ''
+            && inputs.TRE_ADDRESS_SPACE) || '10.0.0.0/16' }}" \
           -e API_CLIENT_ID="${{ inputs.API_CLIENT_ID }}" \
           -e AAD_TENANT_ID="${{ inputs.AAD_TENANT_ID }}" \
           -e TRE_ID="${{ inputs.TRE_ID }}" \
@@ -223,7 +225,8 @@ runs:
             && inputs.CORE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
           -e WORKSPACE_APP_SERVICE_PLAN_SKU="${{ (inputs.WORKSPACE_APP_SERVICE_PLAN_SKU != ''
             && inputs.WORKSPACE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
-          -e TF_VAR_rp_bundle_values='${{ (toJson(inputs.RP_BUNDLE_VALUES) != '""' && inputs.RP_BUNDLE_VALUES) || '{}' }}' \
+          -e TF_VAR_rp_bundle_values='${{ (toJson(inputs.RP_BUNDLE_VALUES) != '""'
+            && inputs.RP_BUNDLE_VALUES) || '{}' }}' \
           -e TF_VAR_resource_processor_number_processes_per_instance="${{ (inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE != ''
             && inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE) || 5 }}" \
           -e E2E_TESTS_NUMBER_PROCESSES="${{ inputs.E2E_TESTS_NUMBER_PROCESSES }}" \

--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -223,7 +223,7 @@ runs:
             && inputs.CORE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
           -e WORKSPACE_APP_SERVICE_PLAN_SKU="${{ (inputs.WORKSPACE_APP_SERVICE_PLAN_SKU != ''
             && inputs.WORKSPACE_APP_SERVICE_PLAN_SKU) || 'P1v2' }}" \
-          -e TF_VAR_rp_bundle_values='${{ inputs.RP_BUNDLE_VALUES }}' \
+          -e TF_VAR_rp_bundle_values='${{ (toJson(inputs.RP_BUNDLE_VALUES) != '""' && inputs.RP_BUNDLE_VALUES) || '{}' }}' \
           -e TF_VAR_resource_processor_number_processes_per_instance="${{ (inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE != ''
             && inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE) || 5 }}" \
           -e E2E_TESTS_NUMBER_PROCESSES="${{ inputs.E2E_TESTS_NUMBER_PROCESSES }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ ENHANCEMENTS:
 BUG FIXES:
 * Fix ENABLE_SWAGGER configuration being ignored in CI ([#3355](https://github.com/microsoft/AzureTRE/pull/3355))
 * Set yq output format when reading a json file ([#3441](https://github.com/microsoft/AzureTRE/pull/3441))
+* Set `{}` as the workflow default for `RP_BUNDLE_VALUES` parameter ([#3444](https://github.com/microsoft/AzureTRE/pull/3444))
 
 COMPONENTS:
 


### PR DESCRIPTION
## What is being addressed

`RP_BUNDLE_VALUES` is an optional variable but its workflow default is an empty string (as is for any secret/var we use in the reusable workflow). That is invalid value in Terraform as the variable is defined as a map.

## How is this addressed

- Add `{}` as the workflow default for the param.