### PR TITLE
Nexus Linux machine uses SSH keys

### DIFF
--- a/docs/tre-templates/shared-services/nexus.md
+++ b/docs/tre-templates/shared-services/nexus.md
@@ -46,7 +46,6 @@ This will deploy the infrastructure required for Nexus, then start the service a
 
 ## Setup and usage
 
-1. A TRE Administrator can access Nexus though the admin jumpbox provisioned as part of the TRE deployment. The username is `adminuser` and the password is located in the Key Vault under `vm-<tre-id>-jumpbox-password`
 2. A researcher can access Nexus from within the workspace by using the internal Nexus URL of `https://nexus-{TRE_ID}.{LOCATION}.cloudapp.azure.com`
 3. To fetch Python packages from the PyPI proxy, a researcher can use `pip install` while specifying the proxy server:
 
@@ -201,3 +200,7 @@ for ext in "${extensions[@]}"; do
     fi
 done
 ```
+
+# Virtual Machine Credentials
+
+A TRE Administrator can access Nexus though the bastion provisioned as part of the TRE deployment. The username is `adminuser` and the SSH private key is located in the Key Vault under `nexus-ssh-private-key`.


### PR DESCRIPTION
Fixes #4359

Update Sonatype Nexus VM to require SSH key-based authentication.

* Remove password-based authentication and related resources from `templates/shared_services/sonatype-nexus-vm/terraform/vm.tf`.
* Add resources to generate and store SSH keys in Key Vault.
* Update the `connection` block to use the SSH private key for authentication.
* Update `docs/tre-templates/shared-services/nexus.md` to reflect the change to SSH key-based authentication and provide instructions on how to retrieve the SSH private key from Key Vault.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/AzureTRE/pull/4366?shareId=fabaa7d9-6140-4eb4-8a6e-38e6e863962f).