### PR TITLE
Fix rogue comma in Windows VM JSON

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -40,7 +40,7 @@
       "type": "string",
       "title": "Admin username",
       "description": "Overide automatic admin username generation.",
-      "default": ","
+      "default": ""
     },
     "vm_size": {
       "$id": "#/properties/vm_size",


### PR DESCRIPTION
This crept in in a recent PR.