### PR TITLE
Add backups to workspaces.  ignore this.

### DIFF
--- a/templates/workspaces/base/cleanup_vault.sh
+++ b/templates/workspaces/base/cleanup_vault.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Uncomment for debugging (will show secrets)
+# set -o xtrace
+
+function usage() {
+    cat <<USAGE
+    Usage: $0 --resource-group some_rg --vault-name some_vault
+    Options:
+        --resource-group     The name of the Azure Resource Group containing the Recovery Services Vault.
+        --vault-name         The name of the Recovery Services Vault.
+    Environment Variables:
+        AZURE_ENVIRONMENT    The name of the Azure environment (e.g., AzureCloud, AzureChinaCloud, etc.). Must be set.
+USAGE
+    exit 1
+}
+
+# Ensure required commands are available
+for cmd in az jq; do
+    if ! command -v $cmd &> /dev/null; then
+        echo "Error: $cmd is not installed."
+        exit 1
+    fi
+done
+
+# Ensure environment variable is set
+if [ -z "${AZURE_ENVIRONMENT:-}" ]; then
+    echo "Error: AZURE_ENVIRONMENT environment variable is not set."
+    usage
+fi
+
+# Ensure arguments are provided
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+# Parse arguments
+while [ "$1" != "" ]; do
+    case $1 in
+    --resource-group)
+        shift
+        RESOURCE_GROUP=$1
+        ;;
+    --vault-name)
+        shift
+        VAULT_NAME=$1
+        ;;
+    *)
+        echo "Unexpected argument: '$1'"
+        usage
+        ;;
+    esac
+
+    if [[ -z "$2" ]]; then
+        break
+    fi
+
+    shift
+done
+
+# Ensure required arguments are set
+if [ -z "${RESOURCE_GROUP:-}" ] || [ -z "${VAULT_NAME:-}" ]; then
+    echo "Error: --resource-group and --vault-name are required."
+    usage
+fi
+
+# Set Azure Cloud environment
+az cloud set --name "$AZURE_ENVIRONMENT"
+
+# Check if Vault Exists
+echo "Checking for Recovery Services Vault: $VAULT_NAME in $RESOURCE_GROUP"
+vault_exists=$(az resource show --resource-group "$RESOURCE_GROUP" --name "$VAULT_NAME" --resource-type "Microsoft.RecoveryServices/vaults" --query "id" -o tsv || echo "")
+
+if [ -z "$vault_exists" ]; then
+    echo "Vault does not exist or is already deleted. Skipping cleanup."
+    exit 0
+fi
+
+# **Disable Soft Delete for the Vault**
+echo "Disabling soft delete for Recovery Services Vault..."
+az backup vault backup-properties set --resource-group "$RESOURCE_GROUP" --vault-name "$VAULT_NAME" --soft-delete-feature-state Disable || echo "Warning: Unable to disable soft delete."
+
+# **Verify Soft Delete is Disabled**
+soft_delete_status=$(az backup vault backup-properties show --resource-group "$RESOURCE_GROUP" --vault-name "$VAULT_NAME" --query "softDeleteFeatureState" -o tsv)
+if [[ "$soft_delete_status" != "Disabled" ]]; then
+    echo "Error: Soft delete is still enabled. Vault cannot be deleted."
+    exit 1
+fi
+
+# **Get all protected backup items (VMs, File Shares, SQL, etc.)**
+echo "Fetching all protected backup items..."
+protected_items=$(az backup item list --resource-group "$RESOURCE_GROUP" --vault-name "$VAULT_NAME" --query "[].{name:name, containerName:properties.containerName, type:properties.protectedItemType}" -o json)
+
+# **Disable protection for each registered backup item**
+for row in $(echo "$protected_items" | jq -c '.[]'); do
+    item_name=$(echo "$row" | jq -r '.name')
+    container_name=$(echo "$row" | jq -r '.containerName')
+    item_type=$(echo "$row" | jq -r '.type')
+
+    echo "Disabling protection for: $item_name ($item_type)"
+    az backup protection disable --resource-group "$RESOURCE_GROUP" --vault-name "$VAULT_NAME" --container-name "$container_name" --item-name "$item_name" --delete-backup-data true --yes || echo "Warning: Failed to disable protection for $item_name"
+done
+
+
+
+

