### PR TITLE
Fix Postgres timeouts when install OHDSI

### DIFF
--- a/templates/workspace_services/ohdsi/porter.yaml
+++ b/templates/workspace_services/ohdsi/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-service-ohdsi
-version: 0.1.70
+version: 0.1.71
 description: "A OHDSI workspace service"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/ohdsi/terraform/atlas_database.tf
+++ b/templates/workspace_services/ohdsi/terraform/atlas_database.tf
@@ -127,6 +127,18 @@ resource "terraform_data" "postgres_core_dns_link" {
   }
 }
 
+resource "terraform_data" "postgres_subnet_wait" {
+  provisioner "local-exec" {
+    command = "sleep 30"
+  }
+
+  depends_on = [
+    azurerm_subnet.postgres,
+    azurerm_subnet_network_security_group_association.postgres,
+    terraform_data.postgres_core_dns_link
+  ]
+}
+
 resource "azurerm_postgresql_flexible_server" "postgres" {
   name                   = "psql-server-${local.service_suffix}"
   resource_group_name    = data.azurerm_resource_group.ws.name
@@ -144,6 +156,10 @@ resource "azurerm_postgresql_flexible_server" "postgres" {
     # If this doesn't complete in a realistic time, no point in waiting the full/default 60m
     create = "15m"
   }
+
+  depends_on = [
+    terraform_data.postgres_subnet_wait,
+  ]
 }
 
 resource "azurerm_postgresql_flexible_server_database" "db" {


### PR DESCRIPTION
## What is being addressed

If OHDSI workspace service is installed after the workspace has already Guacamole in there, then the Postgres will fail to provision due to a timeout.

## How is this addressed

- The reason is unclear, but a short wait between the subnet creation step and the postgres one solves the issue.