### PR TITLE
Ensure AirLock review VMs delete OS disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 BUG FIXES:
 * Letsencrypt.yml fails with "Invalid reference in variable validation" ([#4506](https://github.com/microsoft/AzureTRE/4506))
 * Intermittent management storage account access failure during core deployment ([#4505](https://github.com/microsoft/AzureTRE/4505))
+* Airlock Review Template Leaves OS Disk Behind ([4514](https://github.com/microsoft/AzureTRE/issues/4514))
 
 ## 0.22.0 (April 20, 2025)
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-export-reviewvm
-version: 0.3.0
+version: 0.3.1
 description: "An Azure TRE User Resource Template for reviewing Airlock export requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/main.tf
@@ -34,6 +34,7 @@ provider "azurerm" {
     }
     virtual_machine {
       skip_shutdown_and_force_delete = true
+      delete_os_disk_on_deletion     = true
     }
   }
   storage_use_azuread = true

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-import-reviewvm
-version: 0.4.0
+version: 0.4.1
 description: "An Azure TRE User Resource Template for reviewing Airlock import requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/main.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/main.tf
@@ -34,6 +34,7 @@ provider "azurerm" {
     }
     virtual_machine {
       skip_shutdown_and_force_delete = true
+      delete_os_disk_on_deletion     = true
     }
   }
   storage_use_azuread = true


### PR DESCRIPTION
# Resolves #4514 

## What is being addressed
Ensure AirLock review VMs delete OS disk

## How is this addressed

- Add  `delete_os_disk_on_deletion     = true` to AirLock VM templates
- Update CHANGELOG.md
- Increment template version if needed
