### PR TITLE
Fix argument quoting in second ACR job step in 'Deploy TRE Reusable' GitHub Action

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -253,10 +253,10 @@ jobs:
         run: |
           # shellcheck disable=SC2034,SC2015,SC2125
           for i in {1..3}; do
-            az acr login --name "${{ secrets.CI_CACHE_ACR_NAME }}" && ec=0 && break || ec=\$? && sleep 10
+            az acr login --name "${{ secrets.CI_CACHE_ACR_NAME }}" && ec=0 && break || ec="$?" && sleep 10
           done
           # shellcheck disable=SC2242
-          (exit \$ec)
+          (exit "$ec")
 
       - name: Push cached devcontainer
         run: docker image push ${{ env.CI_CACHE_ACR_URI }}/tredev:${{ inputs.DEVCONTAINER_TAG }}


### PR DESCRIPTION
# Resolves #3778

## What is being addressed

GitHub Action Deploy Azure TRE fails on first run at the [2nd ACR Login step](https://github.com/microsoft/AzureTRE/blob/6d589c49d6d647633109c70ee4636415b1ac17a8/.github/workflows/deploy_tre_reusable.yml#L247) with error $ec numeric argument required.

## How is this addressed

- Add double quotes