### PR TITLE
Update aiohttp

### DIFF
--- a/api_app/requirements.txt
+++ b/api_app/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.10
+aiohttp==3.11.10
 azure-core==1.31.0
 azure-cosmos==4.7.0
 azure-eventgrid==4.20.0

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -8,4 +8,4 @@ pygments==2.16.1
 PyJWT==2.9.0
 azure-cli-core==2.65.0
 azure-identity==1.19.0
-aiohttp==3.10.10
+aiohttp==3.11.10

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -49,7 +49,7 @@ setup(
         "PyJWT==2.9.0",
         "azure-cli-core==2.65.0",
         "azure-identity==1.19.0",
-        "aiohttp==3.10.10"
+        "aiohttp==3.11.10"
     ],
 
     namespace_packages=[],

--- a/resource_processor/vmss_porter/requirements.txt
+++ b/resource_processor/vmss_porter/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.10
+aiohttp==3.11.10
 azure-cli-core==2.65.0
 azure-identity==1.19.0
 azure-monitor-opentelemetry==1.6.4


### PR DESCRIPTION
# Resolves HASH_SIGN_FOLLOWED_BY_ISSUE_NUMBER

## What is being addressed

aiohttp has been updated to 3.11.10 to fix 2 security issues that are fixed in this version. 

## How is this addressed

- Describe the changes made, and if appropriate, why they are addressed this way
- Note any pending work (with links to the issues that will address them)
- Update documentation
- Update CHANGELOG.md if needed
- Increment template version if needed, for guidelines see [Authoring templates - versioning](https://microsoft.github.io/AzureTRE/tre-workspace-authors/authoring-workspace-templates/#versioning)