--- a/templates/workspaces/base/parameters.json
+++ b/templates/workspaces/base/parameters.json
@@ -165,12 +165,6 @@
       "source": {
         "env": "ENABLE_BACKUP"
       }
-    },
-    {
-      "name": "shared_storage_name",
-      "source": {
-        "env": "SHARED_STORAGE_NAME"
-      }
     }
   ]
 }

--- a/templates/workspaces/base/parameters.json
+++ b/templates/workspaces/base/parameters.json
@@ -159,6 +159,18 @@
       "source": {
         "env": "KEY_STORE_ID"
       }
+    },
+    {
+      "name": "enable_backup",
+      "source": {
+        "env": "ENABLE_BACKUP"
+      }
+    },
+    {
+      "name": "shared_storage_name",
+      "source": {
+        "env": "SHARED_STORAGE_NAME"
+      }
     }
   ]
 }

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 1.9.3
+version: 2.0.10
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -126,6 +126,31 @@ parameters:
     type: string
     default: "GRS"
     description: "The redundancy option for the storage account in the workspace: GRS (Geo-Redundant Storage) or ZRS (Zone-Redundant Storage)."
+  - name: enable_backup
+    type: boolean
+    default: true
+    description: "Enable backups for the workspace, including the vm's & shared storage."
+  - name: shared_storage_name
+    type: string
+    default: "vm-shared-storage"
+    description: "The name of the shared storage used for the workspace VMs"
+  - name: backup_vault_name
+    type: string
+    default: ""
+    description: "The name of the backup vault to use for backups"
+  - name: backup_vault_vm_backup_policy_name
+    type: string
+    default: ""
+    description: "The name of the backup policy to use for VM backups"
+  - name: backup_vault_fileshare_backup_policy_name
+    type: string
+    default: ""
+    description: "The name of the backup policy to use for fileshare backups"
+  - name: workspace_resource_name_suffix
+    type: string
+    default: ""
+    description: "A suffix to append to the workspace resource names"
+
 
 outputs:
   - name: app_role_id_workspace_owner
@@ -158,6 +183,22 @@ outputs:
     applyTo:
       - install
       - upgrade
+  - name: backup_vault_name
+    type: string
+    applyTo:
+      - install
+      - upgrade
+  - name: backup_vault_vm_backup_policy_name
+    type: string
+    applyTo:
+      - install
+      - upgrade
+  - name: backup_vault_fileshare_backup_policy_name
+    type: string
+    applyTo:
+      - install
+      - upgrade
+
 
 mixins:
   - exec
@@ -196,6 +237,10 @@ install:
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
         storage_account_redundancy: ${ bundle.parameters.storage_account_redundancy }
+        enable_backup: ${ bundle.parameters.enable_backup }
+        backup_vault_fileshare_backup_policy_name: ${ bundle.parameters.backup_vault_fileshare_backup_policy_name }
+        backup_vault_vm_backup_policy_name: ${ bundle.parameters.backup_vault_vm_backup_policy_name }
+        backup_vault_name: ${ bundle.parameters.backup_vault_name }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -210,6 +255,9 @@ install:
         - name: client_id
         - name: scope_id
         - name: sp_id
+        - name: backup_vault_name
+        - name: backup_vault_vm_backup_policy_name
+        - name: backup_vault_fileshare_backup_policy_name
 
 upgrade:
   - terraform:
@@ -241,6 +289,10 @@ upgrade:
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
         storage_account_redundancy: ${ bundle.parameters.storage_account_redundancy }
+        enable_backup: ${ bundle.parameters.enable_backup }
+        backup_vault_fileshare_backup_policy_name: ${ bundle.parameters.backup_vault_fileshare_backup_policy_name }
+        backup_vault_vm_backup_policy_name: ${ bundle.parameters.backup_vault_vm_backup_policy_name }
+        backup_vault_name: ${ bundle.parameters.backup_vault_name }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -255,6 +307,9 @@ upgrade:
         - name: client_id
         - name: scope_id
         - name: sp_id
