### PR TITLE
make the ARM_CLIENT_ID non mandatory in the bootstrap script

### DIFF
--- a/devops/terraform/bootstrap.sh
+++ b/devops/terraform/bootstrap.sh
@@ -15,7 +15,7 @@ az storage account create --resource-group "$TF_VAR_mgmt_resource_group_name" \
 
 # Grant user blob data contributor permissions
 echo -e "\n\e[34m»»» 🔑 \e[96mGranting Storage Blob Data Contributor role to the current user\e[0m..."
-if [ -n "$ARM_CLIENT_ID" ]; then
+if [ -n "${ARM_CLIENT_ID:-}" ]; then
     USER_OBJECT_ID=$(az ad sp show --id "$ARM_CLIENT_ID" --query id --output tsv)
 else
     USER_OBJECT_ID=$(az ad signed-in-user show --query id --output tsv)


### PR DESCRIPTION
# Tiny fix for https://github.com/microsoft/AzureTRE/pull/4104

## What is being addressed
Added a small fix to `bootstrap.sh` so that it doesn't require setting the non-mandatory `ARM_CLIENT_ID` environment variable in the config