### PR TITLE
Enable security only updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/ui/app"
@@ -17,6 +18,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -25,6 +27,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "maven"
     directory: "/templates/workspace_services/guacamole/guacamole-server/guacamole-auth-azure"
@@ -33,6 +36,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "terraform"
     directory: "/devops/terraform"
@@ -41,6 +45,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "terraform"
     directory: "/core/terraform"
@@ -49,3 +54,4 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0


### PR DESCRIPTION
For all package-ecosystems in dependabot config put open-pull-requests-limit: 0 so that only security updates are followed by dependabot as stated in the https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit