### PR TITLE
Extend validation environment TTL

### DIFF
--- a/.github/workflows/clean_validation_envs.yml
+++ b/.github/workflows/clean_validation_envs.yml
@@ -4,7 +4,7 @@ name: Clean Validation Environments
 on:  # yamllint disable-line rule:truthy
   schedule:
     # Every 2 hours
-    - cron: "0 */2 * * *"
+    - cron: "0 */1 * * *"
   workflow_dispatch:
 
 jobs:
@@ -31,6 +31,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAIN_TRE_ID: ${{ secrets.TRE_ID }}
           GITHUB_REPOSITORY: ${{ github.repository}}
-          BRANCH_LAST_ACTIVITY_IN_HOURS_FOR_STOP: 2
+          BRANCH_LAST_ACTIVITY_IN_HOURS_FOR_STOP: 4
           BRANCH_LAST_ACTIVITY_IN_HOURS_FOR_DESTROY: 48
         run: devops/scripts/clean_ci_validation_envs.sh


### PR DESCRIPTION
# Resolves #4176 

## What is being addressed

Validation environments are stopped before tests are completed.

## How is this addressed

- Stop time extended to 4 hours and workflow is scheduled to run every 1 hour