### PR TITLE
Update docs for Application Admin identity

### DIFF
--- a/docs/tre-admins/identities/application_admin.md
+++ b/docs/tre-admins/identities/application_admin.md
@@ -21,7 +21,7 @@ This user is currently only used from the Porter bundles hosted on the Resource 
 
 ## How to create
 ```bash
-./scripts/aad/create_application_administrator.sh \
+./devops/scripts/aad/create_application_administrator.sh \
 --name "${TRE_ID}" --admin-consent --application-permission "${APPLICATION_PERMISSION}"
 ```
 

--- a/docs/tre-admins/identities/application_admin.md
+++ b/docs/tre-admins/identities/application_admin.md
@@ -24,10 +24,11 @@ This user is currently only used from the Porter bundles hosted on the Resource 
 ./scripts/aad/create_application_administrator.sh \
 --name "${TRE_ID}" --admin-consent --application-permission "${APPLICATION_PERMISSION}"
 ```
+
 | Argument | Description |
 | -------- | ----------- |
 | `--name` | This is used to put a friendly name to the Application that can be seen in the portal. It is typical to use the name of your TRE instance. |
-| `--admin-consent` | If you have the appropriate permission to grant admin consent, then pass in this argument. If you do not, you will have to ask an AAD Admin to consent after you have created the identity. Consent is required for this permission.
+| `--admin-consent` | If you have the appropriate permission to grant admin consent, then pass in this argument. If you do not, you will have to ask an AAD Admin to consent after you have created the identity. Consent is required for this permission. |
 | `--application-permission` | This  is a comma seperated list of the permissions that need to be assigned. For exampler `Application.ReadWrite.All,Directory.Read.All,Group.ReadWrite.All` |
 | `--reset-password` | Optional, default is 0. When run in a headless fashion, 1 is passed in to always reset the password. |
 


### PR DESCRIPTION
## What is being addressed

- Layout of the generated documentation.
- Fix path to script.

## How is this addressed

- Add missing `|` at the end of a line.
- Add `/devops` to the script path in the example command.
