### PR TITLE
Validation missing from template registration API endpoints

### DIFF
--- a/api_app/api/helpers.py
+++ b/api_app/api/helpers.py
@@ -6,6 +6,7 @@ from db.errors import UnableToAccessDatabase
 from db.repositories.base import BaseRepository
 from resources.strings import UNABLE_TO_GET_STATE_STORE_CLIENT
 from services.logging import logger
+from models.domain.resource import ResourceType
 
 
 def get_repository(repo_type: Type[BaseRepository],) -> Callable:
@@ -20,3 +21,8 @@ def get_repository(repo_type: Type[BaseRepository],) -> Callable:
             )
 
     return _get_repo
+
+
+def validate_resource_type(resource_type: str, expected_type: ResourceType):
+    if resource_type != expected_type:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid resourceType for {expected_type.value} template")

--- a/api_app/api/routes/shared_service_templates.py
+++ b/api_app/api/routes/shared_service_templates.py
@@ -2,7 +2,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import parse_obj_as
 
-from api.helpers import get_repository
+from api.helpers import get_repository, validate_resource_type
 from db.errors import EntityDoesNotExist, EntityVersionExist, InvalidInput
 from db.repositories.resource_templates import ResourceTemplateRepository
 from models.domain.resource import ResourceType
@@ -33,6 +33,7 @@ async def get_shared_service_template(shared_service_template_name: str, is_upda
 
 @shared_service_templates_core_router.post("/shared-service-templates", status_code=status.HTTP_201_CREATED, response_model=SharedServiceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_SHARED_SERVICE_TEMPLATES, dependencies=[Depends(get_current_admin_user)])
 async def register_shared_service_template(template_input: SharedServiceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository))) -> ResourceTemplateInResponse:
+    validate_resource_type(template_input.resourceType, ResourceType.SharedService)
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.SharedService)
     except EntityVersionExist:

--- a/api_app/api/routes/workspace_service_templates.py
+++ b/api_app/api/routes/workspace_service_templates.py
@@ -4,7 +4,7 @@ from pydantic import parse_obj_as
 
 from api.routes.resource_helpers import get_template
 from db.errors import EntityVersionExist, InvalidInput
-from api.helpers import get_repository
+from api.helpers import get_repository, validate_resource_type
 from db.repositories.resource_templates import ResourceTemplateRepository
 from models.domain.resource import ResourceType
 from models.schemas.resource_template import ResourceTemplateInResponse, ResourceTemplateInformationInList
@@ -30,6 +30,7 @@ async def get_workspace_service_template(service_template_name: str, is_update: 
 
 @workspace_service_templates_core_router.post("/workspace-service-templates", status_code=status.HTTP_201_CREATED, response_model=WorkspaceServiceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_WORKSPACE_SERVICE_TEMPLATES, dependencies=[Depends(get_current_admin_user)])
 async def register_workspace_service_template(template_input: WorkspaceServiceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository))) -> ResourceTemplateInResponse:
+    validate_resource_type(template_input.resourceType, ResourceType.WorkspaceService)
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.WorkspaceService)
     except EntityVersionExist:

--- a/api_app/api/routes/workspace_templates.py
+++ b/api_app/api/routes/workspace_templates.py
@@ -2,7 +2,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import parse_obj_as
 
-from api.helpers import get_repository
+from api.helpers import get_repository, validate_resource_type
 from db.errors import EntityVersionExist, InvalidInput
 from db.repositories.resource_templates import ResourceTemplateRepository
 from models.domain.resource import ResourceType
@@ -30,6 +30,7 @@ async def get_workspace_template(workspace_template_name: str, is_update: bool =
 
 @workspace_templates_admin_router.post("/workspace-templates", status_code=status.HTTP_201_CREATED, response_model=WorkspaceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_WORKSPACE_TEMPLATES)
 async def register_workspace_template(template_input: WorkspaceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository))) -> ResourceTemplateInResponse:
+    validate_resource_type(template_input.resourceType, ResourceType.Workspace)
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.Workspace)
     except EntityVersionExist:

--- a/api_app/tests_ma/test_api/test_routes/test_workspace_templates.py
+++ b/api_app/tests_ma/test_api/test_routes/test_workspace_templates.py
@@ -75,8 +75,8 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_updating_current_and_template_not_found_create_one(self, get_name_ver_mock, get_current_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
-        get_name_ver_mock.side_effect = EntityDoesNotExist
-        get_current_mock.side_effect = EntityDoesNotExist
+        get_name_ver_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
         create_template_mock.return_value = basic_resource_template
 
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
@@ -89,9 +89,9 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_updating_current_and_template_found_update_and_add(self, get_template_by_name_and_version_mock, get_current_template_mock, update_item_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
-        get_template_by_name_and_version_mock.side_effect = EntityDoesNotExist
-        get_current_template_mock.return_value = basic_resource_template
-        create_template_mock.return_value = basic_resource_template
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_template_mock.return.value = basic_resource_template
+        create_template_mock.return.value = basic_resource_template
 
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
 
@@ -103,13 +103,13 @@ class TestWorkspaceTemplate:
     # POST /workspace-templates
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_same_name_and_version_template_not_allowed(self, get_template_by_name_and_version_mock, app, client, input_workspace_template):
-        get_template_by_name_and_version_mock.return_value = ["exists"]
+        get_template_by_name_and_version_mock.return.value = ["exists"]
 
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
 
         assert response.status_code == status.HTTP_409_CONFLICT
 
-    @patch("api.routes.workspace_service_templates.ResourceTemplateRepository.create_and_validate_template", side_effect=InvalidInput)
+    @patch("api.routes.workspace_service_templates.ResourceTemplateRepository.create_and_validate_template", side.effect=InvalidInput)
     async def test_creating_a_workspace_template_raises_http_422_if_step_ids_are_duplicated(self, _, client, app, input_workspace_template):
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
 
@@ -119,7 +119,7 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     async def test_workspace_templates_by_name_returns_enriched_workspace_template(self, get_current_template_mock, app, client, workspace_template_without_enriching):
         template_name = "template1"
-        get_current_template_mock.return_value = workspace_template_without_enriching(template_name)
+        get_current_template_mock.return.value = workspace_template_without_enriching(template_name)
 
         response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_TEMPLATE_BY_NAME, workspace_template_name=template_name))
 
@@ -134,7 +134,7 @@ class TestWorkspaceTemplate:
     ])
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     async def test_workspace_templates_by_name_returns_returns_error_status_based_on_exception(self, get_current_template_mock, exception, expected_status, app, client):
-        get_current_template_mock.side_effect = exception
+        get_current_template_mock.side.effect = exception
 
         response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_TEMPLATE_BY_NAME, workspace_template_name="tre-workspace-base"))
 
