### PR TITLE
Remove resource locks before deleting resource groups in destroy_env_no_terraform.sh

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -188,5 +188,7 @@ while read -r rg_item; do
   purge_container_repositories "$rg_item"
 
   echo "Deleting resource group: ${rg_item}"
+  # remove any resource locks on resources inside the resource group
+  az lock list --resource-group "${rg_item}" --query "[].id" -o tsv | xargs -r -I {} az lock delete --id "{}"
   az group delete --resource-group "${rg_item}" --yes ${no_wait_option}
 done


### PR DESCRIPTION
Ensure that any resource locks are removed prior to deleting resource groups to prevent deletion failures.