### PR TITLE
Revert "Weak hashes"

### DIFF
--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -292,7 +292,7 @@ function getRefIdForBranch(branchName) {
   return createShortHash(`refs/heads/${branchName}\n`);
 }
 function createShortHash(ref) {
-  const hash = createHash('sha2').update(ref, 'utf8').digest('hex')
+  const hash = createHash('sha1').update(ref, 'utf8').digest('hex')
   return hash.substring(0, 8);
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ BUG FIXES:
 * Add workaround to avoid name clashes for storage accounts([#3863](https://github.com/microsoft/AzureTRE/pull/3858))
 * Resource processor fails to deploy first workspace on fresh TRE deployment ([#3950](https://github.com/microsoft/AzureTRE/issues/3950))
 * Dependency and Vulnerability updates
-* Fix Weak hashes ([#3931](https://github.com/microsoft/AzureTRE/issues/3931))
 * Add lifecycle rule to MySQL resources to stop them recreating on `update` ([#3993](https://github.com/microsoft/AzureTRE/issues/3993))
 * Fixes broken links on 'Using the Azure TRE -> Custom Templates' page of documentation ([[#4003](https://github.com/microsoft/AzureTRE/issues/4003)])
 * Fix 'Renew Lets Encrypt Certificates' GitHub Action ([#3978](https://github.com/microsoft/AzureTRE/issues/3978))


### PR DESCRIPTION
Reverts microsoft/AzureTRE#3963

currently getting these errors:

```
Setting output 'ciGitRef: refs/pull/4011/merge
Error: Digest method not supported
    at new Hash (node:internal/crypto/hash:79:19)
    at createHash (node:crypto:139:10)
    at createShortHash (/home/runner/work/AzureTRE/AzureTRE/.github/scripts/build.js:295:16)
    at getRefIdForPr (/home/runner/work/AzureTRE/AzureTRE/.github/scripts/build.js:288:10)
    at Object.getCommandFromComment (/home/runner/work/AzureTRE/AzureTRE/.github/scripts/build.js:24:19)
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:4:14)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35425:12)
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:26)
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35497:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35553:3
```