### PR TITLE
Add missing changelog entry for 0.26.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ ENHANCEMENTS:
 * Standardize database query parameter handling across repository classes ([#4697](https://github.com/microsoft/AzureTRE/issues/4697))
 * Improve documentation on `address_space` allocation ([#4726](https://github.com/microsoft/AzureTRE/pull/4726))
 * Upgrade to CodeQL v4 actions ([#4750](https://github.com/microsoft/AzureTRE/pull/4750))
+* Enable Workspace to deploy to separate subscription ([#4455](https://github.com/microsoft/AzureTRE/pull/4455))
 
 BUG FIXES:
 * Remove deprecated ms-teams-notification action from E2E test workflows ([#4716](https://github.com/microsoft/AzureTRE/issues/4716))


### PR DESCRIPTION
## What is being addressed

https://github.com/microsoft/AzureTRE/pull/4455 is missing from the 0.26.0 changelog

## How is this addressed

- Update CHANGELOG.md
