### PR TITLE
Expanding industry coverage in Azure TRE Overview documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,22 +2,26 @@
 
 ## What is Azure TRE?
 
-Across the health industry, be it a pharmaceutical company interrogating clinical trial results, or a public health provider analyzing electronic health records, there is the need to enable researchers, analysts, and developers to work with sensitive data sets.  
+Across multiple industries, be it a pharmaceutical company interrogating clinical trial results, a public health provider analyzing electronic health records, or an engineering organization working on next-generation systems, there is a need to enable researchers and solution developers to collaborate on sensitive data.  
 
-Trusted Research Environments (TREs) enable organisations to provide research teams secure access to these data sets along side tooling to ensure a researchers can be productive. Further information on TREs in general can be found in many places, one good resource is [HDR UK](https://www.hdruk.ac.uk/access-to-health-data/trusted-research-environments/).
+Trusted Research Environments (TREs) enable organisations to provide research and development (R&D) teams secure access to data alongside tooling to ensure productivity. Further information on TREs in general can be found in many places, one good resource specifically for healthcare is [HDR UK](https://www.hdruk.ac.uk/access-to-health-data/trusted-research-environments/).
 
-The Azure Trusted Research Environment project is an accelerator to assist Microsoft customers and partners who want to build out Trusted Research environments on Azure. This project enables authorized users to deploy and configure secure workspaces and researcher tooling without a dependency on IT teams.  
+Azure TRE is finding new applications and to date, has been used as the basis for exploring future secure collaboration environments in government and manufacturing. Workloads investigated include systems and software engineering. In truth, any workload in any industry could theoretically be supported with extensions to Azure TRE.
+
+The Azure Trusted Research Environment project is an accelerator to assist Microsoft customers and partners who want to build out Trusted Research environments on Azure. This project enables authorized users to deploy and configure secure workspaces and R&D tooling without a dependency on IT teams.  
 
 This project is typically implemented alongside a data platform that provides research ready datasets to TRE workspaces:
 
 ![Concepts](assets/TRE_Overview.png)
+
+Azure TRE has also been proven to handle unstructured data scenarios. For example, collaborative Computer Aided Design (CAD), with Product Lifecycle Management integration.
 
 TREs are not “one size fits all”, hence although the Azure TRE has a number of out of the box features, the project has been built be extensible, and hence tooling and data platform agnostic.
 
 Core features include:
 
 - Self-service for administrators – workspace creation and administration
-- Self-service for research teams – research tooling creation and administration
+- Self-service for R&D teams – R&D tooling creation and administration
 - Package and repository mirroring
 - Extensible architecture - build your own service templates as required
 - Microsoft Entra ID integration

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Across multiple industries, be it a pharmaceutical company interrogating clinica
 
 Trusted Research Environments (TREs) enable organisations to provide research and development (R&D) teams secure access to data alongside tooling to ensure productivity. Further information on TREs in general can be found in many places, one good resource specifically for healthcare is [HDR UK](https://www.hdruk.ac.uk/access-to-health-data/trusted-research-environments/).
 
-Azure TRE is finding new applications and to date, has been used as the basis for exploring future secure collaboration environments in manufacturing. Workloads investigated include systems and software engineering. In truth, any workload in any industry could theoretically be supported with extensions to Azure TRE.
+Azure TRE is finding new applications and to date, has been used as the basis for exploring future secure collaboration environments in engineering. Workloads investigated include systems and software development. In truth, any workload in any industry could theoretically be supported with extensions to Azure TRE.
 
 The Azure Trusted Research Environment project is an accelerator to assist Microsoft customers and partners who want to build out Trusted Research environments on Azure. This project enables authorized users to deploy and configure secure workspaces and R&D tooling without a dependency on IT teams.  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Across multiple industries, be it a pharmaceutical company interrogating clinica
 
 Trusted Research Environments (TREs) enable organisations to provide research and development (R&D) teams secure access to data alongside tooling to ensure productivity. Further information on TREs in general can be found in many places, one good resource specifically for healthcare is [HDR UK](https://www.hdruk.ac.uk/access-to-health-data/trusted-research-environments/).
 
-Azure TRE is finding new applications and to date, has been used as the basis for exploring future secure collaboration environments in government and manufacturing. Workloads investigated include systems and software engineering. In truth, any workload in any industry could theoretically be supported with extensions to Azure TRE.
+Azure TRE is finding new applications and to date, has been used as the basis for exploring future secure collaboration environments in manufacturing. Workloads investigated include systems and software engineering. In truth, any workload in any industry could theoretically be supported with extensions to Azure TRE.
 
 The Azure Trusted Research Environment project is an accelerator to assist Microsoft customers and partners who want to build out Trusted Research environments on Azure. This project enables authorized users to deploy and configure secure workspaces and R&D tooling without a dependency on IT teams.  
 


### PR DESCRIPTION
# Expands list of industries that Azure TRE is being used in today to include engineering.

## What is being addressed

Updates to Azure TRE Overview documentation (index.md) to expand relevant industries to include engineering in addition to the original health industry only. Azure TRE has been used as the basis of a soluiton for this vertical and we need to highlight this applicability to future readers of the documentation.

## How is this addressed

- Addition of language to broaden applicability of Azure TRE to engineering use.
- Expanding 'Research' and 'researchers' to 'Research and Development (R&D)' to cover engineering development workloads that are not limited to research only.
- This is a documentation update only with no code changes.