### PR TITLE
Update backup.tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ BUG FIXES:
 * Fix spelling in docs using codespell ([#4954](https://github.com/microsoft/AzureTRE/issues/4954))
 * Replace deprecated yaspell with codespell and add pre-commit hook installer to devcontainer. ([#4953](https://github.com/microsoft/AzureTRE/issues/4953))
 * Fix Guacamole Windows VM image selections by aligning schema enums/defaults with supported image options in Windows and review VM templates. ([#4963](https://github.com/microsoft/AzureTRE/issues/4963))
+* Remove deprecated `soft_delete_enabled` setting from `azurerm_recovery_services_vault` in base workspace template. ([#4967](https://github.com/microsoft/AzureTRE/issues/4967))
 
 ## (0.28.0) (March 2, 2026)
 **BREAKING CHANGES**

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 2.8.3
+version: 2.8.4
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspaces/base/terraform/backup/backup.tf
+++ b/templates/workspaces/base/terraform/backup/backup.tf
@@ -4,7 +4,6 @@ resource "azurerm_recovery_services_vault" "vault" {
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = "Standard"
-  soft_delete_enabled = false
   storage_mode_type   = "ZoneRedundant" #  Possible values are "GeoRedundant", "LocallyRedundant" and "ZoneRedundant". Defaults to "GeoRedundant".
   tags                = var.tre_workspace_tags
 


### PR DESCRIPTION
# Resolves #4967 

## What is being addressed

Updated base template to remove `soft_delete = enabled` from the `azurerm_recovery_services_vault` resource as this is no longer a setting which can be configured and is enabled by default on resource creation.

## How is this addressed

- Removed the deprecated `soft_delete_enabled` property from the `azurerm_recovery_services_vault` resource in `templates/workspaces/base/terraform/backup/backup.tf`
- Updated `CHANGELOG.md` with a BUG FIXES entry referencing [#4967](https://github.com/microsoft/AzureTRE/issues/4967)
- Bumped base workspace template version from `2.8.3` to `2.8.4` in `porter.yaml`