### PR TITLE
Fix deletion of Guacamole VM in stopped state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ ENHANCEMENTS:
 * Enhance DPI of Linux display ([[#4200](https://github.com/microsoft/AzureTRE/issues/4200)])
 * Update Admin VM versions ([[#4217](https://github.com/microsoft/AzureTRE/issues/4217)])
 * Update devcontainer/RP/API package versions: base image, docker, az cli, YQ ([#4225](https://github.com/microsoft/AzureTRE/pull/4225))
+* Purge container repos individually in when using `make tre-destroy` ([#4230](https://github.com/microsoft/AzureTRE/pull/4230))
 * Upgrade Python version from 3.8 to 3.12 ([#3949](https://github.com/microsoft/AzureTRE/issues/3949))Upgrade Python version from 3.8 to 3.12 (#3949)
 * Disable storage account key usage ([[#4227](https://github.com/microsoft/AzureTRE/issues/4227)])
 * Update Guacamole dependencies ([[#4232](https://github.com/microsoft/AzureTRE/issues/4232)])

--- a/templates/scripts/delete_azure_resources.sh
+++ b/templates/scripts/delete_azure_resources.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Parameters
+tre_id=$1
+workspace_id=$2
+workspace_service_id=$3
+user_resource_id=$4
+
+# Build the tag filter query
+tag_filters="--tag tre_resource_id=$tre_id"
+[ -n "$workspace_id" ] && tag_filters="$tag_filters --tag tre_workspace_id=$workspace_id"
+[ -n "$workspace_service_id" ] && tag_filters="$tag_filters --tag tre_workspace_service_id=$workspace_service_id"
+[ -n "$user_resource_id" ] && tag_filters="$tag_filters --tag tre_user_resource_id=$user_resource_id"
+
+# login to azure
+az login --identity
+
+# Get the resource IDs with the specified tags
+resource_ids=$(az resource list "$tag_filters" --query "[].id" -o tsv)
+
+# Delete the resources
+if [ -n "$resource_ids" ]; then
+  az resource delete --ids "$resource_ids" --yes
+else
+  echo "No resources found with the specified tags."
+fi

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/Dockerfile.tmpl
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/Dockerfile.tmpl
@@ -6,4 +6,8 @@ FROM --platform=linux/amd64 debian:bookworm-slim
 # PORTER_MIXINS
 
 # Use the BUNDLE_DIR build argument to copy files into the bundle
+RUN mkdir -p ${BUNDLE_DIR}/app
+# hadolint ignore=DL3022
+COPY --from=scripts --link . ${BUNDLE_DIR}/scripts/
+
 COPY --link . ${BUNDLE_DIR}/

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter-build-context.env
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter-build-context.env
@@ -1,0 +1,1 @@
+export PORTER_BUILD_CONTEXT="scripts=../../../../scripts"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.3
+version: 1.3.1
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -243,6 +243,15 @@ uninstall:
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
         container_name: ${ bundle.parameters.tfstate_container_name }
         key: ${ bundle.parameters.id }
+
+  - exec:
+      description: "Run the clean_up_resources.sh script"
+      command: "./scripts/delete_azure_resources.sh"
+      arguments:
+        - ${ bundle.parameters.tre_id }
+        - ${ bundle.parameters.workspace_id }
+        - ${ bundle.parameters.parent_service_id }
+        - ${ bundle.parameters.id }
 
 start:
   - terraform:


### PR DESCRIPTION
Draft - what think about this approach with a script to ensure child resources are deleted? Need to do other VMs.

Add a configuration option to Guacamole VM templates to skip shutdown and force deletion, resolving the issue where VMs in a stopped state cannot be deleted. Update relevant Terraform and Porter files to implement this change and increment version numbers accordingly.

Fixes #4135