### PR TITLE
Fix VM actions when workspace storage doesn't allow shared key access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ BUG FIXES:
 * Fix failing tests, .env missing and storage logs ([#4207](https://github.com/microsoft/AzureTRE/issues/4207))
 * Unable to delete virtual machines, add skip_shutdown_and_force_delete = true ([#4135](https://github.com/microsoft/AzureTRE/issues/4135))
 * Bump terraform version in windows VM template ([#4212](https://github.com/microsoft/AzureTRE/issues/4212))
+* Fix VM actions where Workspace shared storage doesn't allow shared key access ([#4222](https://github.com/microsoft/AzureTRE/issues/4222))
 
 COMPONENTS:
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.0
+version: 1.2.1
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.1
+version: 1.2.2
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/data.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/data.tf
@@ -43,3 +43,30 @@ data "azurerm_user_assigned_identity" "ws_encryption_identity" {
   name                = local.encryption_identity_name
   resource_group_name = data.azurerm_resource_group.ws.name
 }
+
+data "template_file" "get_apt_keys" {
+  template = file("${path.module}/get_apt_keys.sh")
+  vars = {
+    NEXUS_PROXY_URL = local.nexus_proxy_url
+  }
+}
+
+data "template_file" "pypi_sources_config" {
+  template = file("${path.module}/pypi_sources_config.sh")
+  vars = {
+    nexus_proxy_url = local.nexus_proxy_url
+  }
+}
+
+data "template_file" "apt_sources_config" {
+  template = file("${path.module}/apt_sources_config.yml")
+  vars = {
+    nexus_proxy_url = local.nexus_proxy_url
+    apt_sku         = local.apt_sku
+  }
+}
+
+data "azurerm_storage_account" "stg" {
+  name                = local.storage_name
+  resource_group_name = data.azurerm_resource_group.ws.name
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
@@ -123,33 +123,11 @@ data "template_file" "vm_config" {
     STORAGE_ACCOUNT_NAME  = data.azurerm_storage_account.stg.name
     STORAGE_ACCOUNT_KEY   = data.azurerm_storage_account.stg.primary_access_key
     HTTP_ENDPOINT         = data.azurerm_storage_account.stg.primary_file_endpoint
-    FILESHARE_NAME        = var.shared_storage_access ? data.azurerm_storage_share.shared_storage[0].name : ""
+    FILESHARE_NAME        = var.shared_storage_access ? var.shared_storage_name : ""
     NEXUS_PROXY_URL       = local.nexus_proxy_url
     CONDA_CONFIG          = local.selected_image.conda_config ? 1 : 0
     VM_USER               = random_string.username.result
     APT_SKU               = replace(local.apt_sku, ".", "")
-  }
-}
-
-data "template_file" "get_apt_keys" {
-  template = file("${path.module}/get_apt_keys.sh")
-  vars = {
-    NEXUS_PROXY_URL = local.nexus_proxy_url
-  }
-}
-
-data "template_file" "pypi_sources_config" {
-  template = file("${path.module}/pypi_sources_config.sh")
-  vars = {
-    nexus_proxy_url = local.nexus_proxy_url
-  }
-}
-
-data "template_file" "apt_sources_config" {
-  template = file("${path.module}/apt_sources_config.yml")
-  vars = {
-    nexus_proxy_url = local.nexus_proxy_url
-    apt_sku         = local.apt_sku
   }
 }
 
@@ -160,17 +138,6 @@ resource "azurerm_key_vault_secret" "linuxvm_password" {
   tags         = local.tre_user_resources_tags
 
   lifecycle { ignore_changes = [tags] }
-}
-
-data "azurerm_storage_account" "stg" {
-  name                = local.storage_name
-  resource_group_name = data.azurerm_resource_group.ws.name
-}
-
-data "azurerm_storage_share" "shared_storage" {
-  count                = var.shared_storage_access ? 1 : 0
-  name                 = var.shared_storage_name
-  storage_account_name = data.azurerm_storage_account.stg.name
 }
 
 resource "azurerm_dev_test_global_vm_shutdown_schedule" "shutdown_schedule" {

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/main.tf
@@ -33,9 +33,6 @@ provider "azurerm" {
       recover_soft_deleted_certificates = true
       recover_soft_deleted_keys         = true
     }
-    virtual_machine {
-      skip_shutdown_and_force_delete = true
-    }
   }
   storage_use_azuread = true
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.2.0
+version: 1.2.1
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.2.1
+version: 1.2.2
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/data.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/data.tf
@@ -37,12 +37,6 @@ data "azurerm_storage_account" "stg" {
   resource_group_name = data.azurerm_resource_group.ws.name
 }
 
-data "azurerm_storage_share" "shared_storage" {
-  count                = var.shared_storage_access ? 1 : 0
-  name                 = var.shared_storage_name
-  storage_account_name = data.azurerm_storage_account.stg.name
-}
-
 data "azurerm_key_vault_key" "ws_encryption_key" {
   count        = var.enable_cmk_encryption ? 1 : 0
   name         = local.cmk_name

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/main.tf
@@ -28,9 +28,6 @@ provider "azurerm" {
       recover_soft_deleted_certificates = true
       recover_soft_deleted_keys         = true
     }
-    virtual_machine {
-      skip_shutdown_and_force_delete = true
-    }
   }
   storage_use_azuread = true
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -53,7 +53,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
       StorageAccountName     = data.azurerm_storage_account.stg.name
       StorageAccountKey      = data.azurerm_storage_account.stg.primary_access_key
       StorageAccountFileHost = data.azurerm_storage_account.stg.primary_file_host
-      FileShareName          = var.shared_storage_access ? data.azurerm_storage_share.shared_storage[0].name : ""
+      FileShareName          = var.shared_storage_access ? var.shared_storage_name : ""
       CondaConfig            = local.selected_image.conda_config ? 1 : 0
     }
   ))


### PR DESCRIPTION
# Resolves #4221 

## What is being addressed

Workspace storage that doesn't allow shared key access blocks any VM activity post initial deployment.

## How is this addressed

- The TF data object can't be used as that uses shared key to access Azure Files. Since the only usage of the object is to get the share name which we anyway receive as a variable (and pass in the data object), we can just remove it and use the variable directly. This will remove the need for TF to reference the Azure Files object and avoid this problem.