### PR TITLE
Add mermaid diagram for Airlock export request process

### DIFF
--- a/docs/azure-tre-overview/airlock.md
+++ b/docs/azure-tre-overview/airlock.md
@@ -141,6 +141,21 @@ graph LR
 ```
 > Data movement in an Airlock import request
 
+```mermaid
+graph LR
+  subgraph TRE workspace
+  data(Data to export)-->A
+  A[(stalexint</br>export internal)]-->|Request Submitted| B
+  B[(stalexip</br>export in-progress)]-->|Security issues found| D[(stalexblocked</br>export blocked)] 
+  B-->|No security issues found| review{Manual</br>Approval} 
+  review-->|Rejected| C[(stalexrej</br>export rejected)]
+  end
+  subgraph External
+  review-->|Approved| E[(stalexapp</br>export approved)]
+  end
+```
+> Data movement in an Airlock export request
+
 
 TRE:
 


### PR DESCRIPTION
## What is being addressed

Airlock data movement for import request is documented with a diagram, this PR adds similar diagram for the export request.

## How is this addressed

- Add mermaid diagram for export request


![image](https://github.com/user-attachments/assets/2d6ffd79-2861-46d6-812d-773dd7588dac)
