### PR TITLE
Add missing image_gallery_id parameter to portal.yaml for export review vm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
 BUG FIXES:
 * Fix disable public network access for stwebcertsTREID is still flagging in Defender ([#4640](https://github.com/microsoft/AzureTRE/issues/4640))
 * Fix error 'resource with the ID pip-fw-management already exists' during firewall migration ([#4661](https://github.com/microsoft/AzureTRE/issues/4661))
+* Add missing image_gallery_id parameter to porter.yaml for guacamole export review vm ([#4678](https://github.com/microsoft/AzureTRE/pull/4678)]
 
 ## 0.25.0 (July 18, 2025)
 **IMPORTANT**:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -128,7 +128,7 @@ install:
         parent_service_id: ${ bundle.parameters.parent_service_id }
         tre_resource_id: ${ bundle.parameters.id }
         image: ${ bundle.parameters.os_image }
-        vm_size: ${ bundle.parameters.vm_size
+        vm_size: ${ bundle.parameters.vm_size }
         image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: ${ bundle.parameters.airlock_request_sas_url }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-export-reviewvm
-version: 0.3.3
+version: 0.3.4
 description: "An Azure TRE User Resource Template for reviewing Airlock export requests"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/porter.yaml
@@ -40,6 +40,10 @@ parameters:
     type: string
     description: "Resource group containing the shared ACR"
     env: PARENT_SERVICE_ID
+  - name: image_gallery_id
+    type: string
+    description: Azure resource ID for the compute image gallery to pull images from (if specifying custom images by name)
+    default: ""
   - name: id
     type: string
     description: "An Id for this installation"
@@ -124,7 +128,8 @@ install:
         parent_service_id: ${ bundle.parameters.parent_service_id }
         tre_resource_id: ${ bundle.parameters.id }
         image: ${ bundle.parameters.os_image }
-        vm_size: ${ bundle.parameters.vm_size }
+        vm_size: ${ bundle.parameters.vm_size
+        image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: ${ bundle.parameters.airlock_request_sas_url }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
@@ -151,6 +156,7 @@ upgrade:
         tre_resource_id: ${ bundle.parameters.id }
         image: ${ bundle.parameters.os_image }
         vm_size: ${ bundle.parameters.vm_size }
+        image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: "unused"
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }
@@ -189,6 +195,7 @@ uninstall:
         tre_resource_id: ${ bundle.parameters.id }
         image: ${ bundle.parameters.os_image }
         vm_size: ${ bundle.parameters.vm_size }
+        image_gallery_id: ${ bundle.parameters.image_gallery_id }
         airlock_request_sas_url: "unused"
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
         key_store_id: ${ bundle.parameters.key_store_id }


### PR DESCRIPTION
If you are using compute gallery images with your Guacamole VMs, then the `image_gallery_id` parameter is needed to carry the compute gallery reference.

It is present as a parameter in:

**Windows VM:**

https://github.com/microsoft/AzureTRE/blob/90b158b9bdf89af1c8e564e45617aef4976d299e/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml#L77

**Windows Import Review VM:**

https://github.com/microsoft/AzureTRE/blob/90b158b9bdf89af1c8e564e45617aef4976d299e/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/porter.yaml#L50

**Linux VM:**

https://github.com/microsoft/AzureTRE/blob/90b158b9bdf89af1c8e564e45617aef4976d299e/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml#L69

But it is missing from the Export Review VM, which causes the following error:

```
Error: parsing "/images/imgdef-my-image-name": parsing the Image ID: the number of segments didn't match 
  
 Expected a Image ID that matched (containing 8 segments): 
  
 > /subscriptions/XXX/resourceGroups/example-resource-group/providers/Microsoft.Compute/images/imageValue 
  
 However this value was provided (which was parsed into 0 segments): 
  
 > /images/imgdef-my-image-name
  
 The following Segments are expected: 
  
 * Segment 0 - this should be the literal value "subscriptions" 
 * Segment 1 - this should be the UUID of the Azure Subscription 
 * Segment 2 - this should be the literal value "resourceGroups" 
 * Segment 3 - this should be the name of the Resource Group 
 * Segment 4 - this should be the literal value "providers" 
 * Segment 5 - this should be the name of the Resource Provider [for example 'Microsoft.Compute'] 
 * Segment 6 - this should be the literal value "images" 
 * Segment 7 - this should be the user specified value for this image [for example "imageValue"] 
```

This PR adds it in so its possible to use custom images with the Export Review VM.