### PR TITLE
Fix unable to delete Guacamole VM in stopped state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ BUG FIXES:
 - Create policy to allow all user to configure color profiles to remove auth dialog. ([#4184](https://github.com/microsoft/AzureTRE/pull/4184))
 - Pre configure VS code option to prevent script failure ([#4185](https://github.com/microsoft/AzureTRE/pull/4185))
 - Enable symlinks to work on Linux VM shared storage ([#4180](https://github.com/microsoft/AzureTRE/issues/4180))
+- Unable to delete virtual machines, add skip_shutdown_and_force_delete = true ([#4135](https://github.com/microsoft/AzureTRE/issues/4135))
 
 COMPONENTS:
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-export-reviewvm
-version: 0.1.12
+version: 0.1.13
 description: "An Azure TRE User Resource Template for reviewing Airlock export requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/main.tf
@@ -32,6 +32,9 @@ provider "azurerm" {
       recover_soft_deleted_certificates = true
       recover_soft_deleted_keys         = true
     }
+    virtual_machine {
+      skip_shutdown_and_force_delete = true
+    }
   }
   storage_use_azuread = true
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-import-reviewvm
-version: 0.2.12
+version: 0.2.13
 description: "An Azure TRE User Resource Template for reviewing Airlock import requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/main.tf
@@ -32,6 +32,9 @@ provider "azurerm" {
       recover_soft_deleted_certificates = true
       recover_soft_deleted_keys         = true
     }
+    virtual_machine {
+      skip_shutdown_and_force_delete = true
+    }
   }
   storage_use_azuread = true
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.0.7
+version: 1.0.8
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/main.tf
@@ -33,6 +33,9 @@ provider "azurerm" {
       recover_soft_deleted_certificates = true
       recover_soft_deleted_keys         = true
     }
+    virtual_machine {
+      skip_shutdown_and_force_delete = true
+    }
   }
   storage_use_azuread = true
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.0.6
+version: 1.0.7
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
@@ -28,6 +28,9 @@ provider "azurerm" {
       recover_soft_deleted_certificates = true
       recover_soft_deleted_keys         = true
     }
+    virtual_machine {
+      skip_shutdown_and_force_delete = true
+    }
   }
   storage_use_azuread = true
 }


### PR DESCRIPTION
Fixes #4135

Add `skip_shutdown_and_force_delete` configuration to Guacamole VM templates to fix deletion issue.

* Modify `main.tf` files in `templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform`, `guacamole-azure-import-reviewvm/terraform`, `guacamole-azure-linuxvm/terraform`, and `guacamole-azure-windowsvm/terraform` to include `skip_shutdown_and_force_delete = true` under the `virtual_machine` block in the `features` section.
* Update `porter.yaml` files in `templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm`, `guacamole-azure-import-reviewvm`, `guacamole-azure-windowsvm`, and `guacamole-azure-linuxvm` to increment the version numbers.
* Update `CHANGELOG.md` to include the fix for the deletion issue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/AzureTRE/pull/4203?shareId=cfeaf941-f47c-4f71-96b0-c522cfaaa773).