### PR TITLE
Include AzureML FQDN as a bundle output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 * Update Guacamole to version 1.5.1 ([#3443](https://github.com/microsoft/AzureTRE/issues/3443))
 
 BUG FIXES:
+* AML workspace service fails to install and puts firewall into failed state ([#3448](https://github.com/microsoft/AzureTRE/issues/3448))
 
 COMPONENTS:
 

--- a/templates/workspace_services/azureml/porter.yaml
+++ b/templates/workspace_services/azureml/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-azureml
-version: 0.8.1
+version: 0.8.8
 description: "An Azure TRE service for Azure Machine Learning"
 registry: azuretre
 dockerfile: Dockerfile.tmpl
@@ -115,6 +115,11 @@ outputs:
     applyTo:
       - install
       - upgrade
+  - name: aml_fqdn
+    type: string
+    applyTo:
+      - install
+      - upgrade
 
 mixins:
   - terraform:
@@ -155,6 +160,7 @@ install:
         - name: storage_tag
         - name: batch_tag
         - name: mcr_tag
+        - name: aml_fqdn
 
 upgrade:
   - terraform:
@@ -188,6 +194,7 @@ upgrade:
         - name: storage_tag
         - name: batch_tag
         - name: mcr_tag
+        - name: aml_fqdn
 
 uninstall:
   - terraform:

--- a/templates/workspace_services/azureml/porter.yaml
+++ b/templates/workspace_services/azureml/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-azureml
-version: 0.8.8
+version: 0.8.2
 description: "An Azure TRE service for Azure Machine Learning"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/azureml/terraform/outputs.tf
+++ b/templates/workspace_services/azureml/terraform/outputs.tf
@@ -11,7 +11,7 @@ output "azureml_storage_account_id" {
 }
 
 output "aml_fqdn" {
-  value = module.terraform_azurerm_environment_configuration.aml_studio_endpoint
+  value = regex("(?:(?P<scheme>[^:/?#]+):)?(?://(?P<fqdn>[^/?#:]*))?", module.terraform_azurerm_environment_configuration.aml_studio_endpoint).fqdn
 }
 
 output "connection_uri" {


### PR DESCRIPTION
# Resolves #3448 

## What is being addressed

Output the Aml service fqdn as a bundle output. This is needed for the next step where it is added to the firewall rules.


