### PR TITLE
Support plan mode deployment

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -16,6 +16,11 @@ on:  # yamllint disable-line rule:truthy
         type: environment
         default: CICD
         required: true
+      DEPLOY_MODE:
+        description: The deployment mode to use (plan or apply)
+        type: string
+        default: apply
+        required: true
 
 # This will prevent multiple runs of this entire workflow.
 # We should NOT cancel in progress runs as that can destabilize the environment.
@@ -38,6 +43,7 @@ jobs:
       environmentName: ${{ github.event.inputs.environment || 'CICD' }}
       E2E_TESTS_NUMBER_PROCESSES: 1
       DEVCONTAINER_TAG: 'latest'
+      DEPLOY_MODE: ${{ github.event.inputs.DEPLOY_MODE }}
     secrets:
       AAD_TENANT_ID: ${{ secrets.AAD_TENANT_ID }}
       ACR_NAME: ${{ secrets.ACR_NAME }}

--- a/devops/scripts/terraform_wrapper.sh
+++ b/devops/scripts/terraform_wrapper.sh
@@ -97,6 +97,10 @@ terraform init -input=false -backend=true -reconfigure \
     -backend-config="container_name=${container_name}" \
     -backend-config="key=${key}"
 
+if [[ ${DEPLOY_MODE} == "plan" ]]; then
+    tf_command="terraform plan -out=tfplan && terraform show -json tfplan > plan_output.json"
+fi
+
 RUN_COMMAND=1
 while [ $RUN_COMMAND = 1 ]
 do
@@ -126,5 +130,3 @@ do
         exit 1
     fi
 done
-
-

--- a/docs/tre-admins/setup-instructions/manual-deployment.md
+++ b/docs/tre-admins/setup-instructions/manual-deployment.md
@@ -71,6 +71,40 @@ Open your browser and navigate to the `/api/docs` route of the API:  `https://<a
 
 ![Swagger UI](../../assets/quickstart_swaggerui.png)
 
+## Using the DEPLOY_MODE variable
+
+The `DEPLOY_MODE` variable allows you to control whether the deployment runs in 'plan' mode or 'apply' mode. In 'plan' mode, the terraform plan is generated and can be reviewed before applying. In 'apply' mode, the terraform plan is applied directly.
+
+### Setting the DEPLOY_MODE variable
+
+To set the `DEPLOY_MODE` variable, use the following commands:
+
+```bash
+export DEPLOY_MODE=plan
+```
+
+or
+
+```bash
+export DEPLOY_MODE=apply
+```
+
+### Example usage
+
+To run the deployment in 'plan' mode:
+
+```bash
+export DEPLOY_MODE=plan
+make all
+```
+
+To run the deployment in 'apply' mode:
+
+```bash
+export DEPLOY_MODE=apply
+make all
+```
+
 ## Next steps
 
 * [Configure Shared Services](configuring-shared-services.md)

--- a/docs/tre-admins/setup-instructions/workflows.md
+++ b/docs/tre-admins/setup-instructions/workflows.md
@@ -147,6 +147,39 @@ Configure variables used in the deployment workflow:
 | `ENABLE_SWAGGER` | Optional. Determines whether the Swagger interface for the API will be available. Default value is `false`. |
 | `FIREWALL_SKU` | Optional. The SKU of the Azure Firewall instance. Default value is `Standard`. Allowed values [`Basic`, `Standard`, `Premium`]. See [Azure Firewall SKU feature comparison](https://learn.microsoft.com/en-us/azure/firewall/choose-firewall-sku). |
 
+### Using the DEPLOY_MODE variable
+
+The `DEPLOY_MODE` variable allows you to control whether the deployment runs in 'plan' mode or 'apply' mode. In 'plan' mode, the terraform plan is generated and can be reviewed before applying. In 'apply' mode, the terraform plan is applied directly.
+
+### Setting the DEPLOY_MODE variable
+
+To set the `DEPLOY_MODE` variable, use the following commands:
+
+```bash
+export DEPLOY_MODE=plan
+```
+
+or
+
+```bash
+export DEPLOY_MODE=apply
+```
+
+### Example usage
+
+To run the deployment in 'plan' mode:
+
+```bash
+export DEPLOY_MODE=plan
+make all
+```
+
+To run the deployment in 'apply' mode:
+
+```bash
+export DEPLOY_MODE=apply
+make all
+```
 
 ### Deploy the TRE using the workflow
 


### PR DESCRIPTION
Related to #4029

Add support for 'plan' mode deployments to evaluate the terraform plan before applying it.

* **devops/scripts/terraform_wrapper.sh**
  - Add a check for the `DEPLOY_MODE` variable.
  - Execute `terraform plan` without applying if `DEPLOY_MODE` is set to 'plan'.
  - Log the plan output to a file.

* **docs/tre-admins/setup-instructions/manual-deployment.md**
  - Add instructions on using the `DEPLOY_MODE` variable for 'plan' mode deployments.
  - Include examples of setting the `DEPLOY_MODE` variable to 'plan' and 'apply'.

* **.github/workflows/deploy_tre.yml**
  - Add an input for `DEPLOY_MODE` in the workflow.
  - Pass the `DEPLOY_MODE` input to the deployment script.

* **docs/tre-admins/setup-instructions/workflows.md**
  - Add instructions on using the `DEPLOY_MODE` variable for 'plan' mode deployments via the GitHub UI.
  - Include examples of setting the `DEPLOY_MODE` variable to 'plan' and 'apply'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/AzureTRE/issues/4029?shareId=2ecc9b66-5e23-4492-930e-5b8ae2dda742).