### PR TITLE
SecuredByRole fails if workspaceRoles or appRoles are not yet defined. Add ui to versions listing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ BUG FIXES:
 
 COMPONENTS:
 
+## 0.15.1 (October 12, 2023)
+
+BUG FIXES:
+* SecuredByRole failing if roles are null ([#3740](https://github.com/microsoft/AzureTRE/issues/3740  ))
+
+COMPONENTS:
+| name | version |
+| ----- | ----- |
+| devops | 0.5.1 |
+| core | 0.8.9 |
+| ui | 0.5.11 |
+| tre-workspace-base | 1.5.0 |
+| tre-workspace-unrestricted | 0.11.1 |
+| tre-workspace-airlock-import-review | 0.12.7 |
+| tre-service-mlflow | 0.7.7 |
+| tre-workspace-service-health | 0.2.5 |
+| tre-service-databricks | 1.0.3 |
+| tre-service-innereye | 0.6.4 |
+| tre-workspace-service-gitea | 0.8.7 |
+| tre-workspace-service-mysql | 0.4.5 |
+| tre-workspace-service-ohdsi | 0.2.4 |
+| tre-service-guacamole-linuxvm | 0.6.9 |
+| tre-service-guacamole-export-reviewvm | 0.1.8 |
+| tre-service-guacamole-windowsvm | 0.7.9 |
+| tre-service-guacamole-import-reviewvm | 0.2.8 |
+| tre-service-guacamole | 0.10.5 |
+| tre-user-resource-aml-compute-instance | 0.5.7 |
+| tre-service-azureml | 0.8.10 |
+| tre-shared-service-cyclecloud | 0.5.5 |
+| tre-shared-service-databricks-private-auth | 0.1.5 |
+| tre-shared-service-gitea | 0.6.10 |
+| tre-shared-service-airlock-notifier | 0.9.0 |
+| tre-shared-service-admin-vm | 0.4.3 |
+| tre-shared-service-certs | 0.5.1 |
+| tre-shared-service-sonatype-nexus | 2.8.12 |
+| tre-shared-service-firewall | 1.1.5 |
+
 ## 0.15.0 (October 10, 2023)
 
 FEATURES:

--- a/devops/scripts/list_versions.sh
+++ b/devops/scripts/list_versions.sh
@@ -20,10 +20,18 @@ function component_version () {
   echo -e "| $1 | $version |"
 }
 
+function ui_version () {
+  # get version from ./ui/app/package.json
+  version=$(yq -oy eval ".version" "./ui/app/package.json")
+  echo -e "| ui | $version |"
+}
+
+
 echo -e "| name | version |\n| ----- | ----- |"
 
 component_version "devops" "devops/version.txt"
 component_version "core" "core/version.txt"
+ui_version
 
 find . -type f -name "porter.yaml" -not -path "*/.cnab/*" -print0 | sort | while read -r -d $'\0' file
 do

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.35.0",

--- a/ui/app/src/components/shared/SecuredByRole.tsx
+++ b/ui/app/src/components/shared/SecuredByRole.tsx
@@ -47,7 +47,7 @@ export const SecuredByRole: React.FunctionComponent<SecuredByRoleProps> = (props
   }, [apiCall, workspaceCtx.workspace.id, props.workspaceId, workspaceCtx.roles]);
 
   return (
-    (workspaceRoles.some(x => props.allowedWorkspaceRoles?.includes(x)) || appRoles.roles.some(x => props.allowedAppRoles?.includes(x)))
+    ((workspaceRoles && workspaceRoles.some(x => props.allowedWorkspaceRoles?.includes(x))) || (appRoles && appRoles.roles.some(x => props.allowedAppRoles?.includes(x))))
       ? props.element
       : (props.errorString && (workspaceRoles.length > 0 || appRoles.roles.length > 0)
           ? <MessageBar messageBarType={MessageBarType.error} isMultiline={true}>


### PR DESCRIPTION
# Resolves #3740

## What is being addressed

- Add check for undefined workspaceRoles and appRoles
- Update list versions script to output UI version
- Update changelog for 0.15.1 release
