### PR TITLE
Letsencrypt.yml fails with “Invalid reference in variable validation”

### DIFF
--- a/.github/workflows/lets_encrypt.yml
+++ b/.github/workflows/lets_encrypt.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.2.9
+          terraform_version: 1.9.8
           terraform_wrapper: false
 
       - name: Renew Certificates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * Format the error message in the Operations panel for enhanced readability ([#4493](https://github.com/microsoft/AzureTRE/issues/4493))
 
 BUG FIXES:
+* Letsencrypt.yml fails with "Invalid reference in variable validation" ([#4506](https://github.com/microsoft/AzureTRE/4506))
 
 ## 0.22.0 (April 20, 2025)
 


### PR DESCRIPTION
# Resolves #4506

## What is being addressed

- Bumps the terraform version in `letsencrypt.yml` to align with the devcontainer terraform version (1.9.8).
- Updated `CHANGELOG`

## Tests

I have tested this change manually on my local TRE deployment branch.  It is not covered by automated tests.