### PR TITLE
Fix "log analytics workspaces not found" error when deploying Databricks workspace service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 <!-- markdownlint-disable MD041 -->
 ## 0.24.0 [Unreleased]
 
-* _No changes yet_
+ENHANCEMENTS:
+
+BUG FIXES:
+* Fix "log analytics workspaces not found" error when deploying Databricks workspace service ([#4585](https://github.com/microsoft/AzureTRE/pull/4585))
 
 ## 0.23.0 (June 10, 2025)
 **BREAKING CHANGES & MIGRATIONS**:

--- a/templates/workspace_services/databricks/porter.yaml
+++ b/templates/workspace_services/databricks/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-databricks
-version: 1.0.12
+version: 1.0.13
 description: "An Azure TRE service for Azure Databricks."
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/workspace_services/databricks/terraform/data.tf
+++ b/templates/workspace_services/databricks/terraform/data.tf
@@ -31,5 +31,5 @@ data "azurerm_private_dns_zone" "dfscore" {
 
 data "azurerm_log_analytics_workspace" "workspace" {
   name                = "log-${local.workspace_resource_name_suffix}"
-  resource_group_name = local.core_resource_group_name
+  resource_group_name = local.resource_group_name
 }


### PR DESCRIPTION
## What is being addressed

Fix issue introduced by PR #4576 in this commit:

https://github.com/microsoft/AzureTRE/pull/4576/commits/f36aff23996b5a74183eebed35c6f23bb1798ab6

The LA workspace name was switched to use the *workspace* name, but the resource group name was not updated at the same time.

```
data "azurerm_log_analytics_workspace" "workspace" {
  name                = "log-${local.workspace_resource_name_suffix}"
  resource_group_name = local.core_resource_group_name
}
```

This PR updates the resource group name to use the workspace resource group name:

```
data "azurerm_log_analytics_workspace" "workspace" {
  name                = "log-${local.workspace_resource_name_suffix}"
  resource_group_name = local.resource_group_name
}
```