### PR TITLE
Allow UI_SITE_NAME and UI_FOOTER_TEXT to be passed to deploy_tre_reusable.yaml

### DIFF
--- a/.github/workflows/deploy_tre_reusable.yml
+++ b/.github/workflows/deploy_tre_reusable.yml
@@ -35,6 +35,16 @@ on: # yamllint disable-line rule:truthy
         description: ""
         type: string
         required: true
+      UI_SITE_NAME:
+        description: Change the header text in the TRE portal
+        type: string
+        default: ""
+        required: false
+      UI_FOOTER_TEXT:
+        description: Change the footer text in the TRE portal
+        type: string
+        default: ""
+        required: false
     secrets:
       AAD_TENANT_ID:
         description: ""
@@ -772,8 +782,8 @@ jobs:
           MGMT_STORAGE_ACCOUNT_NAME: ${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}
           SWAGGER_UI_CLIENT_ID: "${{ secrets.SWAGGER_UI_CLIENT_ID }}"
           USER_MANAGEMENT_ENABLED: ${{ vars.USER_MANAGEMENT_ENABLED }}
-          UI_SITE_NAME: "${{ vars.UI_SITE_NAME }}"
-          UI_FOOTER_TEXT: "${{ vars.UI_FOOTER_TEXT }}"
+          UI_SITE_NAME: "${{ inputs.UI_SITE_NAME || vars.UI_SITE_NAME }}"
+          UI_FOOTER_TEXT: "${{ inputs.UI_FOOTER_TEXT || vars.UI_FOOTER_TEXT }}"
 
   e2e_tests_smoke:
     name: "Run E2E Tests (Smoke)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ ENHANCEMENTS:
 * Delete old database migrations ([#4168](https://github.com/microsoft/AzureTRE/issues/4168))
 * Update terraform to reduce recreation of private endpoints and other resources ([#4539](https://github.com/microsoft/AzureTRE/pull/4539))
 * Disable ACR admin account ([#4542](https://github.com/microsoft/AzureTRE/pull/4542))
+* Allow UI_SITE_NAME and UI_FOOTER_TEXT to be dynamically calculated passed in deploy_tre_reusable.yaml ([#TBC](https://github.com/microsoft/AzureTRE/pull/TBC))
 
 BUG FIXES:
 * Letsencrypt.yml fails with "Invalid reference in variable validation" ([#4506](https://github.com/microsoft/AzureTRE/4506))


### PR DESCRIPTION
## What is being addressed

This is a small follow up to #4201 allowing the UI_SITE_NAME and UI_FOOTER_TEXT to be passed as parameters to `deploy_tre_reusable.yaml`.

The current behaviour of this script reads these variables directly from the Actions variables (`var.UI_SITE_NAME` and `vars.UI_FOOTER_TEXT`), whereas this change allows you to pass the variables in to the `deploy_tre_reusable.yaml` workflow as parameters - allowing per dynamically calculated variables to be passed.

For example, if you want to append a version number or a date stamp to your `UI_FOOTER_TEXT`, the calling workflow of `deploy_tre_reusable.yaml` can perform this string manipulation and pass the value through.  This was more difficult before as the variable values were set statically in the Actions variables (updating Actions variables from a workflow is painful as the default GH API token does not have rights to perform this).

If values for `UI_SITE_NAME` and `UI_FOOTER_TEXT` are not passed as parameters, the Actions variables values are used instead.