### PR TITLE
Update Docker dependency update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,12 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 0
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Fixes #3867

This pull request updates the Docker dependency update schedule in the dependabot.yml file. The schedule is now set to run monthly and will ignore any version updates that are only semver patches. This change ensures that the Docker dependencies are regularly updated while avoiding unnecessary pull requests for minor version updates.