### PR TITLE
Fix test results workflow to skip dockerbuild artifacts

### DIFF
--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -35,7 +35,7 @@ jobs:
 
           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
 
-          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read -r artifact
+          gh api "$artifacts_url" -q '.artifacts[] | select(.name | endswith(".dockerbuild") | not) | [.name, .archive_download_url] | @tsv' | while read -r artifact
           do
             IFS=$'\t' read -r name url <<< "$artifact"
             gh api "$url" > "$name.zip"


### PR DESCRIPTION
## What is being addressed

The docker build action has started uploading artifacts intended for tracing in DockerDesktop. The test_results workflow assumed all artifacts are zip files which they aren't anymore.

## How is this addressed

- Skip downloading artifacts that end with `buildbuild`