### PR TITLE
Update doc and config schema for tre_id

### DIFF
--- a/config_schema.json
+++ b/config_schema.json
@@ -13,7 +13,7 @@
     "tre_id": {
       "description": "TRE unique identifier",
       "type": "string",
-      "pattern": "^[a-zA-Z 0-9\\_]*$",
+      "pattern": "^[a-z]*$",
       "maxLength": 11
     },
     "management": {

--- a/docs/tre-admins/environment-variables.md
+++ b/docs/tre-admins/environment-variables.md
@@ -21,7 +21,7 @@
 
 | <div style="width: 330px">Environment variable name</div> | Description |
 | ------------------------- | ----------- |
-| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `mytre-dev` will result in a resource group name for Azure TRE instance of `rg-mytre-dev`. This must be less than 12 characters. Allowed characters: Alphanumeric and underscores|
+| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `mytre-dev` will result in a resource group name for Azure TRE instance of `rg-mytre-dev`. This must be less than 12 characters. Allowed characters: lowercase letters|
 | `TRE_URL`| This will be generated for you by populating your `TRE_ID`. This is used so that you can automatically register bundles |
 | `CORE_ADDRESS_SPACE` | The address space for the Azure TRE core virtual network. `/22` or larger. |
 | `TRE_ADDRESS_SPACE` | The address space for the whole TRE environment virtual network where workspaces networks will be created (can include the core network as well). E.g. `10.0.0.0/12`|

--- a/docs/tre-admins/setup-instructions/cicd-pre-deployment-steps.md
+++ b/docs/tre-admins/setup-instructions/cicd-pre-deployment-steps.md
@@ -62,7 +62,7 @@ Configure the following secrets in your github environment:
 
 | <div style="width: 230px">Secret name</div> | Description |
 | ----------- | ----------- |
-| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: Alphanumeric, underscores, and hyphens. |
+| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: lowercase letters. |
 | `MGMT_RESOURCE_GROUP_NAME` | The name of the shared resource group for all Azure TRE core resources. |
 | `MGMT_STORAGE_ACCOUNT_NAME` | The name of the storage account to hold the Terraform state and other deployment artifacts. E.g. `mystorageaccount`. |
 | `ACR_NAME` | A globally unique name for the Azure Container Registry (ACR) that will be created to store deployment images. |

--- a/docs/tre-admins/setup-instructions/setup-auth-entities.md
+++ b/docs/tre-admins/setup-instructions/setup-auth-entities.md
@@ -19,7 +19,7 @@ Next, you will set the configuration variables for the specific Azure TRE instan
 
     The rest of the variables can have their default values.
 
-1. Decide on a name for your `tre_id`, which is an alphanumeric (with underscores allowed) ID for the Azure TRE instance. The value will be used in various Azure resources and AAD application names. It **needs to be globally unique and less than 12 characters in length**. Use only lowercase letters. Choose wisely!
+1. Decide on a name for your `tre_id` ID for the Azure TRE instance. The value will be used in various Azure resources and AAD application names. It **needs to be globally unique and less than 12 characters in length**. Use **only** lowercase letters. Choose wisely!
 1. Once you have decided on which AD Tenant paradigm, then you should be able to set `aad_tenant_id` in the authentication section in your `config.yaml` file.
 1. Your AAD Tenant Admin can now use the terminal window in Visual Studio Code to execute the following script from within the development container to create all the AAD Applications that are used for TRE. The details of the script are covered in the [auth document](../auth.md).
 

--- a/docs/tre-admins/setup-instructions/workflows.md
+++ b/docs/tre-admins/setup-instructions/workflows.md
@@ -63,7 +63,7 @@ Configure the TRE ID and LOCATION repository secrets
 
 | <div style="width: 230px">Secret name</div> | Description |
 | ----------- | ----------- |
-| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: Alphanumeric and underscores. |
+| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: lowercase letters. |
 | `LOCATION` | The Azure location (region) for all resources. E.g. `westeurope` |
 
 ### Create app registrations for API authentication
@@ -123,7 +123,7 @@ Configure additional secrets used in the deployment workflow:
 
 | <div style="width: 230px">Secret name</div> | Description |
 | ----------- | ----------- |
-| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: Alphanumeric, underscores, and hyphens. |
+| `TRE_ID` | A globally unique identifier. `TRE_ID` can be found in the resource names of the Azure TRE instance; for example, a `TRE_ID` of `tre-dev-42` will result in a resource group name for Azure TRE instance of `rg-tre-dev-42`. This must be less than 12 characters. Allowed characters: lowercase letters. |
 | `MGMT_RESOURCE_GROUP_NAME` | The name of the shared resource group for all Azure TRE core resources. |
 | `MGMT_STORAGE_ACCOUNT_NAME` | The name of the storage account to hold the Terraform state and other deployment artifacts. E.g. `mystorageaccount`. |
 | `ACR_NAME` | A globally unique name for the Azure Container Registry (ACR) that will be created to store deployment images. |


### PR DESCRIPTION
# Resolves #3536 

## What is being addressed

The documentation and config.yaml schema suggests underscores can be used in a tre_id. This updates the. documentation and schema to only allow lowercase letters. Maybe hyphens are ok? (looks like all storage accounts use a replace on hyphens but not sure if there are other resources that assume the id only has lowercase letters)