+        - name: backup_vault_name
+        - name: backup_vault_vm_backup_policy_name
+        - name: backup_vault_fileshare_backup_policy_name
   - az:
       description: "Set Azure Cloud Environment"
       arguments:
@@ -281,6 +336,30 @@ upgrade:
         register-aad-application: '${ bundle.parameters.register_aad_application }'
 
 uninstall:
+  - az:
+      description: "Set Azure Cloud Environment"
+      arguments:
+        - cloud
+        - set
+      flags:
+        name: ${ bundle.parameters.azure_environment }
+  - az:
+      description: "Azure Login"
+      arguments:
+        - login
+      flags:
+        service-principal: ""
+        username: '${ bundle.credentials.azure_client_id }'
+        password: '${ bundle.credentials.azure_client_secret }'
+        tenant: '${ bundle.credentials.azure_tenant_id }'
+        allow-no-subscriptions: ""
+  - exec:
+      description: "Running Recovery Services Vault Cleanup"
+      command: ./cleanup_vault.sh
+      flags:
+        resource-group: '${ bundle.parameters.workspace_resource_name_suffix }'
+        vault-name: '${ bundle.parameters.backup_vault_name }'
+
   - terraform:
       description: "Tear down workspace"
       vars:
@@ -309,6 +388,10 @@ uninstall:
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
         storage_account_redundancy: ${ bundle.parameters.storage_account_redundancy }
+        enable_backup: ${ bundle.parameters.enable_backup }
+        backup_vault_fileshare_backup_policy_name: ${ bundle.parameters.backup_vault_fileshare_backup_policy_name }
+        backup_vault_vm_backup_policy_name: ${ bundle.parameters.backup_vault_vm_backup_policy_name }
+        backup_vault_name: ${ bundle.parameters.backup_vault_name }
       backendConfig:
         use_azuread_auth: "true"
         use_oidc: "true"
@@ -316,3 +399,13 @@ uninstall:
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
         container_name: ${ bundle.parameters.tfstate_container_name }
         key: ${ bundle.parameters.tre_id }-ws-${ bundle.parameters.id }
+      outputs:
+        - name: app_role_id_workspace_owner
+        - name: app_role_id_workspace_researcher
+        - name: app_role_id_workspace_airlock_manager
+        - name: client_id
+        - name: scope_id
+        - name: sp_id
+        - name: backup_vault_name
+        - name: backup_vault_vm_backup_policy_name
+        - name: backup_vault_fileshare_backup_policy_name

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -130,10 +130,6 @@ parameters:
     type: boolean
     default: true
     description: "Enable backups for the workspace, including the vm's & shared storage."
-  - name: shared_storage_name
-    type: string
-    default: "vm-shared-storage"
-    description: "The name of the shared storage used for the workspace VMs"
   - name: backup_vault_name
     type: string
     default: ""

--- a/templates/workspaces/base/template_schema.json
+++ b/templates/workspaces/base/template_schema.json
@@ -73,6 +73,13 @@
         "Manual"
       ],
       "updateable": true