@@ -145,9 +145,9 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_not_updating_current_and_new_registration_current_is_enforced(self, get_name_ver_mock, get_current_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
         input_workspace_template.current = False
-        get_name_ver_mock.side_effect = EntityDoesNotExist
-        get_current_mock.side_effect = EntityDoesNotExist
-        create_template_mock.return_value = basic_resource_template
+        get_name_ver_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
+        create_template_mock.return.value = basic_resource_template
 
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
 
@@ -158,9 +158,9 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_creating_template_enriched_template_is_returned(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
-        get_template_by_name_and_version_mock.side_effect = EntityDoesNotExist
-        get_current_template_mock.side_effect = EntityDoesNotExist
-        create_template_mock.return_value = basic_resource_template
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
+        create_template_mock.return.value = basic_resource_template
 
         response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
 
@@ -173,10 +173,10 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_creating_workspace_service_template_custom_actions_is_set(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
-        get_template_by_name_and_version_mock.side_effect = EntityDoesNotExist
-        get_current_template_mock.side_effect = EntityDoesNotExist
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
         basic_resource_template.customActions = [CustomAction(name='my-custom-action', description='This is a test custom action')]
-        create_template_mock.return_value = basic_resource_template
+        create_template_mock.return.value = basic_resource_template
 
         expected_template = parse_obj_as(WorkspaceTemplateInResponse, enrich_workspace_template(basic_resource_template))
 
@@ -188,10 +188,10 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_creating_workspace_service_template_custom_actions_is_not_set(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
-        get_template_by_name_and_version_mock.side_effect = EntityDoesNotExist
-        get_current_template_mock.side_effect = EntityDoesNotExist
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
         basic_resource_template.customActions = []
-        create_template_mock.return_value = basic_resource_template
+        create_template_mock.return.value = basic_resource_template
         input_workspace_template_dict = input_workspace_template.dict()
         input_workspace_template_dict.pop("customActions")
 
@@ -203,9 +203,9 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_creating_workspace_template_workspace_resource_type_is_set(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
-        get_template_by_name_and_version_mock.side_effect = EntityDoesNotExist
-        get_current_template_mock.side_effect = EntityDoesNotExist
-        create_template_mock.return_value = basic_resource_template
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
+        create_template_mock.return.value = basic_resource_template
 
         await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
 
@@ -215,10 +215,39 @@ class TestWorkspaceTemplate:
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
     @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
     async def test_when_creating_workspace_service_template_service_resource_type_is_set(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_workspace_service_template):
-        get_template_by_name_and_version_mock.side_effect = EntityDoesNotExist
-        get_current_template_mock.side_effect = EntityDoesNotExist
-        create_template_mock.return_value = basic_workspace_service_template
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
+        create_template_mock.return.value = basic_workspace_service_template
 
         await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_SERVICE_TEMPLATES), json=input_workspace_template.dict())
 
         create_template_mock.assert_called_once_with(input_workspace_template, ResourceType.WorkspaceService, '')
+
+    # Add test cases to validate resourceType property in register_workspace_template function
+    @patch("api.routes.workspace_templates.ResourceTemplateRepository.create_template")
+    @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
+    @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
+    async def test_register_workspace_template_invalid_resource_type(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
+        input_workspace_template.resourceType = ResourceType.WorkspaceService
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
+        create_template_mock.return.value = basic_resource_template
+
+        response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Invalid resourceType for workspace template"
+
+    @patch("api.routes.workspace_templates.ResourceTemplateRepository.create_template")
+    @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_current_template")
+    @patch("api.routes.workspace_templates.ResourceTemplateRepository.get_template_by_name_and_version")
+    async def test_register_workspace_template_valid_resource_type(self, get_template_by_name_and_version_mock, get_current_template_mock, create_template_mock, app, client, input_workspace_template, basic_resource_template):
+        input_workspace_template.resourceType = ResourceType.Workspace
+        get_template_by_name_and_version_mock.side.effect = EntityDoesNotExist
+        get_current_mock.side.effect = EntityDoesNotExist
+        create_template_mock.return.value = basic_resource_template
+
+        response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_workspace_template.dict())
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["resourceType"] == ResourceType.Workspace


### PR DESCRIPTION
Add validation for `resourceType` property in template registration API endpoints.

* **Helpers**:
  - Add `validate_resource_type` function in `api_app/api/helpers.py` to validate the `resourceType` property.
  - Add missing import for `ResourceType` in `api_app/api/helpers.py`.

* **Workspace Templates**:
  - Use `validate_resource_type` in `register_workspace_template` function in `api_app/api/routes/workspace_templates.py`.
  - Add test cases in `api_app/tests_ma/test_api/test_routes/test_workspace_templates.py` to validate `resourceType` property in `register_workspace_template` function.

* **Workspace Service Templates**:
  - Use `validate_resource_type` in `register_workspace_service_template` function in `api_app/api/routes/workspace_service_templates.py`.
  - Add test cases in `api_app/tests_ma/test_api/test_routes/test_workspace_service_templates.py` to validate `resourceType` property in `register_workspace_service_template` function.

* **Shared Service Templates**:
  - Use `validate_resource_type` in `register_shared_service_template` function in `api_app/api/routes/shared_service_templates.py`.
  - Add test cases in `api_app/tests_ma/test_api/test_routes/test_shared_service_templates.py` to validate `resourceType` property in `register_shared_service_template` function.

