### PR TITLE
Add permissions to parent workflows

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -26,6 +26,8 @@ jobs:
     name: "Deploy main"
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/deploy_tre_reusable.yml
+    permissions:
+      checks: write
     with:
       ciGitRef: ${{ github.ref }}
       e2eTestsCustomSelector: >-

--- a/.github/workflows/deploy_tre_branch.yml
+++ b/.github/workflows/deploy_tre_branch.yml
@@ -58,6 +58,8 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     needs: [prepare-not-main]
     uses: ./.github/workflows/deploy_tre_reusable.yml
+    permissions:
+      checks: write
     with:
       ciGitRef: ${{ github.ref }}
       prHeadSha: ${{ github.sha }}

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -150,6 +150,8 @@ jobs:
       needs.pr_comment.outputs.command == 'run-tests-shared-services'
     name: Deploy PR
     uses: ./.github/workflows/deploy_tre_reusable.yml
+    permissions:
+      checks: write
     with:
       prRef: ${{ needs.pr_comment.outputs.prRef }}
       prHeadSha: ${{ needs.pr_comment.outputs.prHeadSha }}


### PR DESCRIPTION
## What is being addressed

In a previous PR I've added permissions to reusable workflows and that needs to propagate up to the calling workflows too (if not, they assign default permissions which isn't enough).

Unfortunately this can't be tested until it reaches the main branch.