### PR TITLE
Add validation to Template API endpoints

### DIFF
--- a/api_app/api/routes/shared_service_templates.py
+++ b/api_app/api/routes/shared_service_templates.py
@@ -33,6 +33,8 @@ async def get_shared_service_template(shared_service_template_name: str, is_upda
 
 @shared_service_templates_core_router.post("/shared-service-templates", status_code=status.HTTP_201_CREATED, response_model=SharedServiceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_SHARED_SERVICE_TEMPLATES, dependencies=[Depends(get_current_admin_user)])
 async def register_shared_service_template(template_input: SharedServiceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository))) -> ResourceTemplateInResponse:
+    if template_input.resourceType != ResourceType.SharedService:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=strings.INVALID_RESOURCE_TYPE.format('SharedService', template_input.resourceType))
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.SharedService)
     except EntityVersionExist:

--- a/api_app/api/routes/user_resource_templates.py
+++ b/api_app/api/routes/user_resource_templates.py
@@ -1,4 +1,3 @@
-
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import parse_obj_as
@@ -32,6 +31,8 @@ async def get_user_resource_template(service_template_name: str, user_resource_t
 
 @user_resource_templates_core_router.post("/workspace-service-templates/{service_template_name}/user-resource-templates", status_code=status.HTTP_201_CREATED, response_model=UserResourceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_USER_RESOURCE_TEMPLATES, dependencies=[Depends(get_current_admin_user)])
 async def register_user_resource_template(template_input: UserResourceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository)), workspace_service_template=Depends(get_workspace_service_template_by_name_from_path)) -> UserResourceTemplateInResponse:
+    if template_input.resourceType != ResourceType.UserResource:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=strings.INVALID_RESOURCE_TYPE.format('UserResource', template_input.resourceType))
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.UserResource, workspace_service_template.name)
     except EntityVersionExist:

--- a/api_app/api/routes/workspace_service_templates.py
+++ b/api_app/api/routes/workspace_service_templates.py
@@ -30,6 +30,8 @@ async def get_workspace_service_template(service_template_name: str, is_update: 
 
 @workspace_service_templates_core_router.post("/workspace-service-templates", status_code=status.HTTP_201_CREATED, response_model=WorkspaceServiceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_WORKSPACE_SERVICE_TEMPLATES, dependencies=[Depends(get_current_admin_user)])
 async def register_workspace_service_template(template_input: WorkspaceServiceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository))) -> ResourceTemplateInResponse:
+    if template_input.resourceType != ResourceType.WorkspaceService:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=strings.INVALID_RESOURCE_TYPE.format('WorkspaceService', template_input.resourceType))
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.WorkspaceService)
     except EntityVersionExist:

--- a/api_app/api/routes/workspace_templates.py
+++ b/api_app/api/routes/workspace_templates.py
@@ -30,6 +30,8 @@ async def get_workspace_template(workspace_template_name: str, is_update: bool =
 
 @workspace_templates_admin_router.post("/workspace-templates", status_code=status.HTTP_201_CREATED, response_model=WorkspaceTemplateInResponse, response_model_exclude_none=True, name=strings.API_CREATE_WORKSPACE_TEMPLATES)
 async def register_workspace_template(template_input: WorkspaceTemplateInCreate, template_repo=Depends(get_repository(ResourceTemplateRepository))) -> ResourceTemplateInResponse:
+    if template_input.resourceType != ResourceType.Workspace:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=strings.INVALID_RESOURCE_TYPE.format('Workspace', template_input.resourceType))
     try:
         return await template_repo.create_and_validate_template(template_input, ResourceType.Workspace)
     except EntityVersionExist:

--- a/api_app/resources/strings.py
+++ b/api_app/resources/strings.py
@@ -254,3 +254,6 @@ PARAMETERS_WITH_WRONG_TYPE = "Parameters with wrong type"
 
 # Value that a sensitive is replaced with in Cosmos
 REDACTED_SENSITIVE_VALUE = "REDACTED"
+
+# Common error message for invalid resource type
+INVALID_RESOURCE_TYPE = "Invalid resourceType. Expected '{}'. Received '{}'."

--- a/api_app/tests_ma/test_api/test_routes/test_shared_service_templates.py
+++ b/api_app/tests_ma/test_api/test_routes/test_shared_service_templates.py
@@ -112,3 +112,22 @@ class TestSharedServiceTemplates:
         response = await client.post(app.url_path_for(strings.API_CREATE_SHARED_SERVICE_TEMPLATES), json=input_shared_service_template.dict())
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    # POST /shared-service-templates
+    async def test_post_shared_service_template_with_invalid_resource_type(self, app, client):
+        input_data = {
+            "name": "invalid-template",
+            "description": "Invalid template",
+            "version": "0.1.0",
+            "resourceType": "InvalidType",
+            "current": True,
+            "type": "object",
+            "required": [],
+            "properties": {},
+            "actions": []
+        }
+
+        response = await client.post(app.url_path_for(strings.API_CREATE_SHARED_SERVICE_TEMPLATES), json=input_data)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.json()["detail"] == strings.INVALID_RESOURCE_TYPE.format('SharedService', input_data.resourceType)

