### PR TITLE
[DRAFT] Added support to specify tags in the config.yaml that will be applied to all resources deployed by TRE

### DIFF
--- a/.github/actions/devcontainer_run_command/action.yml
+++ b/.github/actions/devcontainer_run_command/action.yml
@@ -121,6 +121,9 @@ inputs:
     description: "JSON string containing key/value pairs to injet into the Resource Processor as ENV vars"
     required: false
     default: ""
+  TAGS:
+    description: "Tags to apply to all Azure resources"
+    required: false
 
 runs:
   using: composite
@@ -231,4 +234,8 @@ runs:
             && inputs.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE) || 5 }}" \
           -e E2E_TESTS_NUMBER_PROCESSES="${{ inputs.E2E_TESTS_NUMBER_PROCESSES }}" \
           '${{ inputs.CI_CACHE_ACR_NAME }}${{ env.ACR_DOMAIN_SUFFIX }}/tredev:${{ inputs.DEVCONTAINER_TAG }}' \
+          -e TAGS='${{ (toJson(inputs.TAGS) != '""'
+            && inputs.TAGS) || '{}' }}' \
+          -e TF_VAR_tags='${{ (toJson(inputs.TAGS) != '""'
+            && inputs.TAGS) || '{}' }}' \
         bash -c "${{ inputs.COMMAND }}"

--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -243,6 +243,7 @@ jobs:
           TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
           MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
+          TAGS: ${{ vars.TAGS }}
 
       - name: ACR Login
         # failure in the first attempt indicates a new ACR, so we need to try again after it's been created
@@ -353,6 +354,7 @@ jobs:
           CORE_APP_SERVICE_PLAN_SKU: ${{ vars.CORE_APP_SERVICE_PLAN_SKU }}
           RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE: ${{ vars.RESOURCE_PROCESSOR_NUMBER_PROCESSES_PER_INSTANCE }}
           RP_BUNDLE_VALUES: ${{ vars.RP_BUNDLE_VALUES }}
+          TAGS: ${{ vars.TAGS }}
 
       - name: API Healthcheck
         uses: ./.github/actions/devcontainer_run_command
@@ -522,6 +524,7 @@ jobs:
           TRE_ID: ${{ secrets.TRE_ID }}
           LOCATION: ${{ vars.LOCATION }}
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
+          TAGS: ${{ vars.TAGS }}
 
   register_bundles:
     name: Register Bundles
@@ -582,6 +585,7 @@ jobs:
           TRE_ID: ${{ secrets.TRE_ID }}
           LOCATION: ${{ vars.LOCATION }}
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
+          TAGS: ${{ vars.TAGS }}
 
   register_user_resource_bundles:
     name: Register User Resource Bundles
@@ -632,6 +636,7 @@ jobs:
           LOCATION: ${{ vars.LOCATION }}
           BUNDLE_TYPE: ${{ matrix.BUNDLE_TYPE }}
           WORKSPACE_SERVICE_NAME: ${{ matrix.WORKSPACE_SERVICE_NAME }}
+          TAGS: ${{ vars.TAGS }}
 
   deploy_shared_services:
     name: Deploy shared services
@@ -662,6 +667,7 @@ jobs:
           TEST_ACCOUNT_CLIENT_SECRET: "${{ secrets.TEST_ACCOUNT_CLIENT_SECRET }}"
           TRE_ID: ${{ secrets.TRE_ID }}
           LOCATION: ${{ vars.LOCATION }}
+          TAGS: ${{ vars.TAGS }}
 
       - name: State Store Migrations
         uses: ./.github/actions/devcontainer_run_command
@@ -681,6 +687,7 @@ jobs:
           TERRAFORM_STATE_CONTAINER_NAME: ${{ vars.TERRAFORM_STATE_CONTAINER_NAME }}
           MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
+          TAGS: ${{ vars.TAGS }}
 
   deploy_ui:
     name: Deploy UI
@@ -711,6 +718,7 @@ jobs:
           MGMT_RESOURCE_GROUP_NAME: ${{ secrets.MGMT_RESOURCE_GROUP_NAME }}
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
           SWAGGER_UI_CLIENT_ID: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
+          TAGS: ${{ vars.TAGS }}
 
   e2e_tests_smoke:
     name: "Run E2E Tests (Smoke)"
@@ -746,6 +754,7 @@ jobs:
           TRE_ID: ${{ secrets.TRE_ID }}
           IS_API_SECURED: false
           WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ vars.WORKSPACE_APP_SERVICE_PLAN_SKU }}
+          TAGS: ${{ vars.TAGS }}
 
       - name: Upload Test Results
         if: always()
@@ -790,6 +799,7 @@ jobs:
           IS_API_SECURED: false
           WORKSPACE_APP_SERVICE_PLAN_SKU: ${{ vars.WORKSPACE_APP_SERVICE_PLAN_SKU }}
           E2E_TESTS_NUMBER_PROCESSES: ${{ inputs.E2E_TESTS_NUMBER_PROCESSES }}
+          TAGS: ${{ vars.TAGS }}
 
       - name: Upload Test Results
         if: always()

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -76,3 +76,7 @@ developer_settings:
 
 # Used by the API and Resource processor application to change log level
 #  debug: true
+
+# Specify here tags that should be applied to all resources deployed by the TRE
+# tag_name: "tag_value"
+#  tags: '{"tag_key": "tag_value"}'

--- a/core/terraform/appgateway/locals.tf
+++ b/core/terraform/appgateway/locals.tf
@@ -24,10 +24,12 @@ locals {
   redirect_configuration_name        = "rdrcfg-tosecure"
 
   certificate_name = "cert-primary"
-  tre_core_tags = {
-    tre_id              = var.tre_id
-    tre_core_service_id = var.tre_id
-  }
+  tre_core_tags = merge(
+    var.tre_core_tags, {
+      tre_id              = var.tre_id
+      tre_core_service_id = var.tre_id
+    }
+  )
 
   appgateway_diagnostic_categories_enabled = ["ApplicationGatewayAccessLog", "ApplicationGatewayPerformanceLog", "ApplicationGatewayFirewallLog"]
 }

--- a/core/terraform/appgateway/variables.tf
+++ b/core/terraform/appgateway/variables.tf
@@ -8,3 +8,8 @@ variable "api_fqdn" {}
 variable "keyvault_id" {}
 variable "static_web_dns_zone_id" {}
 variable "log_analytics_workspace_id" {}
