### PR TITLE
Fix missing arguments for airlock manager requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ BUG FIXES:
 * Airlock Review Template Leaves OS Disk Behind ([4514](https://github.com/microsoft/AzureTRE/issues/4514))
 * Enabled Shared Access Key access on the core storage account ([#4448](https://github.com/microsoft/AzureTRE/issues/4448))
 * Remove `strtobool` from airlock_processor ([#4535](https://github.com/microsoft/AzureTRE/issues/4535))
+* Fix missing arguments for airlock manager requests ([#4544](https://github.com/microsoft/AzureTRE/issues/4544))
 
 ## 0.22.0 (April 20, 2025)
 

--- a/api_app/api/routes/requests.py
+++ b/api_app/api/routes/requests.py
@@ -28,7 +28,7 @@ async def get_requests(
                 order_ascending=order_ascending,
             )
         else:
-            requests = await airlock_request_repo.get_airlock_requests_for_airlock_manager(user)
+            requests = await airlock_request_repo.get_airlock_requests_for_airlock_manager(user_id=user.id, type=type, status=status, order_by=order_by, order_ascending=order_ascending)
 
         return requests
 

--- a/api_app/db/repositories/airlock_requests.py
+++ b/api_app/db/repositories/airlock_requests.py
@@ -146,12 +146,12 @@ class AirlockRequestRepository(BaseRepository):
             raise EntityDoesNotExist
         return parse_obj_as(AirlockRequest, airlock_requests)
 
-    async def get_airlock_requests_for_airlock_manager(self, user: User, type: Optional[AirlockRequestType] = None, status: Optional[AirlockRequestStatus] = None, order_by: Optional[str] = None, order_ascending=True) -> List[AirlockRequest]:
+    async def get_airlock_requests_for_airlock_manager(self, user_id: str, type: Optional[AirlockRequestType] = None, status: Optional[AirlockRequestStatus] = None, order_by: Optional[str] = None, order_ascending=True) -> List[AirlockRequest]:
         workspace_repo = await WorkspaceRepository.create()
         access_service = get_access_service()
 
         workspaces = await workspace_repo.get_active_workspaces()
-        user_role_assignments = access_service.get_identity_role_assignments(user.id)
+        user_role_assignments = access_service.get_identity_role_assignments(user_id)
 
         valid_roles = {ra.role_id for ra in user_role_assignments}
 

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/ui/app/src/components/shared/RequestsList.tsx
+++ b/ui/app/src/components/shared/RequestsList.tsx
@@ -104,7 +104,7 @@ export const RequestsList: React.FunctionComponent = () => {
       );
       requests = mapRequestsToWorkspace(requests, fetchedWorkspaces.workspaces);
       airlock_manager_requests = await apiCall(
-        `${ApiEndpoint.Requests}?${query.slice(0, -1)}&airlock_manager=true`,
+        `${ApiEndpoint.Requests}${query.slice(0, -1)}&airlock_manager=true`,
         HttpMethod.Get,
       );
       airlock_manager_requests = mapRequestsToWorkspace(


### PR DESCRIPTION
Add missing parameters to the requests route for the airlock manager, ensuring proper functionality and filtering of requests. 

Update tests to validate the changes.

Remove additonal `?` being passed by the UI in querystring

Fixes #4544