+    },
+    "enable_backup": {
+      "type": "boolean",
+      "title": "Enable Backup",
+      "description": "Enable backups for the workspace, including the vm's & shared storage.",
+      "default": true,
+      "updateable": true
     }
   },
   "allOf": [
@@ -304,6 +311,7 @@
       "create_aad_groups",
       "client_id",
       "client_secret",
+      "enable_backup",
       "enable_airlock",
       "configure_review_vms",
       "airlock_review_config",

--- a/templates/workspaces/base/terraform/aad/aad.tf
+++ b/templates/workspaces/base/terraform/aad/aad.tf
@@ -103,6 +103,7 @@ resource "azuread_service_principal" "workspace" {
 
 resource "azuread_service_principal_password" "workspace" {
   service_principal_id = azuread_service_principal.workspace.object_id
+
 }
 
 resource "azurerm_key_vault_secret" "client_id" {

--- a/templates/workspaces/base/terraform/api-permissions.tf
+++ b/templates/workspaces/base/terraform/api-permissions.tf
@@ -20,3 +20,16 @@ resource "azurerm_role_assignment" "api_reader" {
   role_definition_name = "Reader"
   principal_id         = data.azurerm_user_assigned_identity.api_id.principal_id
 }
+
+# adds the needed permissions to the API to manage the backup and site recovery
+resource "azurerm_role_assignment" "backup_contributor" {
+  scope                = azurerm_resource_group.ws.id
+  role_definition_name = "Backup Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.api_id.principal_id
+}
+
+resource "azurerm_role_assignment" "site_recover_contributor" {
+  scope                = azurerm_resource_group.ws.id
+  role_definition_name = "Site Recovery Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.api_id.principal_id
+}

--- a/templates/workspaces/base/terraform/backup/backup.tf
+++ b/templates/workspaces/base/terraform/backup/backup.tf
@@ -1,0 +1,136 @@
+
+resource "azurerm_recovery_services_vault" "vault" {
+  name                = local.vault_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = "Standard"
+  soft_delete_enabled = true
+  storage_mode_type   = "ZoneRedundant" #  Possible values are "GeoRedundant", "LocallyRedundant" and "ZoneRedundant". Defaults to "GeoRedundant".
+  tags                = var.tre_workspace_tags
+
+  dynamic "identity" {
+    for_each = var.enable_cmk_encryption ? [1] : []
+    content {
+      type         = "UserAssigned"
+      identity_ids = [azurerm_user_assigned_identity.encryption_identity[0].id]
+    }
+  }
+
+  dynamic "encryption" {
+    for_each = var.enable_cmk_encryption ? [1] : []
+    content{
+      key_id                            = azurerm_key_vault_key.encryption_key[0].versionless_id
+      infrastructure_encryption_enabled = true
+      user_assigned_identity_id         = azurerm_user_assigned_identity.encryption_identity[0].id
+      use_system_assigned_identity      = false
+    }
+  }
+
+  lifecycle { ignore_changes = [encryption, tags] }
+
+}
+
+resource "azurerm_backup_policy_vm" "vm_policy" {
+  name                = local.vm_backup_policy_name
+  resource_group_name = var.resource_group_name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
+
+
+  timezone = "UTC"
+
+  backup {
+    frequency = "Daily"
+    time      = "22:00"
+  }
+
+  retention_daily {
+    count = 14
+  }
+
+  retention_weekly {
+    count    = 4
+    weekdays = ["Sunday"]
+  }
+
+  retention_monthly {
+    count     = 12
+    weekdays  = ["Monday"]
+    weeks     = ["First"]
+  }
+
+  retention_yearly {
+    count = 2
+    months = ["December"]
+    weekdays = ["Sunday"]
+    weeks = ["Last"]
+  }
+
+  depends_on = [
+    azurerm_recovery_services_vault.vault
+  ]
+
+
+}
+
+resource "azurerm_backup_policy_file_share" "file_share_policy" {
+  name                = local.fs_backup_policy_name
+  resource_group_name = var.resource_group_name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
+
+  timezone = "UTC"
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 14
+  }
+
+  retention_weekly {
+    count    = 4
+    weekdays = ["Sunday"]
+  }
+
+  retention_monthly {
+    count     = 12
+    weekdays  = ["Monday"]
+    weeks     = ["First"]
+  }
+
+  retention_yearly {
+    count = 2
+    months = ["December"]
+    weekdays = ["Sunday"]
+    weeks = ["Last"]
+  }
+
+  depends_on = [
+    azurerm_recovery_services_vault.vault
+  ]
+
+}
+
+resource "azurerm_backup_container_storage_account" "storage_account" {
+  resource_group_name = var.resource_group_name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
+  storage_account_id  = var.azurerm_storage_account_id
+
+  depends_on = [
+    azurerm_recovery_services_vault.vault
+  ]
+}
+
+resource "azurerm_backup_protected_file_share" "file_share" {
+  resource_group_name        = var.resource_group_name
+  recovery_vault_name        = azurerm_recovery_services_vault.vault.name
+  source_storage_account_id  = var.azurerm_storage_account_id
+  source_file_share_name     = var.shared_storage_name
+  backup_policy_id           = azurerm_backup_policy_file_share.file_share_policy.id
+
+  depends_on = [
+    azurerm_backup_policy_file_share.file_share_policy,
+    azurerm_backup_container_storage_account.storage_account
+  ]
+}

--- a/templates/workspaces/base/terraform/backup/locals.tf
+++ b/templates/workspaces/base/terraform/backup/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  short_workspace_id     = substr(var.tre_resource_id, -4, -1)
+  vault_name             = "arsv-${var.tre_id}-ws-${local.short_workspace_id}"
+  vm_backup_policy_name  = "abp-vm-${var.tre_id}-ws-${local.short_workspace_id}"
+  fs_backup_policy_name  = "abp-fs-${var.tre_id}-ws-${local.short_workspace_id}"
+}

--- a/templates/workspaces/base/terraform/backup/outputs.tf
+++ b/templates/workspaces/base/terraform/backup/outputs.tf
@@ -1,0 +1,11 @@
+output "backup_vault_name" {
+  value = azurerm_recovery_services_vault.vault.name
+}
+
+output "backup_vault_vm_backup_policy_name" {
+  value = azurerm_backup_policy_vm.vm_policy.name
+}
+
+output "backup_vault_fileshare_backup_policy_name" {
+  value = azurerm_backup_policy_file_share.file_share_policy.name
+}

--- a/templates/workspaces/base/terraform/backup/providers.tf
+++ b/templates/workspaces/base/terraform/backup/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  # In modules we should only specify the min version
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.117.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1.0"
+    }
+  }
+}