--- a/api_app/tests_ma/test_api/test_routes/test_user_resource_templates.py
+++ b/api_app/tests_ma/test_api/test_routes/test_user_resource_templates.py
@@ -102,6 +102,25 @@ class TestUserResourceTemplatesRequiringAdminRights:
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    # POST /workspace-service-templates/{template_name}/user-resource-templates
+    async def test_post_user_resource_template_with_invalid_resource_type(self, app, client):
+        input_data = {
+            "name": "invalid-template",
+            "description": "Invalid template",
+            "version": "0.1.0",
+            "resourceType": "InvalidType",
+            "current": True,
+            "type": "object",
+            "required": [],
+            "properties": {},
+            "actions": []
+        }
+
+        response = await client.post(app.url_path_for(strings.API_CREATE_USER_RESOURCE_TEMPLATES, service_template_name="guacamole"), json=input_data)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.json()["detail"] == strings.INVALID_RESOURCE_TYPE.format('UserResource', input_data.resourceType)
+
 
 class TestUserResourceTemplatesNotRequiringAdminRights:
     @pytest.fixture(autouse=True, scope='class')

--- a/api_app/tests_ma/test_api/test_routes/test_workspace_service_templates.py
+++ b/api_app/tests_ma/test_api/test_routes/test_workspace_service_templates.py
@@ -176,3 +176,22 @@ class TestWorkspaceServiceTemplatesRequiringAdminRights:
         response = await client.get(app.url_path_for(strings.API_GET_WORKSPACE_SERVICE_TEMPLATE_BY_NAME, service_template_name="template1"))
 
         assert response.status_code == expected_status
+
+    # POST /workspace-service-templates/
+    async def test_post_workspace_service_template_with_invalid_resource_type(self, app, client):
+        input_data = {
+            "name": "invalid-template",
+            "description": "Invalid template",
+            "version": "0.1.0",
+            "resourceType": "InvalidType",
+            "current": True,
+            "type": "object",
+            "required": [],
+            "properties": {},
+            "actions": []
+        }
+
+        response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_SERVICE_TEMPLATES), json=input_data)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.json()["detail"] == strings.INVALID_RESOURCE_TYPE.format('WorkspaceService', input_data.resourceType)

--- a/api_app/tests_ma/test_api/test_routes/test_workspace_templates.py
+++ b/api_app/tests_ma/test_api/test_routes/test_workspace_templates.py
@@ -222,3 +222,22 @@ class TestWorkspaceTemplate:
         await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_SERVICE_TEMPLATES), json=input_workspace_template.dict())
 
         create_template_mock.assert_called_once_with(input_workspace_template, ResourceType.WorkspaceService, '')
+
+    # POST /workspace-templates
+    async def test_post_workspace_template_with_invalid_resource_type(self, app, client):
+        input_data = {
+            "name": "invalid-template",
+            "description": "Invalid template",
+            "version": "0.1.0",
+            "resourceType": "InvalidType",
+            "current": True,
+            "type": "object",
+            "required": [],
+            "properties": {},
+            "customActions": []
+        }
+
+        response = await client.post(app.url_path_for(strings.API_CREATE_WORKSPACE_TEMPLATES), json=input_data)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.json()["detail"] == strings.INVALID_RESOURCE_TYPE.format('Workspace', input_data.resourceType)


### PR DESCRIPTION
Fixes #1123

Add validation to API endpoints to ensure correct resourceType in template registration payloads.

* **Workspace Service Templates**: Add validation in `api_app/api/routes/workspace_service_templates.py` to check if `resourceType` is `WorkspaceService` before registering the template. Return a 422 Unprocessable Entity error if the `resourceType` does not match.
* **Workspace Templates**: Add validation in `api_app/api/routes/workspace_templates.py` to check if `resourceType` is `Workspace` before registering the template. Return a 422 Unprocessable Entity error if the `resourceType` does not match.
* **User Resource Templates**: Add validation in `api_app/api/routes/user_resource_templates.py` to check if `resourceType` is `UserResource` before registering the template. Return a 422 Unprocessable Entity error if the `resourceType` does not match.
* **Shared Service Templates**: Add validation in `api_app/api/routes/shared_service_templates.py` to check if `resourceType` is `SharedService` before registering the template. Return a 422 Unprocessable Entity error if the `resourceType` does not match.
* **Common Error Message**: Add a common error message string `INVALID_RESOURCE_TYPE` in `api_app/resources/strings.py` for validation errors, including the expected and received resourceType.
* **Tests**: Add tests in `api_app/tests_ma/test_api/test_routes/test_workspace_service_templates.py`, `api_app/tests_ma/test_api/test_routes/test_workspace_templates.py`, `api_app/tests_ma/test_api/test_routes/test_user_resource_templates.py`, and `api_app/tests_ma/test_api/test_routes/test_shared_service_templates.py` to cover validation for each template registration

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/AzureTRE/pull/4344?shareId=44ef0a01-0d1e-443a-995d-26eb865180ee).