### PR TITLE
Destroy TRE script unbound variable fix

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -114,13 +114,13 @@ if [ "${keyvault}" != "0" ]; then
 
   keys=$(az keyvault key list --vault-name "${keyvault_name}" -o json | jq -r '.[].id')
   for key_id in ${keys}; do
-    echo "Deleting ${secret_id}"
+    echo "Deleting ${key_id}"
     az keyvault key delete --id "${key_id}"
   done
 
   certificates=$(az keyvault certificate list --vault-name "${keyvault_name}" -o json | jq -r '.[].id')
   for certificate_id in ${certificates}; do
-    echo "Deleting ${secret_id}"
+    echo "Deleting ${certificate_id}"
     az keyvault certificate delete --id "${certificate_id}"
   done
 


### PR DESCRIPTION
Small bug in the `destroy_env_no_terraform.sh` script -

In the for loops that delete keyvault keys and certificates, the `${secret_id}` variable is used in both loops instead of `${key_id}` and `${certificate_id}` respectively.

This only manifests with an error ("unbound variable") if your key vault doesn't contain secrets (mine did due to another unrelated issue) so won't occur under normal circumstances, however the stdout of the script will be incorrect.