### PR TITLE
Improve documentation on TRE teardown

### DIFF
--- a/docs/tre-admins/tear-down.md
+++ b/docs/tre-admins/tear-down.md
@@ -6,7 +6,7 @@ To remove the Azure TRE and its resources from your Azure subscription run:
 make tre-destroy
 ```
 
-Alternatively, you can delete the resource groups in Azure Portal or using the CLI:
+Alternatively, you can directly delete the resource groups in Azure Portal or using the CLI, however the `make` method is recommended if you plan to re-deploy the Azure TRE since it performs [additional tidy up](https://github.com/microsoft/AzureTRE/blob/main/devops/scripts/destroy_env_no_terraform.sh) which prevent re-deployment errors.
 
 ```cmd
 az group delete --name <resource group name>


### PR DESCRIPTION
# Resolves #3777

## What is being addressed

Add a little info to the docs to nudge users to use `make tre-destroy` rather than `az group delete` since the latter will cause deployment errors if trying to re-deploy using the same TRE name.