### PR TITLE
update readme; add CGI partnership

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Core features include:
 
 The aim is to bring together learnings from past customer engagements where TREs have been built into a single reference solution. This is a solution accelerator aiming to be a great starting point for a customized TRE solution. You're encouraged to download and customize the solution to meet your requirements
 
-This project does not have a dedicated team of maintainers but relies on you and the community to maintain and enhance the solution. Microsoft will on project-to-project basis continue to extend the solution in collaboration with customers and partners. No guarantees can be offered as to response times on issues, feature requests, or to the long term road map for the project.
+This project is maintained by CGI in partnership with Microsoft. Support for the project is provided on a best-effort basis through the open-source community and project maintainers. No guarantees can be made regarding response times for issues, feature requests, or long-term roadmap commitments.
 
 It is important before deployment of the solution that the [Support Policy](SUPPORT.md) is read and understood.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,9 +4,9 @@
 
 This project has been created to accelerate the development of Trusted Research Environments by Microsoft and its partners while working with customers.
 
-This project does not have a dedicated team of maintainers outside of those who are working on an active engagements and as such issues will be responded to on a best efforts basis. No guarantees can be offered as to response times on issues, feature requests, or to the long term road map for the project.
+This project is maintained by CGI in partnership with Microsoft. Support for the project is provided on a best-effort basis through the open-source community and project maintainers. No guarantees can be made regarding response times for issues, feature requests, or long-term roadmap commitments.
 
-Taking the above statement into account the team involved in this effort wish for the project to evolve into a stable, production ready resource with active contributors from Microsoft and the wider community.
+Taking the above statement into account the team involved in this effort wish for the project to evolve into a stable, production ready resource with active contributors from CGI, Microsoft and the wider community.
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates.  For new issues, file your bug or feature request as a new Issue.
 


### PR DESCRIPTION
# Update README to outline CGI/Microsoft partnership

## What is being addressed

Updating the README to outline the collaboration between CGI and Microsoft. CGI is to maintain TRE and work with Microsoft as partners going forward.

## How is this addressed
Change to README and SUPPORT.md only. This is not a code change.
