### PR TITLE
Add permissions to pr_bot and flag_external_pr workflows

### DIFF
--- a/.github/workflows/flag_external_pr.yml
+++ b/.github/workflows/flag_external_pr.yml
@@ -10,6 +10,8 @@ jobs:
   check_author:
     name: Check PR author
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       # Ensure we have the script file for the github-script action to use
       - name: Checkout

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -18,6 +18,9 @@ jobs:
     # - the commenting user has write permissions (i.e. is OWNER or COLLABORATOR)
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: write
     outputs:
       command: ${{ steps.check_command.outputs.command }}
       prRef: ${{ steps.check_command.outputs.prRef }}
@@ -68,6 +71,8 @@ jobs:
     needs: [pr_comment]
     if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     environment: CICD
     name: Destroy PR env
     steps:
@@ -102,6 +107,8 @@ jobs:
     needs: [pr_comment]
     if: ${{ needs.pr_comment.outputs.command == 'test-destroy-env' && needs.pr_comment.outputs.branchRefId != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     environment: CICD
     name: Destroy branch env
     steps:


### PR DESCRIPTION
Fixes #3842 

## What is being addressed

Workflows don't have write access by default (a recent change) and this workflow writes/changes a PR hence need to be give permissions.