### PR TITLE
Add requests endpoint to core TRE API

### DIFF
--- a/api_app/api/routes/api.py
+++ b/api_app/api/routes/api.py
@@ -8,7 +8,7 @@ from fastapi.openapi.utils import get_openapi
 from api.helpers import get_repository
 from db.repositories.workspaces import WorkspaceRepository
 from api.routes import health, ping, workspaces, workspace_templates, workspace_service_templates, user_resource_templates, \
-    shared_services, shared_service_templates, migrations, costs, airlock, operations, metadata
+    shared_services, shared_service_templates, migrations, costs, airlock, operations, metadata, requests
 from core import config
 from resources import strings
 
@@ -49,6 +49,7 @@ core_router.include_router(workspaces.workspaces_shared_router, tags=["workspace
 core_router.include_router(migrations.migrations_core_router, tags=["migrations"])
 core_router.include_router(costs.costs_core_router, tags=["costs"])
 core_router.include_router(costs.costs_workspace_router, tags=["costs"])
+core_router.include_router(requests.router, tags=["requests"])
 
 core_swagger_router = APIRouter()
 swagger_disabled_router = APIRouter()

--- a/api_app/api/routes/requests.py
+++ b/api_app/api/routes/requests.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from typing import List, Optional
+from pydantic import UUID4
+
+from api.dependencies.database import get_repository
+from db.repositories.airlock_requests import AirlockRequestRepository
+from models.domain.airlock_request import AirlockRequest
+from services.authentication import get_current_tre_user_or_tre_admin
+
+router = APIRouter()
+
+@router.get("/requests", response_model=List[AirlockRequest], name="get_requests")
+async def get_requests(
+    workspace_id: Optional[UUID4] = None,
+    user=Depends(get_current_tre_user_or_tre_admin),
+    airlock_request_repo=Depends(get_repository(AirlockRequestRepository))
+) -> List[AirlockRequest]:
+    try:
+        requests = await airlock_request_repo.get_airlock_requests(workspace_id=workspace_id, creator_user_id=user.id, order_by="createdWhen", order_ascending=False)
+        return requests
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))

--- a/api_app/tests_ma/test_db/test_repositories/test_airlock_request_repository.py
+++ b/api_app/tests_ma/test_db/test_repositories/test_airlock_request_repository.py
@@ -152,3 +152,61 @@ async def test_get_airlock_requests_queries_db(airlock_request_repo):
 
     await airlock_request_repo.get_airlock_requests(WORKSPACE_ID)
     airlock_request_repo.container.query_items.assert_called_once_with(query=expected_query, parameters=expected_parameters)
+
+
+async def test_get_airlock_requests_with_user_id(airlock_request_repo):
+    airlock_request_repo.container.query_items = MagicMock()
+    user_id = "test_user_id"
+    expected_query = airlock_request_repo.airlock_requests_query() + f' WHERE c.createdBy.id=@user_id'
+    expected_parameters = [
+        {"name": "@user_id", "value": user_id},
+        {"name": "@status", "value": None},
+        {"name": "@type", "value": None},
+    ]
+
+    await airlock_request_repo.get_airlock_requests(creator_user_id=user_id)
+    airlock_request_repo.container.query_items.assert_called_once_with(query=expected_query, parameters=expected_parameters)
+
+
+async def test_get_airlock_requests_with_status(airlock_request_repo):
+    airlock_request_repo.container.query_items = MagicMock()
+    status = AirlockRequestStatus.Submitted
+    expected_query = airlock_request_repo.airlock_requests_query() + f' WHERE c.status=@status'
+    expected_parameters = [
+        {"name": "@user_id", "value": None},
+        {"name": "@status", "value": status},
+        {"name": "@type", "value": None},
+    ]
+
+    await airlock_request_repo.get_airlock_requests(status=status)
+    airlock_request_repo.container.query_items.assert_called_once_with(query=expected_query, parameters=expected_parameters)
+
+
+async def test_get_airlock_requests_with_type(airlock_request_repo):
+    airlock_request_repo.container.query_items = MagicMock()
+    request_type = AirlockRequestType.Import
+    expected_query = airlock_request_repo.airlock_requests_query() + f' WHERE c.type=@type'
+    expected_parameters = [
+        {"name": "@user_id", "value": None},
+        {"name": "@status", "value": None},
+        {"name": "@type", "value": request_type},
+    ]
+
+    await airlock_request_repo.get_airlock_requests(type=request_type)
+    airlock_request_repo.container.query_items.assert_called_once_with(query=expected_query, parameters=expected_parameters)
+
+
+async def test_get_airlock_requests_with_multiple_filters(airlock_request_repo):
+    airlock_request_repo.container.query_items = MagicMock()
+    user_id = "test_user_id"
+    status = AirlockRequestStatus.Submitted
+    request_type = AirlockRequestType.Import
+    expected_query = airlock_request_repo.airlock_requests_query() + f' WHERE c.createdBy.id=@user_id AND c.status=@status AND c.type=@type'
+    expected_parameters = [
+        {"name": "@user_id", "value": user_id},
+        {"name": "@status", "value": status},
+        {"name": "@type", "value": request_type},
+    ]
+
+    await airlock_request_repo.get_airlock_requests(creator_user_id=user_id, status=status, type=request_type)
+    airlock_request_repo.container.query_items.assert_called_once_with(query=expected_query, parameters=expected_parameters)

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -21,6 +21,7 @@ import { initializeFileTypeIcons } from '@fluentui/react-file-type-icons';
 import { CostResource } from './models/costs';
 import { CostsContext } from './contexts/CostsContext';
 import { LoadingState } from './models/loadingState';
+import { Requests } from './components/requests/Requests';
 
 export const App: React.FunctionComponent = () => {
   const [appRoles, setAppRoles] = useState([] as Array<string>);
@@ -98,6 +99,7 @@ export const App: React.FunctionComponent = () => {
                               <WorkspaceProvider />
                             </WorkspaceContext.Provider>
                           } />
+                          <Route path="/requests" element={<Requests />} />
                         </Routes>
                       </CostsContext.Provider>
                     </GenericErrorBoundary>


### PR DESCRIPTION
Add a new 'requests' endpoint in the core TRE API to view airlock requests across workspaces.