### PR TITLE
Fix use of deprecated argument in jq

### DIFF
--- a/devops/scripts/register_bundle_with_api.sh
+++ b/devops/scripts/register_bundle_with_api.sh
@@ -99,7 +99,7 @@ fi
 acr_domain_suffix=$(az cloud show --query suffixes.acrLoginServerEndpoint --output tsv)
 explain_json=$(porter explain --reference "${acr_name}${acr_domain_suffix}"/"$(yq eval '.name' porter.yaml)":v"$(yq eval '.version' porter.yaml)" -o json)
 
-payload=$(echo "${explain_json}" | jq --argfile json_schema template_schema.json --arg current "${current}" --arg bundle_type "${bundle_type}" '. + {"json_schema": $json_schema, "resourceType": $bundle_type, "current": $current}')
+payload=$(echo "${explain_json}" | jq --slurpfile json_schema template_schema.json --arg current "${current}" --arg bundle_type "${bundle_type}" '. + {"json_schema": $json_schema[0], "resourceType": $bundle_type, "current": $current}')
 
 if [ "${dry_run}" == "true" ]; then
     echo "--dry-run specified - automatic bundle registration disabled. Use the script output to self-register. "


### PR DESCRIPTION
# Resolves #4446 

## What is being addressed

The default base image used by the devcontainer happens to include jq version 1.6. If this changes to upgrade jq to 1.7 or later the bug described in #4446 will occur.

## How is this addressed

There is only one script file this is used and it's a trivial change to fix it.

