### PR TITLE
Update permissions for 'checks'

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -99,6 +99,9 @@ jobs:
   deploy_management:
     name: Deploy Management
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     environment: ${{ inputs.environmentName }}
     steps:
       - name: Show inputs
@@ -173,7 +176,7 @@ jobs:
 
       - name: Report check status start
         if: inputs.prHeadSha != ''
-        uses: LouisBrunner/checks-action@v1.6.0
+        uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ inputs.prHeadSha }}
@@ -806,6 +809,9 @@ jobs:
     name: Summary
     needs: [e2e_tests_smoke, e2e_tests_custom]
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     if: always()
     environment: ${{ inputs.environmentName }}
     steps:
@@ -816,7 +822,7 @@ jobs:
       # If prHeadSha is specified then explicity mark the checks for that SHA
       - name: Report check status
         if: inputs.prHeadSha != ''
-        uses: LouisBrunner/checks-action@v1.6.0
+        uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # the name must be identical to the one received by the real job

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       pull-requests: write
       checks: write
+      contents: read
     outputs:
       command: ${{ steps.check_command.outputs.command }}
       prRef: ${{ steps.check_command.outputs.prRef }}
@@ -58,7 +59,7 @@ jobs:
       # and will have to send it "manually"
       - name: Bypass E2E check-runs status
         if: ${{ steps.check_command.outputs.command == 'test-force-approve' }}
-        uses: LouisBrunner/checks-action@v1.6.0
+        uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # the name must be identical to the one received by the real job


### PR DESCRIPTION
## What is being addressed

There other places where workflows update github `checks` and need permissions to do that.
Also update the action version that does it.