### PR TITLE
Add moved block to handle firewall public IP count migration

### DIFF
--- a/templates/shared_services/firewall/porter.yaml
+++ b/templates/shared_services/firewall/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-firewall
-version: 1.3.1
+version: 1.3.2
 description: "An Azure TRE Firewall shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/shared_services/firewall/terraform/firewall.tf
+++ b/templates/shared_services/firewall/terraform/firewall.tf
@@ -11,7 +11,7 @@ resource "azurerm_public_ip" "fwtransit" {
 }
 
 moved {
-  from = azurerm_public_ip.fwpip
+  from = azurerm_public_ip.fwtransit
   to   = azurerm_public_ip.fwtransit[0]
 }
 


### PR DESCRIPTION
# Resolves #4355

## What is being addressed

Updated the `moved` block to handle resource address change when adding count to
the firewall's public IP resource, preventing unwanted recreation of the IP address.