### PR TITLE
Fix PivotItem/SecuredByRole render and workspace cost reloading

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.35.0",

--- a/ui/app/src/components/shared/CostsTag.tsx
+++ b/ui/app/src/components/shared/CostsTag.tsx
@@ -25,7 +25,7 @@ export const CostsTag: React.FunctionComponent<CostsTagProps> = (props: CostsTag
         costs = workspaceCtx.costs;
       } else if (costsCtx.costs.length > 0) {
         costs = costsCtx.costs;
-      } else {
+      } else if(!workspaceCtx.workspace.id) {
         let scopeId = (await apiCall(`${ApiEndpoint.Workspaces}/${props.resourceId}/scopeid`, HttpMethod.Get)).workspaceAuth.scopeId;
         const r = await apiCall(`${ApiEndpoint.Workspaces}/${props.resourceId}/${ApiEndpoint.Costs}`, HttpMethod.Get, scopeId, undefined, ResultType.JSON);
         costs = [{costs: r.costs, id: r.id, name: r.name }];
@@ -44,11 +44,11 @@ export const CostsTag: React.FunctionComponent<CostsTagProps> = (props: CostsTag
           maximumFractionDigits: 2
         }).format(resourceCosts.costs[0].cost);
         setFormattedCost(formattedCost);
-        setLoadingState(LoadingState.Ok);
       }
+      setLoadingState(LoadingState.Ok);
     }
     fetchCostData();
-  }, [apiCall, costsCtx.loadingState, props.resourceId, workspaceCtx.costs, costsCtx.costs]);
+  }, [apiCall, props.resourceId, workspaceCtx.costs, costsCtx.costs, workspaceCtx.workspace.id]);
 
   const costBadge = (
     <Stack.Item style={{ maxHeight: 18 }} className="tre-badge">

--- a/ui/app/src/components/shared/ResourceBody.tsx
+++ b/ui/app/src/components/shared/ResourceBody.tsx
@@ -62,19 +62,19 @@ export const ResourceBody: React.FunctionComponent<ResourceBodyProps> = (props: 
       }
       {
         !props.readonly &&
-        <SecuredByRole allowedAppRoles={historyRoles} allowedWorkspaceRoles={historyRoles} workspaceId={workspaceId} element={
-          <PivotItem headerText="History">
+        <PivotItem headerText="History">
+          <SecuredByRole allowedAppRoles={historyRoles} allowedWorkspaceRoles={historyRoles} workspaceId={workspaceId} errorString={`Must have ${historyRoles.join(" or ")} role`} element={
             <ResourceHistoryList resource={props.resource} />
-          </PivotItem>
-        } />
+          } />
+        </PivotItem>
       }
       {
         !props.readonly &&
-        <SecuredByRole allowedAppRoles={operationsRoles} allowedWorkspaceRoles={operationsRoles} workspaceId={workspaceId} element={
-          <PivotItem headerText="Operations">
+        <PivotItem headerText="Operations">
+          <SecuredByRole allowedAppRoles={operationsRoles} allowedWorkspaceRoles={operationsRoles} workspaceId={workspaceId} errorString={`Must have ${operationsRoles.join(" or ")} role`} element={
             <ResourceOperationsList resource={props.resource} />
-          </PivotItem>
-        } />
+          } />
+        </PivotItem>
       }
     </Pivot>
   );

--- a/ui/app/src/components/shared/ResourceCard.tsx
+++ b/ui/app/src/components/shared/ResourceCard.tsx
@@ -149,7 +149,6 @@ export const ResourceCard: React.FunctionComponent<ResourceCardProps> = (props: 
                   </Stack.Item>
                 </Stack>
               </Stack.Item>
-              {console.log("costTagsToles", costsTagsRoles)}
               <SecuredByRole allowedAppRoles={costsTagsRoles} allowedWorkspaceRoles={costsTagsRoles} workspaceId={workspaceId} element={
                 <CostsTag resourceId={props.resource.id} />
               }


### PR DESCRIPTION
Fixes #3738

## What is being addressed

- Cannot surround PivotItem by SecuredByRole element so using error message
- Costs relead when roles update
