### PR TITLE
Update disk size for Linux and Windows VMs

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/parameters.json
@@ -99,6 +99,18 @@
       "source": {
         "env": "KEY_STORE_ID"
       }
+    },
+    {
+      "name": "os_disk_account_type",
+      "source": {
+        "env": "OS_DISK_ACCOUNT_TYPE"
+      }
+    },
+    {
+      "name": "os_disk_size",
+      "source": {
+        "env": "OS_DISK_SIZE"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.4
+version: 1.3.0
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -73,6 +73,14 @@ parameters:
     type: string
     description: "Timezone for the shutdown schedule"
     default: "UTC"
+  - name: os_disk_account_type
+    type: string
+    default: "Standard_LRS"
+    description: "The type of storage account to use for the OS disk"
+  - name: os_disk_size
+    type: int
+    default: 64
+    description: "The size of the OS disk in GB"
 
   # the following are added automatically by the resource processor
   - name: id
@@ -166,6 +174,8 @@ install:
         shutdown_timezone: ${ bundle.parameters.shutdown_timezone }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
+        os_disk_account_type: ${ bundle.parameters.os_disk_account_type }
+        os_disk_size: ${ bundle.parameters.os_disk_size }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -197,6 +207,8 @@ upgrade:
         shutdown_timezone: ${ bundle.parameters.shutdown_timezone }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
+        os_disk_account_type: ${ bundle.parameters.os_disk_account_type }
+        os_disk_size: ${ bundle.parameters.os_disk_size }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -240,6 +252,8 @@ uninstall:
         shutdown_timezone: ${ bundle.parameters.shutdown_timezone }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
+        os_disk_account_type: ${ bundle.parameters.os_disk_account_type }
+        os_disk_size: ${ bundle.parameters.os_disk_size }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -6,7 +6,9 @@
   "description": "Linux virtual machine.",
   "required": [
     "os_image",
-    "vm_size"
+    "vm_size",
+    "os_disk_account_type",
+    "os_disk_size"
   ],
   "authorizedRoles": [
     "WorkspaceOwner", "WorkspaceResearcher"
@@ -49,6 +51,38 @@
       "title": "Enable Shutdown Schedule",
       "default": false,
       "description": "Enable automatic shutdown schedule for the VM"
+    },
+    "os_disk_account_type": {
+      "$id": "#/properties/os_disk_account_type",
+      "type": "string",
+      "title": "OS Disk Account Type",
+      "description": "The type of storage account to use for the OS disk",
+      "default": "Standard_LRS",
+      "enum": [
+        "Standard_LRS",
+        "Premium_LRS",
+        "StandardSSD_LRS",
+        "UltraSSD_LRS"
+      ]
+    },
+    "os_disk_size": {
+      "$id": "#/properties/os_disk_size",
+      "type": "integer",
+      "title": "OS Disk Size",
+      "description": "The size of the OS disk in GB",
+      "default": 64,
+      "enum": [
+        64,
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32767
+      ]
     }
   },
   "allOf": [

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
@@ -65,7 +65,8 @@ resource "azurerm_linux_virtual_machine" "linuxvm" {
   os_disk {
     name                   = "osdisk-${local.vm_name}"
     caching                = "ReadWrite"
-    storage_account_type   = "Standard_LRS"
+    storage_account_type   = var.os_disk_account_type
+    disk_size_gb           = var.os_disk_size
     disk_encryption_set_id = var.enable_cmk_encryption ? azurerm_disk_encryption_set.linuxvm_disk_encryption[0].id : null
   }
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/variables.tf
@@ -44,3 +44,11 @@ variable "enable_cmk_encryption" {
 variable "key_store_id" {
   type = string
 }
+variable "os_disk_account_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+variable "os_disk_size" {
+  type    = number
+  default = 64
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/parameters.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/parameters.json
@@ -99,6 +99,18 @@
       "source": {
         "env": "KEY_STORE_ID"
       }
+    },
+    {
+      "name": "os_disk_account_type",
+      "source": {
+        "env": "OS_DISK_ACCOUNT_TYPE"
+      }
+    },
+    {
+      "name": "os_disk_size",
+      "source": {
+        "env": "OS_DISK_SIZE"
+      }
     }
   ]
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.2.5
+version: 1.3.0
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -114,6 +114,14 @@ parameters:
   - name: key_store_id
     type: string
     default: ""
+  - name: os_disk_account_type
+    type: string
+    default: "Standard_LRS"
+    description: "The type of storage account to use for the OS disk"
+  - name: os_disk_size
+    type: int
+    default: 128
+    description: "The size of the OS disk in GB"
 
 outputs:
   - name: ip
@@ -161,6 +169,8 @@ install:
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
+        os_disk_account_type: ${ bundle.parameters.os_disk_account_type }
+        os_disk_size: ${ bundle.parameters.os_disk_size }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -189,6 +199,8 @@ upgrade:
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
+        os_disk_account_type: ${ bundle.parameters.os_disk_account_type }
+        os_disk_size: ${ bundle.parameters.os_disk_size }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -229,6 +241,8 @@ uninstall:
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
+        os_disk_account_type: ${ bundle.parameters.os_disk_account_type }
+        os_disk_size: ${ bundle.parameters.os_disk_size }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -5,6 +5,10 @@
     "title": "Windows Virtual Machine",
     "description": "Windows virtual machine.",
     "required": [
+        "os_image",
+        "vm_size",
+        "os_disk_account_type",
+        "os_disk_size"
     ],
     "authorizedRoles": [
       "WorkspaceOwner", "WorkspaceResearcher"
@@ -40,6 +44,38 @@
         "title": "Shared storage",
         "default": true,
         "description": "Enable access to shared storage"
+      },
+      "os_disk_account_type": {
+        "$id": "#/properties/os_disk_account_type",
+        "type": "string",
+        "title": "OS Disk Account Type",
+        "description": "The type of storage account to use for the OS disk",
+        "default": "Standard_LRS",
+        "enum": [
+          "Standard_LRS",
+          "Premium_LRS",
+          "StandardSSD_LRS",
+          "UltraSSD_LRS"
+        ]
+      },
+      "os_disk_size": {
+        "$id": "#/properties/os_disk_size",
+        "type": "integer",
+        "title": "OS Disk Size",
+        "description": "The size of the OS disk in GB",
+        "default": 128,
+        "enum": [
+          64,
+          128,
+          256,
+          512,
+          1024,
+          2048,
+          4096,
+          8192,
+          16384,
+          32767
+        ]
       }
     }
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/variables.tf
@@ -33,3 +33,11 @@ variable "enable_cmk_encryption" {
 variable "key_store_id" {
   type = string
 }
+variable "os_disk_account_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+variable "os_disk_size" {
+  type    = number
+  default = 128
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -76,7 +76,8 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   os_disk {
     name                   = "osdisk-${local.vm_name}"
     caching                = "ReadWrite"
-    storage_account_type   = "Standard_LRS"
+    storage_account_type   = var.os_disk_account_type
+    disk_size_gb           = var.os_disk_size
     disk_encryption_set_id = var.enable_cmk_encryption ? azurerm_disk_encryption_set.windowsvm_disk_encryption[0].id : null
   }
 


### PR DESCRIPTION
Fixes #4317

Add support for configurable OS disk account type and size for Linux and Windows VMs.

* **Linux VM Changes:**
  - Add new parameters `os_disk_account_type` and `os_disk_size` in `parameters.json`.
  - Update `porter.yaml` to include new parameters and update `install`, `upgrade`, and `uninstall` steps.
  - Add new properties `os_disk_account_type` and `os_disk_size` in `template_schema.json` and update the `required` array.
  - Add new variables `os_disk_account_type` and `os_disk_size` in `variables.tf`.
  - Update `os_disk` block in `linuxvm.tf` to use new variables `os_disk_account_type` and `os_disk_size`.

* **Windows VM Changes:**
  - Add new parameters `os_disk_account_type` and `os_disk_size` in `parameters.json`.
  - Update `porter.yaml` to include new parameters and update `install`, `upgrade`, and `uninstall` steps.
  - Add new properties `os_disk_account_type` and `os_disk_size` in `template_schema.json` and update the `required` array.
  - Add new variables `os_disk_account_type` and `os_disk_size` in `variables.tf`.
  - Update `os_disk` block in `windowsvm.tf` to use new variables `os_disk_account_type` and `os_disk_size`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/AzureTRE/pull/4334?shareId=034f56dd-6507-427a-af34-0d7bd6f8e66b).