### PR TITLE
Add pypi.org into Allow List for Nexus Firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ ENHANCEMENTS:
 BUG FIXES:
 
 
+## 0.14.1 (Unreleased)
+
+BUG FIXES:
+* Fix firewall config related to Nexus so that `pypi.org` is added to the allow-list  ([#3694](https://github.com/microsoft/AzureTRE/issues/3694))
+
+COMPONENTS:
+| name | version |
+| ----- | ----- |
+| devops | 0.5.1 |
+| core | 0.8.6 |
+| tre-workspace-base | 1.4.7 |
+| tre-workspace-unrestricted | 0.10.4 |
+| tre-workspace-airlock-import-review | 0.11.6 |
+| tre-service-mlflow | 0.7.5 |
+| tre-workspace-service-health | 0.2.4 |
+| tre-service-databricks | 1.0.3 |
+| tre-service-innereye | 0.6.4 |
+| tre-workspace-service-gitea | 0.8.5 |
+| tre-workspace-service-mysql | 0.4.4 |
+| tre-workspace-service-ohdsi | 0.2.3 |
+| tre-service-guacamole-linuxvm | 0.6.8 |
+| tre-service-guacamole-export-reviewvm | 0.1.7 |
+| tre-service-guacamole-windowsvm | 0.7.8 |
+| tre-service-guacamole-import-reviewvm | 0.2.7 |
+| tre-service-guacamole | 0.10.4 |
+| tre-user-resource-aml-compute-instance | 0.5.7 |
+| tre-service-azureml | 0.8.10 |
+| tre-shared-service-cyclecloud | 0.5.4 |
+| tre-shared-service-databricks-private-auth | 0.1.5 |
+| tre-shared-service-gitea | 0.6.5 |
+| tre-shared-service-airlock-notifier | 0.9.0 |
+| tre-shared-service-admin-vm | 0.4.3 |
+| tre-shared-service-certs | 0.5.1 |
+| tre-shared-service-sonatype-nexus | 2.8.11 |
+| tre-shared-service-firewall | 1.1.4 |
+
 ## 0.14.0 (August 25, 2023)
 
 ENHANCEMENTS:

--- a/docs/tre-templates/shared-services/nexus.md
+++ b/docs/tre-templates/shared-services/nexus.md
@@ -65,7 +65,7 @@ Nexus Shared Service requires access to resources outside of the Azure TRE VNET.
 | --- | --- |
 | AzureActiveDirectory | Authorize the signed in user against Azure Active Directory. |
 | AzureContainerRegistry | Pull the Nexus container image, as it is located in Azure Container Registry.  |
-| pypi.org | Enables Nexus to "proxy" python packages to use inside of workspaces. |
+| pypi.org, *.pypi.org | Enables Nexus to "proxy" python packages to use inside of workspaces. |
 | repo.anaconda.com | Enables Nexus to "proxy" conda packages to use inside of workspaces. |
 | conda.anaconda.org | Enables Nexus to "proxy" additional conda packages to use inside of workspaces such as conda-forge. |
 | *.docker.com | Enables Nexus to "proxy" docker repos to use inside of workspaces. |

--- a/templates/shared_services/sonatype-nexus-vm/porter.yaml
+++ b/templates/shared_services/sonatype-nexus-vm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-sonatype-nexus
-version: 2.8.10
+version: 2.8.11
 description: "A Sonatype Nexus shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/shared_services/sonatype-nexus-vm/terraform/locals.tf
+++ b/templates/shared_services/sonatype-nexus-vm/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   core_vnet                       = "vnet-${var.tre_id}"
   core_resource_group_name        = "rg-${var.tre_id}"
-  nexus_allowed_fqdns             = "*.pypi.org,files.pythonhosted.org,security.ubuntu.com,archive.ubuntu.com,keyserver.ubuntu.com,repo.anaconda.com,*.docker.com,*.docker.io,conda.anaconda.org,azure.archive.ubuntu.com,packages.microsoft.com,repo.almalinux.org,download-ib01.fedoraproject.org,cran.r-project.org,cloud.r-project.org"
+  nexus_allowed_fqdns             = "pypi.org,*.pypi.org,files.pythonhosted.org,security.ubuntu.com,archive.ubuntu.com,keyserver.ubuntu.com,repo.anaconda.com,*.docker.com,*.docker.io,conda.anaconda.org,azure.archive.ubuntu.com,packages.microsoft.com,repo.almalinux.org,download-ib01.fedoraproject.org,cran.r-project.org,cloud.r-project.org"
   nexus_allowed_fqdns_list        = distinct(compact(split(",", replace(local.nexus_allowed_fqdns, " ", ""))))
   workspace_vm_allowed_fqdns      = "r3.o.lencr.org,x1.c.lencr.org"
   workspace_vm_allowed_fqdns_list = distinct(compact(split(",", replace(local.workspace_vm_allowed_fqdns, " ", ""))))


### PR DESCRIPTION
# Resolves #3694 

Adds `pypi.org` into the allow list of FQDNs for the Nexus service.