### PR TITLE
change tsconfig `moduleResolution` to `bundler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ENHANCEMENTS:
 * Update dependencies to address Dependabot security alerts: `aiohttp` to 3.14.1, `Pygments` to 2.20.0, `esbuild`, `ws`, `js-yaml`, `@babel/core`, `flatted` (via vitest upgrade), and `react-router-dom`. ([#4950](https://github.com/microsoft/AzureTRE/issues/4950))
 
 BUG FIXES:
+* Fix UI TypeScript deprecation warning by updating `moduleResolution` to `bundler` in `tsconfig.json`. ([#4968](https://github.com/microsoft/AzureTRE/issues/4968))
 * Fix API timeout and name collision failures on workspace creation by checking storage account name availability and improved logging. ([#4946](https://github.com/microsoft/AzureTRE/pull/4946))
 * Fix error handling in airlock processor ([#4929](https://github.com/microsoft/AzureTRE/pull/4929))
 * Fix dependabot high severity alerts for packages fast-uri, lodash, picomatch, immutable, minimatch, flatted and PyJWT

--- a/ui/app/package-lock.json
+++ b/ui/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tre-ui",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tre-ui",
-      "version": "0.8.27",
+      "version": "0.8.28",
       "dependencies": {
         "@azure/msal-browser": "^2.35.0",
         "@azure/msal-react": "^1.5.12",

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/ui/app/tsconfig.json
+++ b/ui/app/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
# Resolves #4968
## What is being addressed

The current moduleResolution setting of "node" (node10) is deprecated, since we are using vite as a bundler then moduleResolution should be updated to "bundler"

## How is this addressed

- change moduleResolution to bundler
- Updated CHANGELOG.md
- Increment ui version