### PR TITLE
Siba/format error message

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -24,6 +24,7 @@
     "react-redux": "^8.0.4",
     "react-router-dom": "6.28.2",
     "remark-gfm": "^3.0.1",
+    "strip-ansi": "^7.1.0",
     "typescript": "^5.6.3",
     "vite": "latest",
     "vite-plugin-eslint": "^1.8.1",

--- a/ui/app/src/components/shared/ResourceOperationListItem.tsx
+++ b/ui/app/src/components/shared/ResourceOperationListItem.tsx
@@ -1,8 +1,9 @@
-import { DefaultPalette, IStackItemStyles, Stack } from "@fluentui/react";
-
+import { DefaultPalette, IStackItemStyles, Stack, Panel, PanelType, Link } from "@fluentui/react";
+import React from "react";
+import stripAnsi from 'strip-ansi';
 interface ResourceOperationListItemProps {
-  header: String;
-  val: String;
+  header: string;
+  val: string;
 }
 
 export const ResourceOperationListItem: React.FunctionComponent<
@@ -14,15 +15,51 @@ export const ResourceOperationListItem: React.FunctionComponent<
       color: DefaultPalette.neutralSecondary,
     },
   };
+  const [isOpen, setIsOpen] = React.useState(false);
+  const cleanupError = (error: string) => {
+    // Remove ANSI escape codes
+    let cleanedError = stripAnsi(error);
+
+    //Replace various vertical bars with new lines
+    cleanedError = cleanedError.replace(/[│╷╵]/g, "\n");
+
+    // Remove leading and trailing whitespace
+    return cleanedError.trim();
+  };
+
+  // Check if the value is an error message
+  const isError = props.val.includes("Error:") || props.val.includes("error:");
+
   return (
     <>
       <Stack wrap horizontal>
         <Stack.Item styles={stackItemStyles} style={{ width: "20%" }}>
           {props.header}
         </Stack.Item>
-        <Stack.Item styles={stackItemStyles} style={{ width: "80%" }}>
-          : {props.val}
-        </Stack.Item>
+
+        {isError ? (
+          <>
+            <Stack.Item styles={stackItemStyles} style={{ width: "80%" }}>
+              <Link onClick={() => setIsOpen(true)}>An error occurred, click to view the error details</Link>
+            </Stack.Item>
+            <Panel
+              headerText="Error Details"
+              isOpen={isOpen}
+              type={PanelType.large}
+              closeButtonAriaLabel="Close"
+              isLightDismiss
+              onDismiss={() => setIsOpen(false)}
+            >
+              <div style={{ width: "100%", whiteSpace: "pre-wrap", fontFamily: "monospace", backgroundColor: "#000", color: "#fff", padding: "10px" }}>
+                {cleanupError(props.val)}
+              </div>
+            </Panel>
+          </>
+        ) : (
+          <Stack.Item styles={stackItemStyles} style={{ width: "80%" }}>
+            {props.val}
+          </Stack.Item>
+        )}
       </Stack>
     </>
   );

--- a/ui/app/yarn.lock
+++ b/ui/app/yarn.lock
@@ -4862,7 +4862,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==


### PR DESCRIPTION
# Resolves #4493 

## What is being addressed

Formats the error message in the operations panel

## How is this addressed

- Strips the ANSI characters using the `strip-ansi` package
- Displays a message and the error in a slide-over panel
- 
![image](https://github.com/user-attachments/assets/c55a52d9-e9eb-4b33-9e3c-158d2e7a9837)
![image](https://github.com/user-attachments/assets/a4c063cb-0f53-45af-a2c9-e65707bac0c2)
