### PR TITLE
Fix resource processor porter install logs truncation

### DIFF
--- a/resource_processor/shared/logging.py
+++ b/resource_processor/shared/logging.py
@@ -95,6 +95,14 @@ def initialize_logging() -> logging.Logger:
     return logger
 
 
+def chunk_log_output(output: str, chunk_size: int = 30000):
+    """
+    Split the log output into smaller chunks.
+    """
+    for i in range(0, len(output), chunk_size):
+        yield output[i:i + chunk_size]
+
+
 def shell_output_logger(console_output: str, prefix_item: str, logging_level: int):
     if not console_output:
         logger.debug("shell console output is empty.")
@@ -118,4 +126,5 @@ def shell_output_logger(console_output: str, prefix_item: str, logging_level: in
     console_output = console_output.strip()
 
     if console_output:
-        logger.log(logging_level, f"{prefix_item} {console_output}")
+        for chunk in chunk_log_output(console_output):
+            logger.log(logging_level, f"{prefix_item} {chunk}")

--- a/resource_processor/tests_rp/test_logging.py
+++ b/resource_processor/tests_rp/test_logging.py
@@ -1,6 +1,6 @@
 from mock import patch
 import logging
-from shared.logging import shell_output_logger
+from shared.logging import shell_output_logger, chunk_log_output
 
 
 @patch("shared.logging.logger")
@@ -29,3 +29,20 @@ def test_shell_output_logger_normal_case(mock_logger):
     console_output = "Some logs"
     shell_output_logger(console_output, "prefix", logging.DEBUG)
     mock_logger.log.assert_called_with(logging.DEBUG, "prefix Some logs")
+
+
+@patch("shared.logging.logger")
+def test_shell_output_logger_chunked_logging(mock_logger):
+    console_output = "A" * 60000  # 60,000 characters long
+    shell_output_logger(console_output, "prefix", logging.DEBUG)
+    assert mock_logger.log.call_count == 2
+    mock_logger.log.assert_any_call(logging.DEBUG, f"prefix {'A' * 30000}")
+    mock_logger.log.assert_any_call(logging.DEBUG, f"prefix {'A' * 30000}")
+
+
+def test_chunk_log_output():
+    output = "A" * 60000  # 60,000 characters long
+    chunks = list(chunk_log_output(output, chunk_size=30000))
+    assert len(chunks) == 2
+    assert chunks[0] == "A" * 30000
+    assert chunks[1] == "A" * 30000


### PR DESCRIPTION
Related to #3992

Modify the `shell_output_logger` function in `resource_processor/shared/logging.py` to split lengthy log outputs into smaller chunks before logging.

* **Chunk Log Output**:
  - Add `chunk_log_output` helper function to split the log output into smaller chunks.
  - Update `shell_output_logger` to use `chunk_log_output` for logging lengthy outputs in chunks.

* **Tests**:
  - Add `test_shell_output_logger_chunked_logging` to verify chunked logging functionality.
  - Add `test_chunk_log_output` to test the `chunk_log_output` helper function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/AzureTRE/issues/3992?shareId=f3cdf8a6-311d-4988-b213-4cddbad040a0).