### PR TITLE
Provide Airlock Import Review Workspace with its own DNS zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 0.16.0 (Unreleased)
 
 **BREAKING CHANGES & MIGRATIONS**:
-To resolve the Airlock import issue described in ([#3767](https://github.com/microsoft/AzureTRE/pull/3767)) the new airlock import review tempalte will need registering using `make workspace_bundle BUNDLE=airlock-import-review` and any existing airlock import review workspaces will need upgrading. After upgrade run `make deploy-core` to reinstate and deleted DNS records.
+To resolve the Airlock import issue described in ([#3767](https://github.com/microsoft/AzureTRE/pull/3767)), the new airlock import review tempalte will need to be registered using `make workspace_bundle BUNDLE=airlock-import-review`. Any existing airlock import review workspaces will need to be upgraded. After upgrading, run `make deploy-core` to reinstate any deleted DNS records.
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 0.16.0 (Unreleased)
 
 **BREAKING CHANGES & MIGRATIONS**:
-To resolve the Airlock import issue described in ([#3767](https://github.com/microsoft/AzureTRE/pull/3767)) any existing airlock import review workspaces will need upgrading or recreating. After upgrade run `make deploy-core` to reinstate the DNS record.
+To resolve the Airlock import issue described in ([#3767](https://github.com/microsoft/AzureTRE/pull/3767)) the new airlock import review tempalte will need registering using `make workspace_bundle BUNDLE=airlock-import-review` and any existing airlock import review workspaces will need upgrading. After upgrade run `make deploy-core` to reinstate and deleted DNS records.
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 <!-- markdownlint-disable MD041 -->
 ## 0.16.0 (Unreleased)
 
+**BREAKING CHANGES & MIGRATIONS**:
+To resolve the Airlock import issue described in ([#3767](https://github.com/microsoft/AzureTRE/pull/3767)) any existing airlock import review workspaces will need upgrading or recreating. After upgrade run `make deploy-core` to reinstate the DNS record.
+
 FEATURES:
 
 ENHANCEMENTS:
 
 BUG FIXES:
 * Enabling support for more than 20 users/groups in Workspace API ([#3759](https://github.com/microsoft/AzureTRE/pull/3759  ))
+* Airlock Import Review workspace uses dedicated DNS zone to prevent conflict with core ([#3767](https://github.com/microsoft/AzureTRE/pull/3767))
 
 COMPONENTS:
 

--- a/templates/workspaces/airlock-import-review/Dockerfile.tmpl
+++ b/templates/workspaces/airlock-import-review/Dockerfile.tmpl
@@ -20,7 +20,7 @@ RUN curl -o azuretre.tar.gz -L "https://github.com/microsoft/AzureTRE/archive/re
 
 # Copy and change the file extension of .terraform file to .tf
 COPY ./terraform/import_review_resources.terraform "${BUNDLE_DIR}"/terraform/import_review_resources.tf
-# Remove once base workspace includes this change
+# HACK: PR #3769: Remove once base workspace includes this change
 COPY ./terraform/network_output.terraform "${BUNDLE_DIR}"/terraform/network/temp_output.tf
 
 # PORTER_MIXINS

--- a/templates/workspaces/airlock-import-review/Dockerfile.tmpl
+++ b/templates/workspaces/airlock-import-review/Dockerfile.tmpl
@@ -9,7 +9,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     apt-get update && apt-get install -y git jq curl ca-certificates patch --no-install-recommends
 
-ARG AZURE_TRE_VERSION="0.14.0"
+ARG AZURE_TRE_VERSION="0.15.2"
 
 WORKDIR ${BUNDLE_DIR}
 
@@ -20,6 +20,8 @@ RUN curl -o azuretre.tar.gz -L "https://github.com/microsoft/AzureTRE/archive/re
 
 # Copy and change the file extension of .terraform file to .tf
 COPY ./terraform/import_review_resources.terraform "${BUNDLE_DIR}"/terraform/import_review_resources.tf
+# Remove once base workspace includes this change
+COPY ./terraform/network_output.terraform "${BUNDLE_DIR}"/terraform/network/temp_output.tf
 
 # PORTER_MIXINS
 

--- a/templates/workspaces/airlock-import-review/porter.yaml
+++ b/templates/workspaces/airlock-import-review/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-airlock-import-review
-version: 0.12.7
+version: 0.12.15
 description: "A workspace to do Airlock Data Import Reviews for Azure TRE"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/airlock-import-review/terraform/import_review_resources.terraform
+++ b/templates/workspaces/airlock-import-review/terraform/import_review_resources.terraform
@@ -30,17 +30,38 @@ resource "azurerm_private_endpoint" "sa_import_inprogress_pe" {
 
   lifecycle { ignore_changes = [tags] }
 
-  private_dns_zone_group {
-    name                 = "pdzg-stg-ip-import-blob-${local.workspace_resource_name_suffix}"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.blobcore.id]
-  }
-
   private_service_connection {
     name                           = "psc-stg-ip-import-blob-${local.workspace_resource_name_suffix}"
     private_connection_resource_id = data.azurerm_storage_account.sa_import_inprogress.id
     is_manual_connection           = false
     subresource_names              = ["Blob"]
   }
+
+  tags = local.tre_workspace_tags
+}
+
+resource "azurerm_private_dns_zone" "stg_import_inprogress_blob" {
+  name                = "${data.azurerm_storage_account.sa_import_inprogress.name}.${module.terraform_azurerm_environment_configuration.private_links["privatelink.blob.core.windows.net"]}"
+  resource_group_name = azurerm_resource_group.ws.name
+
+  tags = local.tre_workspace_tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "stg_import_inprogress_blob" {
+  name                  = "vnl-stg-ip-import-blob-${local.workspace_resource_name_suffix}"
+  resource_group_name   = azurerm_resource_group.ws.name
+  private_dns_zone_name = azurerm_private_dns_zone.stg_import_inprogress_blob.name
+  virtual_network_id    = module.network.vnet_id
+
+  tags = local.tre_workspace_tags
+}
+
+resource "azurerm_private_dns_a_record" "stg_import_inprogress_blob" {
+  name                = "@" # Root record
+  zone_name           = azurerm_private_dns_zone.stg_import_inprogress_blob.name
+  resource_group_name = azurerm_resource_group.ws.name
+  ttl                 = 300
+  records             = [azurerm_private_endpoint.sa_import_inprogress_pe.private_service_connection[0].private_ip_address]
 
   tags = local.tre_workspace_tags
 }

--- a/templates/workspaces/airlock-import-review/terraform/network_output.terraform
+++ b/templates/workspaces/airlock-import-review/terraform/network_output.terraform
@@ -1,4 +1,4 @@
-# Remove file when base workspace release updated
+# HACK: PR #3769: Remove file when base workspace release updated
 output "vnet_id" {
   value = azurerm_virtual_network.ws.id
 }

--- a/templates/workspaces/airlock-import-review/terraform/network_output.terraform
+++ b/templates/workspaces/airlock-import-review/terraform/network_output.terraform
@@ -1,0 +1,4 @@
+# Remove file when base workspace release updated
+output "vnet_id" {
+  value = azurerm_virtual_network.ws.id
+}

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 1.5.0
+version: 1.5.1
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/base/terraform/network/outputs.tf
+++ b/templates/workspaces/base/terraform/network/outputs.tf
@@ -1,3 +1,7 @@
+output "vnet_id" {
+  value = azurerm_virtual_network.ws.id
+}
+
 output "services_subnet_id" {
   value = azurerm_subnet.services.id
 }


### PR DESCRIPTION
Fixes #3767

To resolve the Airlock import issue described in ([#3767](https://github.com/microsoft/AzureTRE/pull/3767)) the new airlock import review tempalte in this PR will need registering using `make workspace_bundle BUNDLE=airlock-import-review` and any existing airlock import review workspaces will need upgrading. After upgrade run `make deploy-core` to reinstate and deleted DNS records.

## How is this addressed

- Remove DNS zone registration for review workspace private endpoint
- Create new DNS zone specific to import inprogress storage account
- Create root record to the storage account IP.
- Add temporary and permenant `vnet_id` output of the network module. Temp fix can be removed after the next release.

I have tested the end to end import process.