### PR TITLE
Terraform handles peering sync natively

### DIFF
--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 1.2.3
+version: 1.3.0
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -162,10 +162,6 @@ install:
         enable_local_debugging: ${ bundle.parameters.enable_local_debugging }
         register_aad_application: ${ bundle.parameters.register_aad_application }
         create_aad_groups: ${ bundle.parameters.create_aad_groups }
-        arm_tenant_id: ${ bundle.credentials.azure_tenant_id }
-        arm_client_id: ${ bundle.credentials.azure_client_id }
-        arm_client_secret: ${ bundle.credentials.azure_client_secret }
-        arm_use_msi: ${ bundle.parameters.arm_use_msi }
         auth_client_id: ${ bundle.credentials.auth_client_id }
         auth_client_secret: ${ bundle.credentials.auth_client_secret }
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
@@ -207,10 +203,6 @@ upgrade:
         enable_local_debugging: ${ bundle.parameters.enable_local_debugging }
         register_aad_application: ${ bundle.parameters.register_aad_application }
         create_aad_groups: ${ bundle.parameters.create_aad_groups }
-        arm_tenant_id: ${ bundle.credentials.azure_tenant_id }
-        arm_client_id: ${ bundle.credentials.azure_client_id }
-        arm_client_secret: ${ bundle.credentials.azure_client_secret }
-        arm_use_msi: ${ bundle.parameters.arm_use_msi }
         auth_client_id: ${ bundle.credentials.auth_client_id }
         auth_client_secret: ${ bundle.credentials.auth_client_secret }
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
@@ -276,10 +268,6 @@ uninstall:
         enable_local_debugging: ${ bundle.parameters.enable_local_debugging }
         register_aad_application: ${ bundle.parameters.register_aad_application }
         create_aad_groups: ${ bundle.parameters.create_aad_groups }
-        arm_tenant_id: ${ bundle.credentials.azure_tenant_id }
-        arm_client_id: ${ bundle.credentials.azure_client_id }
-        arm_client_secret: ${ bundle.credentials.azure_client_secret }
-        arm_use_msi: ${ bundle.parameters.arm_use_msi }
         auth_client_id: ${ bundle.credentials.auth_client_id }
         auth_client_secret: ${ bundle.credentials.auth_client_secret }
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }

--- a/templates/workspaces/base/terraform/network/variables.tf
+++ b/templates/workspaces/base/terraform/network/variables.tf
@@ -4,11 +4,5 @@ variable "address_spaces" {}
 variable "ws_resource_group_name" {}
 variable "tre_workspace_tags" {}
 variable "tre_resource_id" {}
-variable "arm_use_msi" {
-  type = bool
-}
-variable "arm_tenant_id" {}
-variable "arm_client_id" {}
-variable "arm_client_secret" {}
 variable "arm_environment" {}
 variable "azure_environment" {}

--- a/templates/workspaces/base/terraform/variables.tf
+++ b/templates/workspaces/base/terraform/variables.tf
@@ -118,11 +118,6 @@ variable "workspace_owner_object_id" {
   default     = ""
   description = "The Object Id of the user that you wish to be the Workspace Owner. E.g. the TEST_AUTOMATION_ACCOUNT."
 }
-variable "arm_use_msi" {
-  type = bool
-}
-variable "arm_tenant_id" {}
-variable "arm_client_id" {}
-variable "arm_client_secret" {}
+
 variable "arm_environment" {}
 variable "azure_environment" {}

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -24,10 +24,6 @@ module "network" {
   ws_resource_group_name = azurerm_resource_group.ws.name
   tre_resource_id        = var.tre_resource_id
   tre_workspace_tags     = local.tre_workspace_tags
-  arm_use_msi            = var.arm_use_msi
-  arm_tenant_id          = var.arm_tenant_id
-  arm_client_id          = var.arm_client_id
-  arm_client_secret      = var.arm_client_secret
   arm_environment        = var.arm_environment
   azure_environment      = var.azure_environment
 }


### PR DESCRIPTION
## What is being addressed

We correctly use AZCLI from within terraform to force network peering sync when there's an address space change.

## How is this addressed

- AzureRM 3.47 improved the ability for Terraform to handle this situation natively. So I've removed the script logic and all associated properties.