### PR TITLE
fixing react router dom version and switching to absolute routing whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- markdownlint-disable MD041 -->
 ## 0.17.0 (Unreleased)
 
+BUG FIXES:
+* Airlock: Creating an import/export request causes a routing error ([#3830](https://github.com/microsoft/AzureTRE/issues/3830))
+
 **BREAKING CHANGES & MIGRATIONS**:
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 ## 0.17.0 (Unreleased)
 
-BUG FIXES:
-* Airlock: Creating an import/export request causes a routing error ([#3830](https://github.com/microsoft/AzureTRE/issues/3830))
-
 **BREAKING CHANGES & MIGRATIONS**:
 
 FEATURES:
@@ -19,6 +16,7 @@ BUG FIXES:
 * Fix issue with workspace menu not working correctly([#3819](https://github.com/microsoft/AzureTRE/issues/3819))
 * Fix issue with connect button showing when no uri([#3820](https://github.com/microsoft/AzureTRE/issues/3820))
 * Fix user resource upgrade validation: use the parent_service_template_name instead of the parent_resource_id. ([#3824](https://github.com/microsoft/AzureTRE/issues/3824))
+* Airlock: Creating an import/export request causes a routing error ([#3830](https://github.com/microsoft/AzureTRE/issues/3830))
 
 COMPONENTS:
 

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.35.0",
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.3",
     "react-redux": "^8.0.4",
-    "react-router-dom": "6",
+    "react-router-dom": "6.21.1",
     "remark-gfm": "^3.0.1",
     "typescript": "^5.1.6",
     "web-vitals": "^3.3.0"

--- a/ui/app/src/components/shared/airlock/Airlock.tsx
+++ b/ui/app/src/components/shared/airlock/Airlock.tsx
@@ -255,7 +255,7 @@ export const Airlock: React.FunctionComponent = () => {
 
   const handleNewRequest = async (newRequest: AirlockRequest) => {
     await getAirlockRequests();
-    navigate(newRequest.id);
+    navigate(`/workspaces/${newRequest.workspaceId}/requests/${newRequest.id}`);
   };
 
   const quickFilters: ICommandBarItemProps[] = [


### PR DESCRIPTION
Fixes #3830  

This PR fixes the following:

- Nails down the react-dom-router dependency to version 6.21.1.
- Updates the routing path to be more absolute when creating an airlock request.