+variable "tre_core_tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/core/terraform/locals.tf
+++ b/core/terraform/locals.tf
@@ -1,9 +1,11 @@
 locals {
   myip = var.public_deployment_ip_address != "" ? var.public_deployment_ip_address : chomp(data.http.myip[0].response_body)
-  tre_core_tags = {
-    tre_id              = var.tre_id
-    tre_core_service_id = var.tre_id
-  }
+  tre_core_tags = merge(
+    var.tags, {
+      tre_id              = var.tre_id
+      tre_core_service_id = var.tre_id
+    }
+  )
 
   api_diagnostic_categories_enabled = [
     "AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs", "AppServiceFileAuditLogs",

--- a/core/terraform/main.tf
+++ b/core/terraform/main.tf
@@ -42,12 +42,13 @@ provider "azurerm" {
 resource "azurerm_resource_group" "core" {
   location = var.location
   name     = "rg-${var.tre_id}"
-  tags = {
-    project    = "Azure Trusted Research Environment"
-    tre_id     = var.tre_id
-    source     = "https://github.com/microsoft/AzureTRE/"
-    ci_git_ref = var.ci_git_ref # TODO: not include if empty
-  }
+  tags = merge(
+    local.tre_core_tags, {
+      project    = "Azure Trusted Research Environment"
+      tre_id     = var.tre_id
+      source     = "https://github.com/microsoft/AzureTRE/"
+      ci_git_ref = var.ci_git_ref # TODO: not include if empty
+  })
 
   lifecycle { ignore_changes = [tags] }
 }
@@ -91,6 +92,7 @@ module "appgateway" {
   keyvault_id                = azurerm_key_vault.kv.id
   static_web_dns_zone_id     = module.network.static_web_dns_zone_id
   log_analytics_workspace_id = module.azure_monitor.log_analytics_workspace_id
+  tre_core_tags              = local.tre_core_tags
 
   depends_on = [
     module.network,
@@ -159,6 +161,7 @@ module "resource_processor_vmss_porter" {
   resource_processor_vmss_sku                      = var.resource_processor_vmss_sku
   arm_environment                                  = var.arm_environment
   rp_bundle_values                                 = var.rp_bundle_values
+  tre_core_tags                                    = local.tre_core_tags
 
   depends_on = [
     module.network,

--- a/core/terraform/network/locals.tf
+++ b/core/terraform/network/locals.tf
@@ -22,10 +22,12 @@ locals {
   # FREE = local.core_services_vnet_subnets[11] # .128 - .191
   # FREE = local.core_services_vnet_subnets[12] # .192 - .254
 
-  tre_core_tags = {
-    tre_id              = var.tre_id
-    tre_core_service_id = var.tre_id
-  }
+  tre_core_tags = merge(
+    var.tre_core_tags, {
+      tre_id              = var.tre_id
+      tre_core_service_id = var.tre_id
+    }
+  )
 
 
   private_dns_zone_names = toset([

--- a/core/terraform/network/variables.tf
+++ b/core/terraform/network/variables.tf
@@ -3,3 +3,8 @@ variable "location" {}
 variable "resource_group_name" {}
 variable "core_address_space" {}
 variable "arm_environment" {}
+variable "tre_core_tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/core/terraform/resource_processor/vmss_porter/locals.tf
+++ b/core/terraform/resource_processor/vmss_porter/locals.tf
@@ -1,9 +1,11 @@
 locals {
   version = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
-  tre_core_tags = {
-    tre_id              = var.tre_id
-    tre_core_service_id = var.tre_id
-  }
+  tre_core_tags = merge(
+    var.tre_core_tags, {
+      tre_id              = var.tre_id
+      tre_core_service_id = var.tre_id
+    }
+  )
 
   azure_environment = lookup({
     "public"       = "AzureCloud"

--- a/core/terraform/resource_processor/vmss_porter/variables.tf
+++ b/core/terraform/resource_processor/vmss_porter/variables.tf
@@ -32,3 +32,9 @@ variable "rp_bundle_values" {
 locals {
   rp_bundle_values_formatted = join("\n      ", [for key in keys(var.rp_bundle_values) : "RP_BUNDLE_${key}=${var.rp_bundle_values[key]}"])
 }
+
+variable "tre_core_tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/core/terraform/variables.tf
+++ b/core/terraform/variables.tf
@@ -180,3 +180,9 @@ variable "is_cosmos_defined_throughput" {
   type    = bool
   default = false
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/devops/terraform/bootstrap.sh
+++ b/devops/terraform/bootstrap.sh
@@ -6,12 +6,16 @@ set -o nounset
 # Baseline Azure resources
 echo -e "\n\e[34m»»» 🤖 \e[96mCreating resource group and storage account\e[0m..."
 # shellcheck disable=SC2154
-az group create --resource-group "$TF_VAR_mgmt_resource_group_name" --location "$LOCATION" -o table
+az group create --resource-group "$TF_VAR_mgmt_resource_group_name" \
+  --location "$LOCATION" \
+  -o table \
+  --tags $(echo "$TAGS" | jq -r 'to_entries | map("\(.key)=\(.value)")| join(" ")') 
 # shellcheck disable=SC2154
 az storage account create --resource-group "$TF_VAR_mgmt_resource_group_name" \
   --name "$TF_VAR_mgmt_storage_account_name" --location "$LOCATION" \
   --allow-blob-public-access false \
-  --kind StorageV2 --sku Standard_LRS -o table
+  --kind StorageV2 --sku Standard_LRS -o table \
+  --tags $(echo "$TAGS" | jq -r 'to_entries | map("\(.key)=\(.value)")| join(" ")')
 
 # Blob container
 # shellcheck disable=SC2154

--- a/devops/terraform/main.tf
+++ b/devops/terraform/main.tf
@@ -7,10 +7,10 @@ resource "azurerm_resource_group" "mgmt" {
   name     = var.mgmt_resource_group_name
   location = var.location
 
-  tags = {
+  tags = merge(var.tags, {
     project = "Azure Trusted Research Environment"
     source  = "https://github.com/microsoft/AzureTRE/"
-  }
+  })
 
   lifecycle { ignore_changes = [tags] }
 }
@@ -25,6 +25,8 @@ resource "azurerm_storage_account" "state_storage" {
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = false
 
+  tags = var.tags
+
   lifecycle { ignore_changes = [tags] }
 }
 
@@ -36,6 +38,8 @@ resource "azurerm_container_registry" "shared_acr" {
   sku                 = var.acr_sku
   admin_enabled       = true
 
+  tags = var.tags
+
   lifecycle { ignore_changes = [tags] }
 }
 
@@ -44,6 +48,8 @@ resource "azurerm_container_registry" "shared_acr" {
 resource "azurerm_container_registry_task" "tredev_purge" {
   name                  = "tredev_purge"
   container_registry_id = azurerm_container_registry.shared_acr.id
+  tags                  = var.tags
+  
   platform {
     os           = "Linux"
     architecture = "amd64"

--- a/devops/terraform/variables.tf
+++ b/devops/terraform/variables.tf
@@ -23,3 +23,10 @@ variable "acr_name" {
   type        = string
   description = "Name of ACR"
 }
+
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/admin-vm/parameters.json
+++ b/templates/shared_services/admin-vm/parameters.json
@@ -45,6 +45,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/admin-vm/porter.yaml
+++ b/templates/shared_services/admin-vm/porter.yaml
@@ -40,6 +40,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: admin_jumpbox_vm_sku
     env: ADMIN_JUMPBOX_VM_SKU
     type: string
@@ -56,6 +61,7 @@ install:
         tre_id: ${ bundle.parameters.tre_id }
         tre_resource_id: ${ bundle.parameters.id }
         admin_jumpbox_vm_sku: ${ bundle.parameters.admin_jumpbox_vm_sku }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -69,6 +75,7 @@ upgrade:
         tre_id: ${ bundle.parameters.tre_id }
         tre_resource_id: ${ bundle.parameters.id }
         admin_jumpbox_vm_sku: ${ bundle.parameters.admin_jumpbox_vm_sku }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -82,6 +89,7 @@ uninstall:
         tre_id: ${ bundle.parameters.tre_id }
         tre_resource_id: ${ bundle.parameters.id }
         admin_jumpbox_vm_sku: ${ bundle.parameters.admin_jumpbox_vm_sku }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/admin-vm/terraform/locals.tf
+++ b/templates/shared_services/admin-vm/terraform/locals.tf
@@ -2,8 +2,11 @@ locals {
   core_vnet                = "vnet-${var.tre_id}"
   core_resource_group_name = "rg-${var.tre_id}"
   keyvault_name            = "kv-${var.tre_id}"
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/shared_services/admin-vm/terraform/variables.tf
+++ b/templates/shared_services/admin-vm/terraform/variables.tf
@@ -11,3 +11,9 @@ variable "tre_resource_id" {
 variable "admin_jumpbox_vm_sku" {
   type = string
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/airlock_notifier/parameters.json
+++ b/templates/shared_services/airlock_notifier/parameters.json
@@ -87,6 +87,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/airlock_notifier/porter.yaml
+++ b/templates/shared_services/airlock_notifier/porter.yaml
@@ -70,6 +70,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 mixins:
   - exec
@@ -91,6 +96,7 @@ install:
         smtp_password: ${ bundle.parameters.smtpPassword }
         smtp_server_enable_ssl: ${ bundle.parameters.smtp_server_enable_ssl }
         smtp_from_email: ${ bundle.parameters.smtp_from_email }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -169,6 +175,7 @@ uninstall:
         smtp_password: ${ bundle.parameters.smtpPassword }
         smtp_server_enable_ssl: ${ bundle.parameters.smtp_server_enable_ssl }
         smtp_from_email: ${ bundle.parameters.smtp_from_email }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/airlock_notifier/terraform/locals.tf
+++ b/templates/shared_services/airlock_notifier/terraform/locals.tf
@@ -5,9 +5,11 @@ locals {
   topic_name_suffix                                = "v2-${var.tre_id}"
   notification_topic_name                          = "evgt-airlock-notification-${local.topic_name_suffix}"
   airlock_notification_eventgrid_subscription_name = "evgs-airlock-notification"
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
   default_tre_url = "https://${data.azurerm_public_ip.app_gateway_ip.fqdn}"
 }

--- a/templates/shared_services/airlock_notifier/terraform/variables.tf
+++ b/templates/shared_services/airlock_notifier/terraform/variables.tf
@@ -39,3 +39,9 @@ variable "smtp_server_enable_ssl" {
   type    = bool
   default = false
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/certs/parameters.json
+++ b/templates/shared_services/certs/parameters.json
@@ -57,6 +57,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/certs/porter.yaml
+++ b/templates/shared_services/certs/porter.yaml
@@ -42,6 +42,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: domain_prefix
     type: string
     description: "The FQDN prefix (prepended to {TRE_ID}.{LOCATION}.cloudapp.azure.com) to generate certificate for"
@@ -67,6 +72,7 @@ install:
         domain_prefix: ${ bundle.parameters.domain_prefix }
         cert_name: ${ bundle.parameters.cert_name }
         tre_resource_id: ${ bundle.parameters.id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -130,6 +136,7 @@ uninstall:
         domain_prefix: ${ bundle.parameters.domain_prefix }
         cert_name: ${ bundle.parameters.cert_name }
         tre_resource_id: ${ bundle.parameters.id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/certs/terraform/locals.tf
+++ b/templates/shared_services/certs/terraform/locals.tf
@@ -19,8 +19,10 @@ locals {
   request_routing_rule_name          = "rqrt-certs-application"
   redirect_configuration_name        = "rdrcfg-certs-tosecure"
 
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/shared_services/certs/terraform/variables.tf
+++ b/templates/shared_services/certs/terraform/variables.tf
@@ -14,3 +14,9 @@ variable "tre_resource_id" {
   type        = string
   description = "Resource ID"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/cyclecloud/parameters.json
+++ b/templates/shared_services/cyclecloud/parameters.json
@@ -45,6 +45,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/cyclecloud/porter.yaml
+++ b/templates/shared_services/cyclecloud/porter.yaml
@@ -46,6 +46,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: connection_uri
@@ -72,6 +77,7 @@ install:
         arm_use_msi: ${ bundle.parameters.arm_use_msi }
         tre_resource_id: ${ bundle.parameters.id }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -91,6 +97,7 @@ upgrade:
         arm_use_msi: ${ bundle.parameters.arm_use_msi }
         tre_resource_id: ${ bundle.parameters.id }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -110,6 +117,7 @@ uninstall:
         arm_use_msi: ${ bundle.parameters.arm_use_msi }
         tre_resource_id: ${ bundle.parameters.id }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/cyclecloud/terraform/locals.tf
+++ b/templates/shared_services/cyclecloud/terraform/locals.tf
@@ -4,8 +4,10 @@ locals {
   short_service_id         = substr(var.tre_resource_id, -4, -1)
   vm_name                  = "cyclecloud-${local.short_service_id}"
   storage_name             = lower(replace("stgcc${var.tre_id}${local.short_service_id}", "-", ""))
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/shared_services/cyclecloud/terraform/variables.tf
+++ b/templates/shared_services/cyclecloud/terraform/variables.tf
@@ -1,3 +1,9 @@
 variable "tre_id" {}
 variable "tre_resource_id" {}
 variable "arm_environment" {}
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}
+

--- a/templates/shared_services/databricks-auth/parameters.json
+++ b/templates/shared_services/databricks-auth/parameters.json
@@ -39,6 +39,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/databricks-auth/porter.yaml
+++ b/templates/shared_services/databricks-auth/porter.yaml
@@ -42,6 +42,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: databricks_workspace_name
@@ -61,6 +66,7 @@ install:
         tre_resource_id: ${ bundle.parameters.id }
         tre_id: ${ bundle.parameters.tre_id }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -76,6 +82,7 @@ upgrade:
         tre_resource_id: ${ bundle.parameters.id }
         tre_id: ${ bundle.parameters.tre_id }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -91,6 +98,7 @@ uninstall:
         tre_resource_id: ${ bundle.parameters.id }
         tre_id: ${ bundle.parameters.tre_id }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/databricks-auth/terraform/locals.tf
+++ b/templates/shared_services/databricks-auth/terraform/locals.tf
@@ -14,8 +14,10 @@ locals {
   container_subnet_name          = "adb-container-subnet-${local.service_resource_name_suffix}"
   network_security_group_name    = "nsg-${local.service_resource_name_suffix}"
 
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/shared_services/databricks-auth/terraform/variables.tf
+++ b/templates/shared_services/databricks-auth/terraform/variables.tf
@@ -9,3 +9,9 @@ variable "tre_resource_id" {
 }
 
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/firewall/parameters.json
+++ b/templates/shared_services/firewall/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/firewall/porter.yaml
+++ b/templates/shared_services/firewall/porter.yaml
@@ -54,6 +54,11 @@ parameters:
     default: "graph.microsoft.com"
   - name: arm_environment
     type: string
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 mixins:
   - terraform:
@@ -69,6 +74,7 @@ install:
         api_driven_network_rule_collections_b64: ${ bundle.parameters.network_rule_collections }
         sku_tier: ${ bundle.parameters.sku_tier }
         microsoft_graph_fqdn: ${ bundle.parameters.microsoft_graph_fqdn }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -85,6 +91,7 @@ upgrade:
         api_driven_network_rule_collections_b64: ${ bundle.parameters.network_rule_collections }
         sku_tier: ${ bundle.parameters.sku_tier }
         microsoft_graph_fqdn: ${ bundle.parameters.microsoft_graph_fqdn }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -101,6 +108,7 @@ uninstall:
         api_driven_network_rule_collections_b64: ${ bundle.parameters.network_rule_collections }
         sku_tier: ${ bundle.parameters.sku_tier }
         microsoft_graph_fqdn: ${ bundle.parameters.microsoft_graph_fqdn }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/firewall/terraform/locals.tf
+++ b/templates/shared_services/firewall/terraform/locals.tf
@@ -10,10 +10,12 @@ locals {
     # "AZFWNetworkRule",
     # "AZFWDnsProxy",
   ]
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
 
   api_driven_application_rule_collection = jsondecode(base64decode(var.api_driven_rule_collections_b64))
   api_driven_network_rule_collection     = jsondecode(base64decode(var.api_driven_network_rule_collections_b64))

--- a/templates/shared_services/firewall/terraform/variables.tf
+++ b/templates/shared_services/firewall/terraform/variables.tf
@@ -27,3 +27,9 @@ variable "sku_tier" {
   type    = string
   default = "Standard"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/gitea/parameters.json
+++ b/templates/shared_services/gitea/parameters.json
@@ -45,6 +45,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/gitea/porter.yaml
+++ b/templates/shared_services/gitea/porter.yaml
@@ -51,6 +51,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 mixins:
   - terraform:
@@ -79,6 +84,7 @@ install:
         mgmt_resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         acr_name: ${ bundle.parameters.mgmt_acr_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -97,6 +103,7 @@ upgrade:
         mgmt_resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         acr_name: ${ bundle.parameters.mgmt_acr_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -115,6 +122,7 @@ uninstall:
         mgmt_resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         acr_name: ${ bundle.parameters.mgmt_acr_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/gitea/terraform/locals.tf
+++ b/templates/shared_services/gitea/terraform/locals.tf
@@ -6,10 +6,12 @@ locals {
   keyvault_name            = "kv-${var.tre_id}"
   version                  = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
   gitea_allowed_fqdns_list = distinct(compact(split(",", replace(var.gitea_allowed_fqdns, " ", ""))))
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags  = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
   webapp_diagnostic_categories_enabled = [
     "AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs", "AppServiceFileAuditLogs",
     "AppServiceAuditLogs", "AppServiceIPSecAuditLogs", "AppServicePlatformLogs", "AppServiceAntivirusScanAuditLogs"

--- a/templates/shared_services/gitea/terraform/variables.tf
+++ b/templates/shared_services/gitea/terraform/variables.tf
@@ -31,3 +31,9 @@ variable "acr_name" {
 }
 
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/shared_services/sonatype-nexus-vm/parameters.json
+++ b/templates/shared_services/sonatype-nexus-vm/parameters.json
@@ -51,6 +51,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/shared_services/sonatype-nexus-vm/porter.yaml
+++ b/templates/shared_services/sonatype-nexus-vm/porter.yaml
@@ -43,6 +43,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: ssl_cert_name
     type: string
     default: "nexus-ssl"
@@ -75,6 +80,7 @@ install:
         tre_id: ${ bundle.parameters.tre_id }
         tre_resource_id: ${ bundle.parameters.id }
         ssl_cert_name: ${ bundle.parameters.ssl_cert_name }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -92,6 +98,7 @@ upgrade:
         tre_id: ${ bundle.parameters.tre_id }
         tre_resource_id: ${ bundle.parameters.id }
         ssl_cert_name: ${ bundle.parameters.ssl_cert_name }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -108,6 +115,7 @@ uninstall:
         tre_id: ${ bundle.parameters.tre_id }
         tre_resource_id: ${ bundle.parameters.id }
         ssl_cert_name: ${ bundle.parameters.ssl_cert_name }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/shared_services/sonatype-nexus-vm/terraform/locals.tf
+++ b/templates/shared_services/sonatype-nexus-vm/terraform/locals.tf
@@ -6,8 +6,10 @@ locals {
   workspace_vm_allowed_fqdns      = "r3.o.lencr.org,x1.c.lencr.org"
   workspace_vm_allowed_fqdns_list = distinct(compact(split(",", replace(local.workspace_vm_allowed_fqdns, " ", ""))))
   storage_account_name            = lower(replace("stg-${var.tre_id}", "-", ""))
-  tre_shared_service_tags = {
-    tre_id                = var.tre_id
-    tre_shared_service_id = var.tre_resource_id
-  }
+  tre_shared_service_tags = merge(
+    var.tags, {
+      tre_id                = var.tre_id
+      tre_shared_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/shared_services/sonatype-nexus-vm/terraform/variables.tf
+++ b/templates/shared_services/sonatype-nexus-vm/terraform/variables.tf
@@ -10,3 +10,9 @@ variable "tre_resource_id" {
 variable "ssl_cert_name" {
   type = string
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/azureml/parameters.json
+++ b/templates/workspace_services/azureml/parameters.json
@@ -69,6 +69,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/azureml/porter.yaml
+++ b/templates/workspace_services/azureml/porter.yaml
@@ -61,6 +61,11 @@ parameters:
     default: false
   - name: arm_environment
     env: ARM_ENVIRONMENT
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: azure_environment
     env: AZURE_ENVIRONMENT
 
@@ -139,6 +144,7 @@ install:
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         arm_environment: ${ bundle.parameters.arm_environment }
         azure_environment: ${ bundle.parameters.azure_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -173,6 +179,7 @@ upgrade:
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         arm_environment: ${ bundle.parameters.arm_environment }
         azure_environment: ${ bundle.parameters.azure_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -207,6 +214,7 @@ uninstall:
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         arm_environment: ${ bundle.parameters.arm_environment }
         azure_environment: ${ bundle.parameters.azure_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/azureml/terraform/locals.tf
+++ b/templates/workspace_services/azureml/terraform/locals.tf
@@ -9,9 +9,12 @@ locals {
   acr_name                       = lower(replace("acr${substr(local.service_resource_name_suffix, -8, -1)}", "-", ""))
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   storage_name                   = lower(replace("stg${substr(local.service_resource_name_suffix, -8, -1)}", "-", ""))
-  tre_workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+
+  tre_workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspace_services/azureml/terraform/variables.tf
+++ b/templates/workspace_services/azureml/terraform/variables.tf
@@ -39,3 +39,9 @@ variable "auth_client_secret" {
 variable "arm_environment" {}
 
 variable "azure_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/azureml/user_resources/aml_compute/parameters.json
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/azureml/user_resources/aml_compute/porter.yaml
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/porter.yaml
@@ -53,6 +53,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 mixins:
   - exec
@@ -72,6 +77,7 @@ install:
         vm_size_sku: ${ bundle.parameters.vm_size }
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         user_object_id: ${ bundle.parameters.user_object_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -89,6 +95,7 @@ upgrade:
         vm_size_sku: ${ bundle.parameters.vm_size }
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         user_object_id: ${ bundle.parameters.user_object_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -106,6 +113,7 @@ uninstall:
         vm_size_sku: ${ bundle.parameters.vm_size }
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         user_object_id: ${ bundle.parameters.user_object_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/azureml/user_resources/aml_compute/terraform/locals.tf
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/terraform/locals.tf
@@ -7,10 +7,13 @@ locals {
   aml_workspace_name             = lower("ml-${substr(local.service_resource_name_suffix, -30, -1)}")
   aml_compute_id                 = "${local.short_service_id}${local.short_user_resource_id}"
   aml_compute_instance_name      = "ci-${local.aml_compute_id}"
-  tre_user_resources_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.parent_service_id
-    tre_user_resource_id     = var.tre_resource_id
-  }
+
+  tre_user_resources_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.parent_service_id
+      tre_user_resource_id     = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspace_services/azureml/user_resources/aml_compute/terraform/variables.tf
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/terraform/variables.tf
@@ -7,3 +7,9 @@ variable "tre_resource_id" {}
 variable "parent_service_id" {}
 variable "auth_tenant_id" {}
 variable "user_object_id" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/databricks/parameters.json
+++ b/templates/workspace_services/databricks/parameters.json
@@ -57,6 +57,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/databricks/porter.yaml
+++ b/templates/workspace_services/databricks/porter.yaml
@@ -48,6 +48,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: databricks_workspace_name
@@ -115,6 +120,7 @@ install:
         address_space: ${ bundle.parameters.address_space }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -142,6 +148,7 @@ upgrade:
         address_space: ${ bundle.parameters.address_space }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -169,6 +176,7 @@ uninstall:
         address_space: ${ bundle.parameters.address_space }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/databricks/terraform/locals.tf
+++ b/templates/workspace_services/databricks/terraform/locals.tf
@@ -20,9 +20,11 @@ locals {
   map_location_url_config = jsondecode(file("${path.module}/databricks-udr.json"))
   storage_name            = lower(replace("stgdbfs${substr(local.service_resource_name_suffix, -8, -1)}", "-", ""))
 
-  tre_workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  tre_workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspace_services/databricks/terraform/variables.tf
+++ b/templates/workspace_services/databricks/terraform/variables.tf
@@ -24,3 +24,9 @@ variable "is_exposed_externally" {
 }
 
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/gitea/parameters.json
+++ b/templates/workspace_services/gitea/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/gitea/porter.yaml
+++ b/templates/workspace_services/gitea/porter.yaml
@@ -60,6 +60,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: aad_authority_url
     type: string
     default: "https://login.microsoftonline.com"
@@ -97,6 +102,7 @@ install:
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -118,6 +124,7 @@ upgrade:
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -139,6 +146,7 @@ uninstall:
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/gitea/terraform/locals.tf
+++ b/templates/workspace_services/gitea/terraform/locals.tf
@@ -8,11 +8,13 @@ locals {
   core_resource_group_name       = "rg-${var.tre_id}"
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   version                        = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
-  workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.id
-  }
+  workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.id
+    }
+  )
   web_app_diagnostic_categories_enabled = [
     "AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs", "AppServiceFileAuditLogs",
     "AppServiceAuditLogs", "AppServiceIPSecAuditLogs", "AppServicePlatformLogs", "AppServiceAntivirusScanAuditLogs"

--- a/templates/workspace_services/gitea/terraform/variables.tf
+++ b/templates/workspace_services/gitea/terraform/variables.tf
@@ -10,3 +10,9 @@ variable "gitea_storage_limit" {
   default     = 100
 }
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/guacamole/parameters.json
+++ b/templates/workspace_services/guacamole/parameters.json
@@ -117,6 +117,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -105,6 +105,11 @@ parameters:
     default: false
   - name: arm_environment
     type: string
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: connection_uri
@@ -145,6 +150,7 @@ install:
         tre_resource_id: ${ bundle.parameters.id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -176,6 +182,7 @@ upgrade:
         tre_resource_id: ${ bundle.parameters.id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -207,6 +214,7 @@ uninstall:
         tre_resource_id: ${ bundle.parameters.id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/guacamole/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/terraform/locals.tf
@@ -14,11 +14,13 @@ locals {
   image_tag_from_file            = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
   image_tag                      = var.image_tag == "" ? local.image_tag_from_file : var.image_tag
   identity_name                  = "id-${local.webapp_name}"
-  workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
   guacamole_diagnostic_categories_enabled = [
     "AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs", "AppServiceFileAuditLogs",
     "AppServiceAuditLogs", "AppServiceIPSecAuditLogs", "AppServicePlatformLogs", "AppServiceAntivirusScanAuditLogs"

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -15,3 +15,9 @@ variable "guac_disable_upload" {}
 variable "is_exposed_externally" {}
 variable "tre_resource_id" {}
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/parameters.json
@@ -75,6 +75,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -65,6 +65,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: os_image
     type: string
     default: "Server 2019 Data Science VM"
@@ -115,6 +120,7 @@ install:
         image: ${ bundle.parameters.os_image }
         vm_size: ${ bundle.parameters.vm_size }
         airlock_request_sas_url: ${ bundle.parameters.airlock_request_sas_url }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -137,6 +143,7 @@ upgrade:
         image: ${ bundle.parameters.os_image }
         vm_size: ${ bundle.parameters.vm_size }
         airlock_request_sas_url: "unused"
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -168,6 +175,7 @@ uninstall:
         image: ${ bundle.parameters.os_image }
         vm_size: ${ bundle.parameters.vm_size }
         airlock_request_sas_url: "unused"
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/locals.tf
@@ -7,12 +7,14 @@ locals {
   vm_name                        = "windowsvm${local.short_service_id}"
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   vm_password_secret_name        = "${local.vm_name}-admin-credentials"
-  tre_user_resources_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.parent_service_id
-    tre_user_resource_id     = var.tre_resource_id
-  }
+  tre_user_resources_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.parent_service_id
+      tre_user_resource_id     = var.tre_resource_id
+    }
+  )
 
   # Load VM SKU/image details from porter.yaml
   porter_yaml   = yamldecode(file("${path.module}/../porter.yaml"))

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/variables.tf
@@ -8,3 +8,9 @@ variable "image_gallery_id" {
   default = ""
 }
 variable "airlock_request_sas_url" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/parameters.json
@@ -81,6 +81,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
@@ -74,6 +74,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: os_image
     type: string
     default: "Server 2019 Data Science VM"
@@ -125,6 +130,7 @@ install:
         vm_size: ${ bundle.parameters.vm_size }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: ${ bundle.parameters.airlock_request_sas_url }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -148,6 +154,7 @@ upgrade:
         vm_size: ${ bundle.parameters.vm_size }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: "unused"
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -180,6 +187,7 @@ uninstall:
         vm_size: ${ bundle.parameters.vm_size }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: "unused"
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/locals.tf
@@ -7,12 +7,14 @@ locals {
   vm_name                        = "windowsvm${local.short_service_id}"
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   vm_password_secret_name        = "${local.vm_name}-admin-credentials"
-  tre_user_resources_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.parent_service_id
-    tre_user_resource_id     = var.tre_resource_id
-  }
+  tre_user_resources_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.parent_service_id
+      tre_user_resource_id     = var.tre_resource_id
+    }
+  )
 
   # Load VM SKU/image details from porter.yaml
   porter_yaml   = yamldecode(file("${path.module}/../porter.yaml"))

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/variables.tf
@@ -8,3 +8,9 @@ variable "image_gallery_id" {
   default = ""
 }
 variable "airlock_request_sas_url" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/parameters.json
@@ -87,6 +87,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -89,6 +89,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: os_image
     type: string
     default: "Ubuntu 18.04 Data Science VM"
@@ -143,6 +148,7 @@ install:
         shared_storage_access: ${ bundle.parameters.shared_storage_access }
         shared_storage_name: ${ bundle.parameters.shared_storage_name }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -167,6 +173,7 @@ upgrade:
         shared_storage_access: ${ bundle.parameters.shared_storage_access }
         shared_storage_name: ${ bundle.parameters.shared_storage_name }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -200,6 +207,7 @@ uninstall:
         shared_storage_access: ${ bundle.parameters.shared_storage_access }
         shared_storage_name: ${ bundle.parameters.shared_storage_name }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/locals.tf
@@ -8,12 +8,14 @@ locals {
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   storage_name                   = lower(replace("stg${substr(local.workspace_resource_name_suffix, -8, -1)}", "-", ""))
   vm_password_secret_name        = "${local.vm_name}-admin-credentials"
-  tre_user_resources_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.parent_service_id
-    tre_user_resource_id     = var.tre_resource_id
-  }
+  tre_user_resources_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.parent_service_id
+      tre_user_resource_id     = var.tre_resource_id
+    }
+  )
   nexus_proxy_url = "https://nexus-${data.azurerm_public_ip.app_gateway_ip.fqdn}"
 
   # Load VM SKU/image details from porter.yaml

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/variables.tf
@@ -11,3 +11,9 @@ variable "shared_storage_name" {}
 variable "image_gallery_id" {
   default = ""
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/parameters.json
@@ -87,6 +87,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -100,6 +100,11 @@ parameters:
     default: "vm-shared-storage"
   - name: arm_environment
     type: string
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: ip
@@ -142,6 +147,7 @@ install:
         shared_storage_access: ${ bundle.parameters.shared_storage_access }
         shared_storage_name: ${ bundle.parameters.shared_storage_name }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -166,6 +172,7 @@ upgrade:
         shared_storage_access: ${ bundle.parameters.shared_storage_access }
         shared_storage_name: ${ bundle.parameters.shared_storage_name }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -199,6 +206,7 @@ uninstall:
         shared_storage_access: ${ bundle.parameters.shared_storage_access }
         shared_storage_name: ${ bundle.parameters.shared_storage_name }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/locals.tf
@@ -8,12 +8,14 @@ locals {
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   storage_name                   = lower(replace("stg${substr(local.workspace_resource_name_suffix, -8, -1)}", "-", ""))
   vm_password_secret_name        = "${local.vm_name}-admin-credentials"
-  tre_user_resources_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.parent_service_id
-    tre_user_resource_id     = var.tre_resource_id
-  }
+  tre_user_resources_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.parent_service_id
+      tre_user_resource_id     = var.tre_resource_id
+    }
+  )
   nexus_proxy_url = "https://nexus-${data.azurerm_public_ip.app_gateway_ip.fqdn}"
 
   # Load VM SKU/image details from porter.yaml

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/variables.tf
@@ -11,3 +11,9 @@ variable "shared_storage_name" {}
 variable "image_gallery_id" {
   default = ""
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/health-services/parameters.json
+++ b/templates/workspace_services/health-services/parameters.json
@@ -69,6 +69,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/health-services/porter.yaml
+++ b/templates/workspace_services/health-services/porter.yaml
@@ -57,6 +57,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: deploy_fhir
     type: boolean
     default: false
@@ -103,6 +108,7 @@ install:
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -128,6 +134,7 @@ upgrade:
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -153,6 +160,7 @@ uninstall:
         auth_tenant_id: ${ bundle.credentials.auth_tenant_id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/health-services/terraform/locals.tf
+++ b/templates/workspace_services/health-services/terraform/locals.tf
@@ -7,9 +7,11 @@ locals {
   service_resource_name_suffix   = "${local.short_workspace_id}svc${local.short_service_id}"
   authority                      = "${var.aad_authority_url}/${local.aad_tenant_id}"
   core_resource_group_name       = "rg-${var.tre_id}"
-  workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspace_services/health-services/terraform/variables.tf
+++ b/templates/workspace_services/health-services/terraform/variables.tf
@@ -49,3 +49,9 @@ variable "auth_client_secret" {
 }
 
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/innereye/parameters.json
+++ b/templates/workspace_services/innereye/parameters.json
@@ -69,6 +69,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/innereye/porter.yaml
+++ b/templates/workspace_services/innereye/porter.yaml
@@ -55,6 +55,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 mixins:
   - exec
@@ -103,6 +108,7 @@ install:
         arm_client_secret: ${ bundle.credentials.azure_client_secret }
         arm_use_msi: ${ bundle.parameters.arm_use_msi }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -132,6 +138,7 @@ uninstall:
         arm_client_secret: ${ bundle.credentials.azure_client_secret }
         arm_use_msi: ${ bundle.parameters.arm_use_msi }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/innereye/terraform/locals.tf
+++ b/templates/workspace_services/innereye/terraform/locals.tf
@@ -10,9 +10,11 @@ locals {
   aml_compute_id                 = substr("${var.tre_id}${var.workspace_id}${local.short_service_id}", -12, -1)
   aml_compute_cluster_name       = "cp-${local.aml_compute_id}"
   azureml_acr_name               = lower(replace("acr${substr(local.service_resource_name_suffix, -8, -1)}", "-", ""))
-  tre_workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  tre_workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspace_services/innereye/terraform/variables.tf
+++ b/templates/workspace_services/innereye/terraform/variables.tf
@@ -10,3 +10,9 @@ variable "arm_use_msi" {
 variable "inference_sp_client_id" {}
 variable "inference_sp_client_secret" {}
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/mlflow/parameters.json
+++ b/templates/workspace_services/mlflow/parameters.json
@@ -57,6 +57,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/mlflow/porter.yaml
+++ b/templates/workspace_services/mlflow/porter.yaml
@@ -59,6 +59,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: internal_connection_uri
@@ -82,6 +87,7 @@ install:
         mgmt_acr_name: ${ bundle.parameters.mgmt_acr_name }
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -100,6 +106,7 @@ upgrade:
         mgmt_acr_name: ${ bundle.parameters.mgmt_acr_name }
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -118,6 +125,7 @@ uninstall:
         mgmt_acr_name: ${ bundle.parameters.mgmt_acr_name }
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/mlflow/terraform/locals.tf
+++ b/templates/workspace_services/mlflow/terraform/locals.tf
@@ -12,11 +12,13 @@ locals {
   mlflow_artefacts_container_name = "mlartefacts"
   image_name                      = "mlflow-server"
   image_tag                       = replace(replace(replace(data.local_file.version.content, "__version__ = \"", ""), "\"", ""), "\n", "")
-  tre_workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  tre_workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
   web_app_diagnostic_categories_enabled = [
     "AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs", "AppServiceFileAuditLogs",
     "AppServiceAuditLogs", "AppServiceIPSecAuditLogs", "AppServicePlatformLogs", "AppServiceAntivirusScanAuditLogs"

--- a/templates/workspace_services/mlflow/terraform/variables.tf
+++ b/templates/workspace_services/mlflow/terraform/variables.tf
@@ -11,3 +11,9 @@ variable "is_exposed_externally" {
   default     = false
 }
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/mysql/parameters.json
+++ b/templates/workspace_services/mysql/parameters.json
@@ -63,6 +63,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/mysql/porter.yaml
+++ b/templates/workspace_services/mysql/porter.yaml
@@ -45,6 +45,11 @@ parameters:
     env: ARM_ENVIRONMENT
     type: string
     default: "public"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
   - name: sql_sku
     type: string
     default: "GP | 5GB 2vCores"
@@ -77,6 +82,7 @@ install:
         storage_mb: ${ bundle.parameters.storage_mb }
         db_name: ${ bundle.parameters.db_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -101,6 +107,7 @@ uninstall:
         storage_mb: ${ bundle.parameters.storage_mb }
         db_name: ${ bundle.parameters.db_name }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/mysql/terraform/locals.tf
+++ b/templates/workspace_services/mysql/terraform/locals.tf
@@ -11,9 +11,11 @@ locals {
     "GP | 5GB 6vCores" = { value = "GP_Gen5_6" },
     "GP | 5GB 8vCores" = { value = "GP_Gen5_8" }
   }
-  workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspace_services/mysql/terraform/variables.tf
+++ b/templates/workspace_services/mysql/terraform/variables.tf
@@ -11,3 +11,9 @@ variable "storage_mb" {
   }
 }
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspace_services/ohdsi/parameters.json
+++ b/templates/workspace_services/ohdsi/parameters.json
@@ -75,6 +75,12 @@
       "source": {
         "env": "DATA_SOURCE_DAIMONS"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspace_services/ohdsi/porter.yaml
+++ b/templates/workspace_services/ohdsi/porter.yaml
@@ -53,6 +53,11 @@ parameters:
   - name: azure_environment
     type: string
     description: "Used by Azure CLI to set the Azure environment"
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
   # parameters for configuring the data source
   - name: configure_data_source
@@ -121,6 +126,7 @@ install:
         configure_data_source: ${ bundle.parameters.configure_data_source }
         data_source_config: ${ bundle.parameters.data_source_config }
         data_source_daimons: ${ bundle.parameters.data_source_daimons }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -165,6 +171,7 @@ upgrade:
         configure_data_source: ${ bundle.parameters.configure_data_source }
         data_source_config: ${ bundle.parameters.data_source_config }
         data_source_daimons: ${ bundle.parameters.data_source_daimons }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -187,6 +194,7 @@ uninstall:
         configure_data_source: ${ bundle.parameters.configure_data_source }
         data_source_config: ${ bundle.parameters.data_source_config }
         data_source_daimons: ${ bundle.parameters.data_source_daimons }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspace_services/ohdsi/terraform/locals.tf
+++ b/templates/workspace_services/ohdsi/terraform/locals.tf
@@ -51,11 +51,13 @@ locals {
     "AppServiceHTTPLogs"
   ]
 
-  tre_workspace_service_tags = {
-    tre_id                   = var.tre_id
-    tre_workspace_id         = var.workspace_id
-    tre_workspace_service_id = var.tre_resource_id
-  }
+  tre_workspace_service_tags = merge(
+    var.tags, {
+      tre_id                   = var.tre_id
+      tre_workspace_id         = var.workspace_id
+      tre_workspace_service_id = var.tre_resource_id
+    }
+  )
 
   # Data Source configuration
   dialects               = local.porter_yaml["custom"]["dialects"]

--- a/templates/workspace_services/ohdsi/terraform/variables.tf
+++ b/templates/workspace_services/ohdsi/terraform/variables.tf
@@ -34,3 +34,9 @@ variable "data_source_daimons" {
   type    = string
   default = null
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspaces/airlock-import-review/parameters.json
+++ b/templates/workspaces/airlock-import-review/parameters.json
@@ -135,6 +135,12 @@
       "source": {
         "env": "AZURE_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspaces/airlock-import-review/porter.yaml
+++ b/templates/workspaces/airlock-import-review/porter.yaml
@@ -114,6 +114,11 @@ parameters:
     default: "P1v3"
   - name: arm_environment
     type: string
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: app_role_id_workspace_owner
@@ -178,6 +183,7 @@ install:
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: false
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -221,6 +227,7 @@ upgrade:
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: false
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -287,6 +294,7 @@ uninstall:
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: false
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspaces/base/parameters.json
+++ b/templates/workspaces/base/parameters.json
@@ -147,6 +147,12 @@
       "source": {
         "env": "AZURE_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -116,6 +116,11 @@ parameters:
     default: true
   - name: arm_environment
     type: string
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: app_role_id_workspace_owner
@@ -177,6 +182,7 @@ install:
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: ${ bundle.parameters.enable_airlock }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -217,6 +223,7 @@ upgrade:
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: ${ bundle.parameters.enable_airlock }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -280,6 +287,7 @@ uninstall:
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: ${ bundle.parameters.enable_airlock }
         arm_environment: ${ bundle.parameters.arm_environment }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }

--- a/templates/workspaces/base/terraform/locals.tf
+++ b/templates/workspaces/base/terraform/locals.tf
@@ -4,8 +4,10 @@ locals {
   storage_name                   = lower(replace("stg${substr(local.workspace_resource_name_suffix, -8, -1)}", "-", ""))
   keyvault_name                  = lower("kv-${substr(local.workspace_resource_name_suffix, -20, -1)}")
   redacted_senstive_value        = "REDACTED"
-  tre_workspace_tags = {
-    tre_id           = var.tre_id
-    tre_workspace_id = var.tre_resource_id
-  }
+  tre_workspace_tags = merge(
+    var.tags, {
+      tre_id           = var.tre_id
+      tre_workspace_id = var.tre_resource_id
+    }
+  )
 }

--- a/templates/workspaces/base/terraform/variables.tf
+++ b/templates/workspaces/base/terraform/variables.tf
@@ -120,3 +120,9 @@ variable "workspace_owner_object_id" {
 }
 
 variable "arm_environment" {}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to all resources"
+  default = {}
+}

--- a/templates/workspaces/unrestricted/parameters.json
+++ b/templates/workspaces/unrestricted/parameters.json
@@ -147,6 +147,12 @@
       "source": {
         "env": "ARM_ENVIRONMENT"
       }
+    },
+    {
+      "name": "tags",
+      "source": {
+        "env": "TAGS"
+      }
     }
   ]
 }

--- a/templates/workspaces/unrestricted/porter.yaml
+++ b/templates/workspaces/unrestricted/porter.yaml
@@ -118,6 +118,11 @@ parameters:
   - name: enable_airlock
     type: boolean
     default: false
+  - name: tags
+    env: TAGS
+    type: string
+    description: "Tags to be applied to all resources"
+    default: "{}"
 
 outputs:
   - name: app_role_id_workspace_owner
@@ -182,6 +187,7 @@ install:
         aad_redirect_uris_b64: ${ bundle.parameters.aad_redirect_uris }
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: ${ bundle.parameters.enable_airlock }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -225,6 +231,7 @@ upgrade:
         aad_redirect_uris_b64: ${ bundle.parameters.aad_redirect_uris }
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: ${ bundle.parameters.enable_airlock }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -291,6 +298,7 @@ uninstall:
         aad_redirect_uris_b64: ${ bundle.parameters.aad_redirect_uris }
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
         enable_airlock: ${ bundle.parameters.enable_airlock }
+        tags: ${ bundle.parameters.tags }
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }


### PR DESCRIPTION
# Resolves #417 

## What is being addressed

We need all resources deployed by TRE (included management) to include specific tags upon creation to comply with corporate tagging policies. 

Important: The current PR contains a draft implementation that solves this issue. It is not fully complete and has not been tested yet. 

## How is this addressed
- Tags can be specified in the `config.yaml` file in a new `tags` field.
- Must be a string representation of JSON object with the following format: `'{"tag_key": "tag_value", "tag_key2": "tag_value2"}'`, similar to `rp_bundle_values`
- The tags are exported to environments variables similar to the other fields.
- Tags are added to `/devops/terraform/bootstrap.sh` directly in the command to create the resource group and storage account. This is done to comply with policies upon creation of resources.
- Tags are added to github actions on a best effort basis. We personally don't use them so I am less knowledgeable on their implementation.
- Tags are added as variable to the management terraform and applied to each resources. (This has been tested)
- Tags are added as variable to the core terraform and appended to the local `tre_core_tags` which is already applied to resources. Extension to modules is also considered.
- Similarily, for `shared_services`, `workspace_services`, `user_resources`, and `workspaces`:
    - Tags are added as terraform variable and appended to the respective locals (`tre_shared_service_tags`, `tre_workspace_service_tags`, `tre_user_resources_tags`, `tre_workspace_tags`)
    - The `porter.yaml` and `parameters,json` files have been updated for each template

#TODO: Tests, update documentation, increment template versions

