### PR TITLE
Gitea Shared Service Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 0.18.0 (Unreleased)
 
 **BREAKING CHANGES & MIGRATIONS**:
-* Update Core Terraform Provider versions ([[#3919](https://github.com/microsoft/AzureTRE/issues/3919)])
+* Update Core Terraform Provider versions ([#3919](https://github.com/microsoft/AzureTRE/issues/3919))
 * Introduction of config value `enable_airlock_email_check`, which defaults to `false`, this is a change in behaviour. If you require email addresses for users before an airlock request is created, set to `true`. ([#3904](https://github.com/microsoft/AzureTRE/issues/3904))
 
 FEATURES:
@@ -22,6 +22,7 @@ BUG FIXES:
 * Dependency and Vulnerability updates
 * Add lifecycle rule to MySQL resources to stop them recreating on `update` ([#3993](https://github.com/microsoft/AzureTRE/issues/3993))
 * Fixes broken links on 'Using the Azure TRE -> Custom Templates' page of documentation ([[#4003](https://github.com/microsoft/AzureTRE/issues/4003)])
+* Add lifecycle rule to the Gitea Shared Service template for the MySQL resource to stop it recreating on `update` ([#4006](https://github.com/microsoft/AzureTRE/issues/4006))
 
 COMPONENTS:
 

--- a/templates/shared_services/gitea/terraform/mysql.tf
+++ b/templates/shared_services/gitea/terraform/mysql.tf
@@ -27,6 +27,8 @@ resource "azurerm_mysql_flexible_database" "gitea" {
   server_name         = azurerm_mysql_flexible_server.gitea.name
   charset             = "utf8"
   collation           = "utf8_unicode_ci"
+
+  lifecycle { ignore_changes = [charset, collation] }
 }
 
 moved {


### PR DESCRIPTION
# Resolves #4006 

## What is being addressed

Updating MySQL resource destorys and recreates the database.

## How is this addressed

- A lifecycle rule has been added for the `charset` and `collation` to stop it recreating.