--- a/templates/workspaces/base/terraform/backup/variables.tf
+++ b/templates/workspaces/base/terraform/backup/variables.tf
@@ -1,0 +1,33 @@
+variable "location" {
+  type = string
+}
+variable "tre_id" {
+  type = string
+}
+variable "resource_group_name" {
+  type = string
+}
+variable "resource_group_id" {
+  type = string
+}
+variable "enable_local_debugging" {
+  type = bool
+}
+variable "tre_workspace_tags" {
+  type = map(string)
+}
+variable "arm_environment" {
+  type = string
+}
+variable "azurerm_storage_account_id" {
+  type = string
+}
+variable "tre_resource_id" {
+  type = string
+}
+variable "enable_cmk_encryption" {
+  type = bool
+}
+variable "shared_storage_name" {
+  type = string
+}

--- a/templates/workspaces/base/terraform/locals.tf
+++ b/templates/workspaces/base/terraform/locals.tf
@@ -10,4 +10,5 @@ locals {
   }
   kv_encryption_key_name   = "tre-encryption-${local.workspace_resource_name_suffix}"
   encryption_identity_name = "id-encryption-${var.tre_id}-${local.short_workspace_id}"
+  shared_storage_name      = "vm-shared-storage"
 }

--- a/templates/workspaces/base/terraform/outputs.tf
+++ b/templates/workspaces/base/terraform/outputs.tf
@@ -29,3 +29,15 @@ output "scope_id" {
   value = var.register_aad_application ? module.aad[0].scope_id : var.scope_id
 }
 
+output "backup_vault_name" {
+  value = var.enable_backup ? module.backup[0].backup_vault_name : var.backup_vault_name
+}
+
+output "backup_vault_vm_backup_policy_name" {
+  value = var.enable_backup ? module.backup[0].backup_vault_vm_backup_policy_name : var.backup_vault_vm_backup_policy_name
+}
+
+output "backup_vault_fileshare_backup_policy_name" {
+  value = var.enable_backup ? module.backup[0].backup_vault_fileshare_backup_policy_name : var.backup_vault_fileshare_backup_policy_name
+}
+

