### PR TITLE
Fix how load_env splits values with `=` sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
 BUG FIXES:
 * Nexus might fail to deploy due to wrong identity used in key-vault extension ([#3492](https://github.com/microsoft/AzureTRE/issues/3492))
 * Airlock notifier needs SCM basic-auth enabled to install ([#3509](https://github.com/microsoft/AzureTRE/issues/3509))
+* `load_env.sh` is able to use an equal `=` sign in values ([#3535](https://github.com/microsoft/AzureTRE/issues/3535))
 
 COMPONENTS:
 

--- a/devops/scripts/load_env.sh
+++ b/devops/scripts/load_env.sh
@@ -20,8 +20,8 @@ else
   while read -r line
   do
     # split the line into name/value
-    name=$(echo "$line" | cut -d= -f1)
-    value=$(echo "$line" | cut -d= -f2)
+    IFS='=' read -r name value <<< "$line"
+
     # Create the Terraform var name form, i.e. convert FOO=BAR to TF_VAR_foo=BAR
     tf_name="TF_VAR_$(echo "$name" | tr '[:upper:]' '[:lower:]')"
 


### PR DESCRIPTION
Resolves #3483

## What is being addressed

The load_env.sh script mishandled values that contain an equal sign.

## How is this addressed

- Fix it.