### PR TITLE
Fix UI build path

### DIFF
--- a/devops/scripts/build_deploy_ui.sh
+++ b/devops/scripts/build_deploy_ui.sh
@@ -28,4 +28,4 @@ yarn build
 
 popd
 
-CONTENT_DIR="$DIR/../../ui/app/build" "$DIR/upload_static_web.sh"
+CONTENT_DIR="$DIR/../../ui/app/dist" "$DIR/upload_static_web.sh"


### PR DESCRIPTION
Switch to Vite broke the UI build. 

Updates the build path for the UI to ensure the correct directory is used during the build process.