--- a/templates/workspaces/base/terraform/storage.tf
+++ b/templates/workspaces/base/terraform/storage.tf
@@ -36,7 +36,7 @@ resource "azurerm_storage_account" "stg" {
 # Using AzAPI as AzureRM uses shared account key for Azure files operations
 resource "azapi_resource" "shared_storage" {
   type      = "Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01"
-  name      = "vm-shared-storage"
+  name      = var.shared_storage_name
   parent_id = "${azurerm_storage_account.stg.id}/fileServices/default"
   body = jsonencode({
     properties = {

--- a/templates/workspaces/base/terraform/variables.tf
+++ b/templates/workspaces/base/terraform/variables.tf
@@ -81,12 +81,6 @@ variable "enable_backup"{
   description = "Enable backups for the workspace"
 }
 
-variable "shared_storage_name" {
-  type        = string
-  default     = "vm-shared-storage"
-  description = "Name of the VM Shared Storage"
-}
-
 # These variables are only passed in if you are not registering an AAD
 # application as they need passing back out
 variable "app_role_id_workspace_owner" {

--- a/templates/workspaces/base/terraform/variables.tf
+++ b/templates/workspaces/base/terraform/variables.tf
@@ -75,6 +75,17 @@ variable "auth_client_secret" {
   type        = string
   description = "Used to authenticate into the AAD Tenant to create the AAD App"
 }
+variable "enable_backup"{
+  type        = bool
+  default     = true
+  description = "Enable backups for the workspace"
+}
+
+variable "shared_storage_name" {
+  type        = string
+  default     = "vm-shared-storage"
+  description = "Name of the VM Shared Storage"
+}
 
 # These variables are only passed in if you are not registering an AAD
 # application as they need passing back out
@@ -138,4 +149,22 @@ variable "storage_account_redundancy" {
   type        = string
   default     = "GRS"
   description = "The redundancy option for the storage account in the workspace: GRS (Geo-Redundant Storage) or ZRS (Zone-Redundant Storage)."
+}
+
+variable "backup_vault_name" {
+  type        = string
+  default     = ""
+  description = "Name of the backup vault"
+}
+
+variable "backup_vault_vm_backup_policy_name" {
+  type        = string
+  default     = ""
+  description = "Name of the backup policy for VMs"
+}
+
+variable "backup_vault_fileshare_backup_policy_name" {
+  type        = string
+  default     = ""
+  description = "Name of the backup policy for File Shares"
 }

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -103,7 +103,7 @@ module "backup" {
   azurerm_storage_account_id               = azurerm_storage_account.stg.id
   enable_local_debugging                   = var.enable_local_debugging
   enable_cmk_encryption                    = var.enable_cmk_encryption
-  shared_storage_name                      = var.shared_storage_name
+  shared_storage_name                      = local.shared_storage_name
 
 
   depends_on = [

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -88,3 +88,29 @@ module "azure_monitor" {
     module.airlock
   ]
 }
+
+
+module "backup" {
+  count                                    = var.enable_backup ? 1 : 0
+  source                                   = "./backup"
+  tre_id                                   = var.tre_id
+  tre_resource_id                          = var.tre_resource_id
+  location                                 = var.location
+  resource_group_name                      = azurerm_resource_group.ws.name
+  resource_group_id                        = azurerm_resource_group.ws.id
+  tre_workspace_tags                       = local.tre_workspace_tags
+  arm_environment                          = var.arm_environment
+  azurerm_storage_account_id               = azurerm_storage_account.stg.id
+  enable_local_debugging                   = var.enable_local_debugging
+  enable_cmk_encryption                    = var.enable_cmk_encryption
+  shared_storage_name                      = var.shared_storage_name
+
+
+  depends_on = [
+    azurerm_storage_account.stg,
+    azapi_resource.shared_storage,
+    module.network,
+    module.airlock,
+    module.aad
+  ]
+}

--- a/templates/workspaces/base/terraform/workspace.tf
+++ b/templates/workspaces/base/terraform/workspace.tf
@@ -110,7 +110,6 @@ module "backup" {
     azurerm_storage_account.stg,
     azapi_resource.shared_storage,
     module.network,
-    module.airlock,
     module.aad
   ]
 }


### PR DESCRIPTION
# Resolves #4362 
This pull request introduces significant updates to the base template for workspaces, primarily focusing on adding backup capabilities and enhancing the cleanup process for Azure Recovery Services Vaults. The key changes include the addition of new parameters and outputs, updates to the `porter.yaml` file for handling backups, and the creation of new Terraform resources for managing backups.

### Backup and Recovery Enhancements:

* [`templates/workspaces/base/cleanup_vault.sh`](diffhunk://#diff-df5ed2762229456796fe6de0525bb8158ef6eae72d0bcb2598c53b73899c8988R1-R110): Added a new script to handle the cleanup of Azure Recovery Services Vaults, including disabling soft delete and removing protected items.
* [`templates/workspaces/base/terraform/backup/backup.tf`](diffhunk://#diff-6505069b802bb65d95fd1cf441d477d064ce425c0a76d751562aba8aa92724b0R1-R136): Introduced new Terraform resources to create and manage Azure Recovery Services Vaults, VM backup policies, and file share backup policies.
* [`templates/workspaces/base/porter.yaml`](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R129-R153): Updated to include new parameters and outputs related to backup configuration, and added steps to handle backup vault cleanup during uninstallation. [[1]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R129-R153) [[2]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R186-R201) [[3]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R240-R243) [[4]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R258-R260) [[5]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R292-R295) [[6]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R310-R312) [[7]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R339-R362) [[8]](diffhunk://#diff-cd8cff2140f58515828cb1ef294aacbeadb99bae8459088c095bb403c1b431d9R391-R411)

### Parameter and Schema Updates:

* [`templates/workspaces/base/parameters.json`](diffhunk://#diff-1ab594dedb5c961b92d90f326f4d7361dd160de5f2e53921b18c580e2518679fR162-R173): Added new parameters `enable_backup` and `shared_storage_name` to support backup configurations.
* [`templates/workspaces/base/template_schema.json`](diffhunk://#diff-de9aeb2e92de44c969857df599e9705da62f75986ae318f7abf506e729d1e19dR76-R82): Updated the schema to include the `enable_backup` parameter, allowing backups to be enabled or disabled for the workspace. [[1]](diffhunk://#diff-de9aeb2e92de44c969857df599e9705da62f75986ae318f7abf506e729d1e19dR76-R82) [[2]](diffhunk://#diff-de9aeb2e92de44c969857df599e9705da62f75986ae318f7abf506e729d1e19dR314)

### Terraform Configuration:

* [`templates/workspaces/base/terraform/backup/variables.tf`](diffhunk://#diff-f0e096512587f92cd19c292a73e38913a376b3d8f77f2837c4ddbecb4e31e4c6R1-R33): Defined new variables for backup configurations, including `location`, `tre_id`, `resource_group_name`, and `shared_storage_name`.
* [`templates/workspaces/base/terraform/backup/outputs.tf`](diffhunk://#diff-1db1470769c535f4b157ec93f2eb03b4b43905585b23aa33b64dcd20c2cf6ca6R1-R11): Added new outputs for backup vault and policy names to be used in other parts of the configuration.
* [`templates/workspaces/base/terraform/storage.tf`](diffhunk://#diff-b71dee846b48a2b6c72a9991a7f278173bf0ce1f21e60c983a611d2cd97fef35L39-R39): Updated the shared storage name variable to be configurable.

### Role Assignments:

* [`templates/workspaces/base/terraform/api-permissions.tf`](diffhunk://#diff-ad999ab4740c6a81ccd0e45a3baea6fc835f9e4ea59a74d72af3d2e3071bfbb8R23-R35): Added new role assignments for `Backup Contributor` and `Site Recovery Contributor` to manage backup and site recovery permissions.

These changes collectively enhance the robustness of the workspace by adding comprehensive backup and recovery functionalities, ensuring that critical data can be protected and restored as needed.

## What is being addressed

Added in a boolen for enable_backup that is set in the workspace config window. The system will deploy a recovery vault and the needed policy's. 
It passes the names of the polices back out so they can be used by other services (sql, vm, etc).

## How is this addressed

- Added terrafrom code to deploy the needed objects. Changed some of the settings for deploying shared vm storage. 
- still needs a management ui for recovery, ability to set the retention and backup policy. And possibly give the ability to move the backups to a diffrent storage account for archive. 
- Workspace documentation needs to be updated. NOT COMPLETED YET!
- base workspace have been bumped up. This needs to be fixed as it was changed for my testing. 
