### PR TITLE
Grey Box, Instead of Costs, Are Being Displayed in Web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * Upgrade unresticted and airlock base template versions due to diagnostic settings retention period being depreciated ([#3704](https://github.com/microsoft/AzureTRE/pull/3704))
+* Fix grey box appearing on resource card when costs are not available. ([#3254](https://github.com/microsoft/AzureTRE/issues/3254))
 
 ## 0.14.1 (September 1, 2023)
 

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.35.0",

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -17,6 +17,7 @@ import { CreateUpdateResource } from './components/shared/create-update-resource
 import { CreateUpdateResourceContext } from './contexts/CreateUpdateResourceContext';
 import { CreateFormResource, ResourceType } from './models/resourceType';
 import { Footer } from './components/shared/Footer';
+import { initializeIcons } from '@fluentui/react/lib/Icons';
 import { initializeFileTypeIcons } from '@fluentui/react-file-type-icons';
 import { CostResource } from './models/costs';
 import { CostsContext } from './contexts/CostsContext';
@@ -43,7 +44,8 @@ export const App: React.FunctionComponent = () => {
     setAppRolesOnLoad();
   }, [apiCall]);
 
-  // initiliase filetype icons
+  // initiliase icons
+  useEffect(() => initializeIcons(), []);
   useEffect(() => initializeFileTypeIcons(), []);
 
   return (

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -45,7 +45,7 @@ export const App: React.FunctionComponent = () => {
   }, [apiCall]);
 
   // initiliase icons
-  useEffect(() => initializeIcons(), []);
+  //useEffect(() => initializeIcons(), []);
   useEffect(() => initializeFileTypeIcons(), []);
 
   return (

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -17,7 +17,6 @@ import { CreateUpdateResource } from './components/shared/create-update-resource
 import { CreateUpdateResourceContext } from './contexts/CreateUpdateResourceContext';
 import { CreateFormResource, ResourceType } from './models/resourceType';
 import { Footer } from './components/shared/Footer';
-import { initializeIcons } from '@fluentui/react/lib/Icons';
 import { initializeFileTypeIcons } from '@fluentui/react-file-type-icons';
 import { CostResource } from './models/costs';
 import { CostsContext } from './contexts/CostsContext';
@@ -44,8 +43,6 @@ export const App: React.FunctionComponent = () => {
     setAppRolesOnLoad();
   }, [apiCall]);
 
-  // initiliase icons
-  //useEffect(() => initializeIcons(), []);
   useEffect(() => initializeFileTypeIcons(), []);
 
   return (

--- a/ui/app/src/components/shared/CostsTag.tsx
+++ b/ui/app/src/components/shared/CostsTag.tsx
@@ -27,7 +27,7 @@ export const CostsTag: React.FunctionComponent<CostsTagProps> = (props: CostsTag
           maximumFractionDigits: 2
         }).format(resourceCosts?.costs[0].cost);
         costBadge = <Stack.Item style={{maxHeight: 18}} className="tre-badge">{formattedCost}</Stack.Item>
-      }else{
+      } else {
         costBadge = (
           <Stack.Item style={{maxHeight: 18}} className="tre-badge">
             <TooltipHost content="Cost data not yet available">

--- a/ui/app/src/components/shared/CostsTag.tsx
+++ b/ui/app/src/components/shared/CostsTag.tsx
@@ -1,4 +1,4 @@
-import { Stack, Shimmer } from "@fluentui/react";
+import { Stack, Shimmer, TooltipHost, Icon } from "@fluentui/react";
 import { useContext } from "react";
 import { CostsContext } from "../../contexts/CostsContext";
 import { LoadingState } from "../../models/loadingState";
@@ -27,6 +27,14 @@ export const CostsTag: React.FunctionComponent<CostsTagProps> = (props: CostsTag
           maximumFractionDigits: 2
         }).format(resourceCosts?.costs[0].cost);
         costBadge = <Stack.Item style={{maxHeight: 18}} className="tre-badge">{formattedCost}</Stack.Item>
+      }else{
+        costBadge = (
+          <Stack.Item style={{maxHeight: 18}} className="tre-badge">
+            <TooltipHost content="Cost data not yet available">
+              <Icon iconName="Clock" />
+            </TooltipHost>
+          </Stack.Item>
+        );
       }
       break;
   }


### PR DESCRIPTION
# Resolves  #3254

## How is this addressed

- Only show cost tag when user has appropriate roles 
- Only show cost tag for resources wit costs implemented in the UI
-  Add clock and tooltip when costs are not yet available
