### PR TITLE
Exclude recovery service vaults from e2e tests by disabling backup in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * Pin all GitHub Actions workflow steps to full commit SHAs to prevent supply chain attacks plus update to latest releases ([#4886](https://github.com/microsoft/AzureTRE/pull/4886))
 * Add Windows Server 2025 image support to Guacamole. ([#4890](https://github.com/microsoft/AzureTRE/issues/4890))
 * Add support for setting resource processor VMSS SKU via environment variables ([#4936](https://github.com/microsoft/AzureTRE/issues/4936))
+* Exclude recovery service vaults from e2e tests ([#4920](https://github.com/microsoft/AzureTRE/issues/4920))
 
 ## (0.28.0) (March 2, 2026)
 **BREAKING CHANGES**

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -8,7 +8,7 @@ import logging
 from resources.resource import post_resource, disable_and_delete_resource
 from resources.workspace import get_workspace_auth_details
 from resources import strings as resource_strings
-from helpers import get_admin_token
+from helpers import get_admin_token, get_template
 
 
 LOGGER = logging.getLogger(__name__)
@@ -46,10 +46,16 @@ async def create_or_get_test_workspace(
             "display_name": f"E2E {description} workspace ({auth_type} AAD)",
             "description": f"{template_name} test workspace for E2E tests",
             "auth_type": auth_type,
-            "address_space_size": "small",
-            "enable_backup": False
+            "address_space_size": "small"
         }
     }
+
+    admin_token = await get_admin_token(verify=verify)
+    async with get_template(template_name, resource_strings.API_WORKSPACE_TEMPLATES, admin_token, verify) as response:
+        template_properties = response.json().get("properties", {})
+        if "enable_backup" in template_properties:
+            payload["properties"]["enable_backup"] = False
+
     if config.TEST_WORKSPACE_APP_PLAN != "":
         payload["properties"]["app_service_plan_sku"] = config.TEST_WORKSPACE_APP_PLAN
 
@@ -57,7 +63,6 @@ async def create_or_get_test_workspace(
         payload["properties"]["client_id"] = client_id
         payload["properties"]["client_secret"] = client_secret
 
-    admin_token = await get_admin_token(verify=verify)
     # TODO: Temp fix to solve creation of workspaces - https://github.com/microsoft/AzureTRE/issues/2986
     await asyncio.sleep(random.uniform(1, 9))
     workspace_path, workspace_id = await post_resource(payload, resource_strings.API_WORKSPACES, access_token=admin_token, verify=verify)

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -52,6 +52,9 @@ async def create_or_get_test_workspace(
 
     admin_token = await get_admin_token(verify=verify)
     async with get_template(template_name, resource_strings.API_WORKSPACE_TEMPLATES, admin_token, verify) as response:
+        assert response.status_code == 200, (
+            f"Failed to GET workspace template '{template_name}': {response.status_code}. Response text: {response.text}"
+        )
         template_properties = response.json().get("properties", {})
         if "enable_backup" in template_properties:
             payload["properties"]["enable_backup"] = False

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -46,7 +46,8 @@ async def create_or_get_test_workspace(
             "display_name": f"E2E {description} workspace ({auth_type} AAD)",
             "description": f"{template_name} test workspace for E2E tests",
             "auth_type": auth_type,
-            "address_space_size": "small"
+            "address_space_size": "small",
+            "enable_backup": False
         }
     }
     if config.TEST_WORKSPACE_APP_PLAN != "":

--- a/e2e_tests/resources/resource.py
+++ b/e2e_tests/resources/resource.py
@@ -8,7 +8,7 @@ from e2e_tests.resources.deployment import delete_done, install_done, patch_done
 from resources import strings
 
 LOGGER = logging.getLogger(__name__)
-TIMEOUT = Timeout(10, read=30)
+TIMEOUT = Timeout(10, read=60)
 
 
 async def get_resource(endpoint, access_token, verify):

--- a/templates/workspaces/airlock-import-review/porter.yaml
+++ b/templates/workspaces/airlock-import-review/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-airlock-import-review
-version: 0.14.9
+version: 0.15.0
 description: "A workspace to do Airlock Data Import Reviews for Azure TRE"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -119,6 +119,10 @@ parameters:
     type: string
     description: "The SKU used when deploying an Azure App Service Plan"
     default: "P1v3"
+  - name: enable_backup
+    type: boolean
+    default: true
+    description: "Enable backups for the workspace, including VMs and shared storage."
   - name: enable_cmk_encryption
     type: boolean
     default: false
@@ -210,6 +214,7 @@ install:
         app_role_id_workspace_airlock_manager: ${ bundle.parameters.app_role_id_workspace_airlock_manager }
         aad_redirect_uris_b64: ${ bundle.parameters.aad_redirect_uris }
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
+        enable_backup: ${ bundle.parameters.enable_backup }
         enable_airlock: false
         arm_environment: ${ bundle.parameters.arm_environment }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
@@ -259,6 +264,7 @@ upgrade:
         app_role_id_workspace_airlock_manager: ${ bundle.parameters.app_role_id_workspace_airlock_manager }
         aad_redirect_uris_b64: ${ bundle.parameters.aad_redirect_uris }
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
+        enable_backup: ${ bundle.parameters.enable_backup }
         enable_airlock: false
         arm_environment: ${ bundle.parameters.arm_environment }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }
@@ -331,6 +337,7 @@ uninstall:
         app_role_id_workspace_airlock_manager: ${ bundle.parameters.app_role_id_workspace_airlock_manager }
         aad_redirect_uris_b64: ${ bundle.parameters.aad_redirect_uris }
         app_service_plan_sku: ${ bundle.parameters.app_service_plan_sku }
+        enable_backup: ${ bundle.parameters.enable_backup }
         enable_airlock: false
         arm_environment: ${ bundle.parameters.arm_environment }
         enable_cmk_encryption: ${ bundle.parameters.enable_cmk_encryption }

--- a/templates/workspaces/airlock-import-review/template_schema.json
+++ b/templates/workspaces/airlock-import-review/template_schema.json
@@ -25,7 +25,7 @@
     },
     "enable_backup": {
       "type": "boolean",
-      "title": "Enable backup",
+      "title": "Enable Backup",
       "description": "Enable backups for the workspace, including VMs and shared storage.",
       "default": true,
       "updateable": true

--- a/templates/workspaces/airlock-import-review/template_schema.json
+++ b/templates/workspaces/airlock-import-review/template_schema.json
@@ -23,6 +23,13 @@
         "S1"
       ]
     },
+    "enable_backup": {
+      "type": "boolean",
+      "title": "Enable backup",
+      "description": "Enable backups for the workspace, including VMs and shared storage.",
+      "default": true,
+      "updateable": true
+    },
     "address_space_size": {
       "type": "string",
       "title": "Address space size",
@@ -172,6 +179,7 @@
       "description",
       "overview",
       "app_service_plan_sku",
+      "enable_backup",
       "address_space_size",
       "address_spaces",
       "auth_type",


### PR DESCRIPTION
# Resolves #4920 

## What is being addressed

E2E tests failing to run due to bug in recovery service vaults.

## How is this addressed

Added parameter to "properties" payload in e2etests/conftest.py to disable backup (currently enabled by default)
```
payload = {
    "templateName": template_name,
    "properties": {
        "display_name": f"E2E {description} workspace ({auth_type} AAD)",
        "description": f"{template_name} test workspace for E2E tests",
        "auth_type": auth_type,
        "address_space_size": "small",
        "enable_backup": False
    }
}
```

duplicating @maxmartin-cgi work so we can get the pipelines running (https://github.com/microsoft/AzureTRE/pull/4921)