### PR TITLE
Enable firewall support for Databricks storage account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ ENHANCEMENTS:
 * Delete old database migrations ([#4168](https://github.com/microsoft/AzureTRE/issues/4168))
 * Update terraform to reduce recreation of private endpoints and other resources ([#4539](https://github.com/microsoft/AzureTRE/pull/4539))
 * Disable ACR admin account ([#4542](https://github.com/microsoft/AzureTRE/pull/4542))
+* Enable firewall support for Databricks storage account ([#4391](https://github.com/microsoft/AzureTRE/issues/4391))
 
 BUG FIXES:
 * Letsencrypt.yml fails with "Invalid reference in variable validation" ([#4506](https://github.com/microsoft/AzureTRE/4506))

--- a/templates/shared_services/databricks-auth/porter.yaml
+++ b/templates/shared_services/databricks-auth/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-databricks-private-auth
-version: 0.1.12
+version: 0.1.13
 description: "An Azure TRE shared service for Azure Databricks authentication."
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/shared_services/databricks-auth/terraform/data.tf
+++ b/templates/shared_services/databricks-auth/terraform/data.tf
@@ -17,3 +17,29 @@ data "azurerm_private_dns_zone" "databricks" {
   name                = module.terraform_azurerm_environment_configuration.private_links["privatelink.azuredatabricks.net"]
   resource_group_name = local.core_resource_group_name
 }
+
+data "azurerm_private_dns_zone" "dfscore" {
+  name                = module.terraform_azurerm_environment_configuration.private_links["privatelink.dfs.core.windows.net"]
+  resource_group_name = local.core_resource_group_name
+}
+
+data "azurerm_private_dns_zone" "blobcore" {
+  name                = module.terraform_azurerm_environment_configuration.private_links["privatelink.blob.core.windows.net"]
+  resource_group_name = local.core_resource_group_name
+}
+
+data "azurerm_resource_group" "databricks_managed_resource_group" {
+  name = split("/", azurerm_databricks_workspace.databricks.managed_resource_group_id)[4]
+
+  depends_on = [azurerm_databricks_workspace.databricks]
+}
+
+data "azurerm_resources" "databricks_managed_resource_list" {
+  resource_group_name = data.azurerm_resource_group.databricks_managed_resource_group.name
+  type                = "Microsoft.Storage/storageAccounts"
+}
+
+data "azurerm_storage_account" "databricks_managed_storage_account" {
+  name                = data.azurerm_resources.databricks_managed_resource_list.resources[0].name
+  resource_group_name = data.azurerm_resources.databricks_managed_resource_list.resource_group_name
+}

--- a/templates/shared_services/databricks-auth/terraform/main.tf
+++ b/templates/shared_services/databricks-auth/terraform/main.tf
@@ -21,6 +21,8 @@ resource "azurerm_databricks_workspace" "databricks" {
   infrastructure_encryption_enabled     = true
   public_network_access_enabled         = false
   network_security_group_rules_required = "NoAzureDatabricksRules"
+  default_storage_firewall_enabled      = true
+  access_connector_id                   = azurerm_databricks_access_connector.connector.id
   tags                                  = local.tre_shared_service_tags
 
   lifecycle { ignore_changes = [tags] }
@@ -38,4 +40,20 @@ resource "azurerm_databricks_workspace" "databricks" {
     azurerm_subnet_network_security_group_association.host,
     azurerm_subnet_network_security_group_association.container
   ]
+}
+
+// required to set default_storage_firewall_enabled = true
+// https://learn.microsoft.com/en-us/azure/databricks/security/network/storage/firewall-support
+//
+resource "azurerm_databricks_access_connector" "connector" {
+  name                = "${local.databricks_workspace_name}-access-connector"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  tags                = local.tre_shared_service_tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle { ignore_changes = [tags] }
 }

--- a/templates/shared_services/databricks-auth/terraform/network.tf
+++ b/templates/shared_services/databricks-auth/terraform/network.tf
@@ -168,3 +168,55 @@ resource "azurerm_private_endpoint" "databricks_auth_private_endpoint" {
     private_dns_zone_ids = [data.azurerm_private_dns_zone.databricks.id]
   }
 }
+
+resource "azurerm_private_endpoint" "databricks_filesystem_private_endpoint" {
+  name                = "pe-adb-fs-${local.service_resource_name_suffix}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  subnet_id           = data.azurerm_subnet.services.id
+  tags                = local.tre_shared_service_tags
+
+  lifecycle { ignore_changes = [tags] }
+
+  private_service_connection {
+    name                           = "private-service-connection-databricks-filesystem-${local.service_resource_name_suffix}"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.databricks.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${data.azurerm_storage_account.databricks_managed_storage_account.name}"])
+    is_manual_connection           = false
+    subresource_names              = ["dfs"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group-databricks-filesystem-${local.service_resource_name_suffix}"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.dfscore.id]
+  }
+
+  depends_on = [
+    data.azurerm_storage_account.databricks_managed_storage_account
+  ]
+}
+
+resource "azurerm_private_endpoint" "databricks_blob_private_endpoint" {
+  name                = "pe-adb-blob-${local.service_resource_name_suffix}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  subnet_id           = data.azurerm_subnet.services.id
+  tags                = local.tre_shared_service_tags
+
+  lifecycle { ignore_changes = [tags] }
+
+  private_service_connection {
+    name                           = "private-service-connection-databricks-blob-${local.service_resource_name_suffix}"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.databricks.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${data.azurerm_storage_account.databricks_managed_storage_account.name}"])
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group-databricks-blob-${local.service_resource_name_suffix}"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.blobcore.id]
+  }
+
+  depends_on = [
+    data.azurerm_storage_account.databricks_managed_storage_account
+  ]
+}

--- a/templates/workspace_services/databricks/porter.yaml
+++ b/templates/workspace_services/databricks/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-databricks
-version: 1.0.11
+version: 1.0.12
 description: "An Azure TRE service for Azure Databricks."
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/databricks/terraform/data.tf
+++ b/templates/workspace_services/databricks/terraform/data.tf
@@ -28,3 +28,8 @@ data "azurerm_private_dns_zone" "dfscore" {
   name                = module.terraform_azurerm_environment_configuration.private_links["privatelink.dfs.core.windows.net"]
   resource_group_name = local.core_resource_group_name
 }
+
+data "azurerm_private_dns_zone" "blobcore" {
+  name                = module.terraform_azurerm_environment_configuration.private_links["privatelink.blob.core.windows.net"]
+  resource_group_name = local.core_resource_group_name
+}

--- a/templates/workspace_services/databricks/terraform/main.tf
+++ b/templates/workspace_services/databricks/terraform/main.tf
@@ -7,6 +7,8 @@ resource "azurerm_databricks_workspace" "databricks" {
   infrastructure_encryption_enabled     = true
   public_network_access_enabled         = var.is_exposed_externally
   network_security_group_rules_required = "NoAzureDatabricksRules"
+  default_storage_firewall_enabled      = true
+  access_connector_id                   = azurerm_databricks_access_connector.connector.id
   tags                                  = local.tre_workspace_service_tags
 
   lifecycle { ignore_changes = [tags] }
@@ -25,4 +27,20 @@ resource "azurerm_databricks_workspace" "databricks" {
     azurerm_subnet_network_security_group_association.host,
     azurerm_subnet_network_security_group_association.container
   ]
+}
+
+// required to set default_storage_firewall_enabled = true
+// https://learn.microsoft.com/en-us/azure/databricks/security/network/storage/firewall-support
+//
+resource "azurerm_databricks_access_connector" "connector" {
+  name                = "${local.databricks_workspace_name}-access-connector"
+  resource_group_name = data.azurerm_resource_group.ws.name
+  location            = data.azurerm_resource_group.ws.location
+  tags                = local.tre_workspace_service_tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle { ignore_changes = [tags] }
 }

--- a/templates/workspace_services/databricks/terraform/network.tf
+++ b/templates/workspace_services/databricks/terraform/network.tf
@@ -212,3 +212,29 @@ resource "azurerm_private_endpoint" "databricks_filesystem_private_endpoint" {
     azurerm_private_endpoint.databricks_control_plane_private_endpoint
   ]
 }
+
+resource "azurerm_private_endpoint" "databricks_blob_private_endpoint" {
+  name                = "pe-adb-blob-${local.service_resource_name_suffix}"
+  location            = data.azurerm_resource_group.ws.location
+  resource_group_name = data.azurerm_resource_group.ws.name
+  subnet_id           = data.azurerm_subnet.services.id
+  tags                = local.tre_workspace_service_tags
+
+  lifecycle { ignore_changes = [tags] }
+
+  private_service_connection {
+    name                           = "private-service-connection-databricks-blob-${local.service_resource_name_suffix}"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.databricks.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.storage_name}"])
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group-databricks-blob-${local.service_resource_name_suffix}"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.blobcore.id]
+  }
+
+  depends_on = [
+    azurerm_private_endpoint.databricks_control_plane_private_endpoint
+  ]
+}


### PR DESCRIPTION
# Resolves #4391

## What is being addressed

Enables the firewall on the Databricks managed storage account for the following services:

- Databricks workspace service
- Databricks authentication shared service

According to the following guide:

https://learn.microsoft.com/en-us/azure/databricks/security/network/storage/firewall-support

## Changes made

- create an `azurerm_databricks_access_connector`
- create `blob` and `dfs` private endpoints to the managed storage account
- set the following attributes on the `azurerm_databricks_workspace`:
  - `default_storage_firewall_enabled`
  - `access_connector_id`

## Local testing performed

1. Set up Databricks prior to this PR
2. Add an external location pointing to an external storage account
3. Set up local compute and serverless compute
4. Test access to the managed storage, and the external storage using both compute clusters

Apply the PR and upgrade Databricks.  Then:

1. Update (external location) credentials to use the new access connector
2. Reapply RBAC on the new access connector for the external location
3. Re-test access to the manage storage, and the external storage using both compute clusters

## Migration note regarding the Unity Catalog Access Connector

Before this change, the Unity Catalog Access Connector was automatically created as part of the Databricks managed resource group.  In order to enable the firewall on the Databricks managed storage account, a new explicitly Access Connector defined in terraform is required, which replaces the previous managed Access Connector.

**Because of this any settings applied to or using the old managed Access Connector must be migrated over to the new one.**

Typically this will be:

- storage credentials defined in Databricks referencing the Access Connector
- RBAC permissions within Azure granted to the Access Connector