### PR TITLE
Fix CLI install dependency issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ BUG FIXES:
 * Fix airlock_notifier not getting the right smtp password ([#3561](https://github.com/microsoft/AzureTRE/issues/3561))
 * Fix issue when deleting failed resources gives no steps ([#3567](https://github.com/microsoft/AzureTRE/issues/3567))
 * Fix airlock_notifier not getting the right smtp password ([#3565](https://github.com/microsoft/AzureTRE/issues/3565))
-* Update CLI install method to fix dependency issue ([#TBD](https://github.com/microsoft/AzureTRE/issues/TBD))
+* Update CLI install method to fix dependency issue ([#3601](https://github.com/microsoft/AzureTRE/issues/3601))
 
 COMPONENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ BUG FIXES:
 * Fix airlock_notifier not getting the right smtp password ([#3561](https://github.com/microsoft/AzureTRE/issues/3561))
 * Fix issue when deleting failed resources gives no steps ([#3567](https://github.com/microsoft/AzureTRE/issues/3567))
 * Fix airlock_notifier not getting the right smtp password ([#3565](https://github.com/microsoft/AzureTRE/issues/3565))
+* Update CLI install method to fix dependency issue ([#TBD](https://github.com/microsoft/AzureTRE/issues/TBD))
 
 COMPONENTS:
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -10,7 +10,7 @@ pip-install: ## install required dependencides
 
 install-cli: ## install CLI (note, run `source <(_TRE_COMPLETE=bash_source tre)` to set up bash completion)
 	sudo rm -rf build dist tre.egg-info
-	sudo python setup.py install
+	sudo pip install .
 
 build-package: ## build package
 	./scripts/build.sh


### PR DESCRIPTION
Resolves #3579

## What is being addressed

The CLI will fail to install on the deployment repo due to a conflicting version with the cryptography dependency.

## How is this addressed

- We used an old method to install the python CLI component (aka `easy_install`) which caused the dependency version resolution failure. Moving to install via `pip` fixes the issue as now the right cryptography version is being discovered and installed.
I've verified this works in the deployment repo too.