### PR TITLE
Fix workspace deletion when backup is enabled

### DIFF
--- a/.github/scripts/build.js
+++ b/.github/scripts/build.js
@@ -114,6 +114,15 @@ async function getCommandFromComment({ core, context, github }) {
           break;
         }
 
+      case "/test-backups":
+        {
+          const runTests = await handleTestCommand({ core, github }, parts, "backup tests", runId, { number: prNumber, authorUsername: prAuthorUsername, repoOwner, repoName, headSha: prHeadSha, refId: prRefId, details: pr }, { username: commentUsername, link: commentLink });
+          if (runTests) {
+            command = "run-tests-backups";
+          }
+          break;
+        }
+
       case "/test-force-approve":
         {
           command = "test-force-approve";
@@ -250,6 +259,7 @@ You can use the following commands:
 &nbsp;&nbsp;&nbsp;&nbsp;/test-extended - build, deploy and run smoke & extended tests on a PR
 &nbsp;&nbsp;&nbsp;&nbsp;/test-extended-aad - build, deploy and run smoke & extended AAD tests on a PR
 &nbsp;&nbsp;&nbsp;&nbsp;/test-shared-services - test the deployment of shared services on a PR build
+&nbsp;&nbsp;&nbsp;&nbsp;/test-backups - build, deploy and run backup tests on a PR
 &nbsp;&nbsp;&nbsp;&nbsp;/test-force-approve - force approval of the PR tests (i.e. skip the deployment checks)
 &nbsp;&nbsp;&nbsp;&nbsp;/test-destroy-env - delete the validation environment for a PR (e.g. to enable testing a deployment from a clean start after previous tests)
 &nbsp;&nbsp;&nbsp;&nbsp;/help - show this help`;

--- a/.github/scripts/build.test.js
+++ b/.github/scripts/build.test.js
@@ -438,6 +438,32 @@ describe('getCommandFromComment', () => {
         });
       });
 
+      describe(`for '/test-backups'`, () => {
+        test(`should set command to 'run-tests-backups'`, async () => {
+          const context = createCommentContext({
+            username: 'admin',
+            body: '/test-backups',
+          });
+          await getCommandFromComment({ core, context, github });
+          expect(outputFor(mockCoreSetOutput, 'command')).toBe('run-tests-backups');
+        });
+
+        test(`should add comment with run link`, async () => {
+          const context = createCommentContext({
+            username: 'admin',
+            body: '/test-backups',
+            pullRequestNumber: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+          });
+          await getCommandFromComment({ core, context, github });
+          expect(mockGithubRestIssuesCreateComment).toHaveComment({
+            owner: 'someOwner',
+            repo: 'someRepo',
+            issue_number: PR_NUMBER.UPSTREAM_NON_DOCS_CHANGES,
+            bodyMatcher: /Running backup tests: https:\/\/github.com\/someOwner\/someRepo\/actions\/runs\/11112222 \(with refid `291ae84f`\)/,
+          });
+        });
+      });
+
       describe(`for '/test-extended' for external PR (i.e. without commit SHA specified)`, () => {
         test(`should set command to 'none'`, async () => {
           const context = createCommentContext({

--- a/.github/workflows/pr_comment_bot.yml
+++ b/.github/workflows/pr_comment_bot.yml
@@ -158,7 +158,8 @@ jobs:
       needs.pr_comment.outputs.command == 'run-tests' ||
       needs.pr_comment.outputs.command == 'run-tests-extended' ||
       needs.pr_comment.outputs.command == 'run-tests-extended-aad' ||
-      needs.pr_comment.outputs.command == 'run-tests-shared-services'
+      needs.pr_comment.outputs.command == 'run-tests-shared-services' ||
+      needs.pr_comment.outputs.command == 'run-tests-backups'
     name: Deploy PR
     uses: ./.github/workflows/deploy_tre_reusable.yml
     permissions:
@@ -174,6 +175,7 @@ jobs:
         ${{ (needs.pr_comment.outputs.command == 'run-tests-extended' && 'extended') ||
         (needs.pr_comment.outputs.command == 'run-tests-extended-aad' && 'extended_aad') ||
         (needs.pr_comment.outputs.command == 'run-tests-shared-services' && 'shared_services') ||
+        (needs.pr_comment.outputs.command == 'run-tests-backups' && 'backups') ||
         (needs.pr_comment.outputs.command == 'run-tests' && '') }}
       environmentName: CICD
       E2E_TESTS_NUMBER_PROCESSES: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ ENHANCEMENTS:
 * Update the version of `super-linter` used in the `build_validation_develop` workflow to 8.7.0 ([#4957](https://github.com/microsoft/AzureTRE/issues/4957))
 
 BUG FIXES:
+* Fix workspace deletion and backup cleanup flows for the base workspace when backup is enabled by adding `delete_backups_on_uninstall`, running pre-teardown backup cleanup (`remove_backup.sh`), and removing deprecated Recovery Services Vault soft-delete configuration so deploy/delete paths work with Azure secure-by-default behavior ([#4962](https://github.com/microsoft/AzureTRE/issues/4962))
 * Fix Nexus shared service security: fetch admin password from Key Vault at runtime via managed identity (IMDS) instead of embedding it in the VM Run Command script content. Fix `deploy_nexus_container.sh` short-circuit path to fail loudly if the container does not start. (`sonatype-nexus` 3.10.0) ([#4983](https://github.com/microsoft/AzureTRE/pull/4983))
 * Fix UI TypeScript deprecation warning by updating `moduleResolution` to `bundler` in `tsconfig.json`. ([#4968](https://github.com/microsoft/AzureTRE/issues/4968))
 * Fix API timeout and name collision failures on workspace creation by checking storage account name availability and improved logging. ([#4946](https://github.com/microsoft/AzureTRE/pull/4946))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ ENHANCEMENTS:
 * Update the version of `super-linter` used in the `build_validation_develop` workflow to 8.7.0 ([#4957](https://github.com/microsoft/AzureTRE/issues/4957))
 
 BUG FIXES:
-* Fix workspace deletion and backup cleanup flows for the base workspace when backup is enabled by adding `delete_backups_on_uninstall`, running pre-teardown backup cleanup (`remove_backup.sh`), and removing deprecated Recovery Services Vault soft-delete configuration so deploy/delete paths work with Azure secure-by-default behavior ([#4962](https://github.com/microsoft/AzureTRE/issues/4962))
+* Fix workspace deletion when backup is enabled for the base, unrestricted and airlock-import-review workspaces by adding a `delete_backups_on_uninstall` flag and a pre-teardown backup cleanup (`remove_backup.sh`) that stops protection and either deletes or retains the Recovery Services Vault, so deletion works with Azure secure-by-default soft delete ([#4962](https://github.com/microsoft/AzureTRE/issues/4962))
 * Fix Nexus shared service security: fetch admin password from Key Vault at runtime via managed identity (IMDS) instead of embedding it in the VM Run Command script content. Fix `deploy_nexus_container.sh` short-circuit path to fail loudly if the container does not start. (`sonatype-nexus` 3.10.0) ([#4983](https://github.com/microsoft/AzureTRE/pull/4983))
 * Fix UI TypeScript deprecation warning by updating `moduleResolution` to `bundler` in `tsconfig.json`. ([#4968](https://github.com/microsoft/AzureTRE/issues/4968))
 * Fix API timeout and name collision failures on workspace creation by checking storage account name availability and improved logging. ([#4946](https://github.com/microsoft/AzureTRE/pull/4946))

--- a/Makefile
+++ b/Makefile
@@ -518,6 +518,14 @@ test-e2e-shared-services: ## 🧪 Run E2E shared service tests
 	$(call target_title, "Running E2E shared service tests") && \
 	$(MAKE) test-e2e-custom SELECTOR=shared_services
 
+# Description: Run E2E backup tests
+# # The E2E backup tests include:
+# # - tests marked with the `backups` selector that verify workspace backup functionality
+# Example: make test-e2e-backups
+test-e2e-backups: ## 🧪 Run E2E backup tests
+	$(call target_title, "Running E2E backup tests") && \
+	$(MAKE) test-e2e-custom SELECTOR=backups
+
 # Description: Run E2E tests with custom selector
 # Arguments: SELECTOR - the selector to run the tests with
 # Example: make test-e2e-custom SELECTOR=smoke

--- a/docs/tre-developers/github-pr-bot-commands.md
+++ b/docs/tre-developers/github-pr-bot-commands.md
@@ -48,6 +48,22 @@ You can use the full or short form of the SHA, but it must be at least 7 charact
 As with `/test`, this command works on PRs from forks, and makes the deployment secrets available.
 Before running tests on a PR, run the same checks on the PR code as for `/test`.
 
+### `/test-backups [<sha>]`
+
+This command runs the build, deploy, and backup tests for a PR.
+
+Use this command when a change has been made that could affect workspace backup functionality.
+
+For PRs from maintainers (i.e. users with write access to microsoft/AzureTRE), `/test-backups` is sufficient.
+
+For other PRs, the checks below should be carried out. Once satisfied that the PR is safe to run tests against, you should use `/test-backups <sha>` where `<sha>` is the SHA for the commit that you have verified.
+You can use the full or short form of the SHA, but it must be at least 7 characters (GitHub UI shows 7 characters).
+
+**IMPORTANT**
+
+As with `/test`, this command works on PRs from forks, and makes the deployment secrets available.
+Before running tests on a PR, run the same checks on the PR code as for `/test`.
+
 ### `/test-destroy-env`
 
 When running `/test` multiple times on a PR, the same TRE ID and environment are used by default. The `/test-destroy-env` command destroys a previously created validation environment, allowing you to re-run `/test` with a clean starting point.

--- a/docs/tre-templates/workspaces/base.md
+++ b/docs/tre-templates/workspaces/base.md
@@ -1,6 +1,6 @@
 # Azure TRE base workspace
 
-The base workspace template is the foundation that all other workspaces and workspace services are built upon. Alternative workspace architectures could be used. However, the templates provided in this repository rely on the specific architecture of this base workspace.
+The base workspace template is the foundation that all other workspaces and workspace services are built upon. Alternative workspace architectures could be used. However, the templates provided in this repository use the base workspace.
 
 The base workspace template contains the following resources:
 
@@ -33,8 +33,10 @@ When `enable_backup` is set (the default) the base workspace deploys a Recovery 
 
 Both flags are updateable, so the choice can be changed on an existing workspace before it is deleted.
 
+> **Note:** If [vault immutability](https://learn.microsoft.com/azure/backup/backup-azure-immutable-vault-concept) is enabled on the Recovery Services Vault (for example, enforced by an Azure Policy in your environment), backups cannot be deleted before they expire. In this case `delete_backups_on_uninstall = true` will not be able to remove the backups or vault, and workspace deletion may fail.
+
 ## Azure Trusted Services
-*Azure Trusted Services* are allowed to connect to both the key vault and storage account provisioned within the workspace. If this is undesirable additional resources without this setting configured can be deployed.
+*Azure Trusted Services* are allowed to connect to both the key vault and storage account provisioned within the workspace. If this is undesirable additional resources without this setting configured could be deployed by a custom workspace.
 
 Further details around which Azure services are allowed to connect can be found below:
 

--- a/docs/tre-templates/workspaces/base.md
+++ b/docs/tre-templates/workspaces/base.md
@@ -22,6 +22,17 @@ When deploying a workspace the following properties need to be configured.
 | `client_id` | Valid client ID of the Workspace App Registration. | The OpenID client ID which should be submitted to the OpenID service when necessary. This value is typically provided to you by the OpenID service when OpenID credentials are generated for your application. |
 | `client_secret` | Valid client secret. | |
 
+## Backup
+
+When `enable_backup` is set (the default) the base workspace deploys a Recovery Services Vault into the workspace resource group and protects the workspace's shared storage (and any VMs configured for backup).
+
+| `delete_backups_on_uninstall` | Behaviour on workspace deletion |
+| ----------------------------- | ------------------------------- |
+| `false` (default) | **Retain the backups.** Protection is stopped but the recovery points are kept. The vault, its backup resources and the workspace resource group are removed from the Terraform state, so the **resource group is retained and continues to hold the Recovery Services Vault and its recovery points** after the workspace is deleted. |
+| `true` | **Delete the backups.** Protection is stopped with data deletion, the backup containers are unregistered and the Recovery Services Vault (with its recovery points) is deleted. Terraform then destroys the rest of the workspace, including its resource group, leaving nothing behind. |
+
+Both flags are updateable, so the choice can be changed on an existing workspace before it is deleted.
+
 ## Azure Trusted Services
 *Azure Trusted Services* are allowed to connect to both the key vault and storage account provisioned within the workspace. If this is undesirable additional resources without this setting configured can be deployed.
 

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -4,6 +4,7 @@ markers =
     extended: marks tests as extended (run less frequently, relatively slow)
     extended_aad
     shared_services
+    backups: only backup related
     performance: marks tests for performance evaluation
     timeout: used to set test timeout with pytest-timeout
     airlock: only airlock related

--- a/e2e_tests/test_backups.py
+++ b/e2e_tests/test_backups.py
@@ -34,16 +34,18 @@ async def test_create_base_workspace_with_backup_setting(enable_backup, expected
     workspace_id = ""
 
     try:
+        properties = {
+            "display_name": f"E2E Backup Workspace {uuid.uuid4().hex[:8]}",
+            "description": "Base workspace for backup E2E tests",
+            "auth_type": "Automatic",
+            "address_space_size": "small",
+            "enable_backup": enable_backup,
+        }
+        if enable_backup:
+            properties["delete_backups_on_uninstall"] = True
         payload = {
             "templateName": strings.BASE_WORKSPACE,
-            "properties": {
-                "display_name": f"E2E Backup Workspace {uuid.uuid4().hex[:8]}",
-                "description": "Base workspace for backup E2E tests",
-                "auth_type": "Automatic",
-                "address_space_size": "small",
-                "enable_backup": enable_backup,
-                "delete_backups_on_uninstall": True,
-            },
+            "properties": properties,
         }
 
         workspace_path, workspace_id = await post_resource(

--- a/e2e_tests/test_backups.py
+++ b/e2e_tests/test_backups.py
@@ -1,0 +1,77 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from starlette import status
+
+from e2e_tests.conftest import clean_up_test_workspace
+from e2e_tests.helpers import assert_status, get_admin_token, get_auth_header, get_template
+from e2e_tests.resources import strings
+from e2e_tests.resources.resource import post_resource
+from e2e_tests.resources.workspace import get_workspace
+
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.mark.backups
+@pytest.mark.parametrize(
+    "enable_backup, expected_backup_outputs",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+async def test_create_base_workspace_with_backup_setting(enable_backup, expected_backup_outputs, verify) -> None:
+    admin_token = await get_admin_token(verify=verify)
+
+    async with get_template(strings.BASE_WORKSPACE, strings.API_WORKSPACE_TEMPLATES, admin_token, verify) as response:
+        assert_status(response, [status.HTTP_200_OK], f"Failed to GET template: {strings.BASE_WORKSPACE}")
+        template_properties = response.json().get("properties", {})
+        assert "enable_backup" in template_properties
+
+    workspace_path = ""
+    workspace_id = ""
+
+    try:
+        payload = {
+            "templateName": strings.BASE_WORKSPACE,
+            "properties": {
+                "display_name": f"E2E Backup Workspace {uuid.uuid4().hex[:8]}",
+                "description": "Base workspace for backup E2E tests",
+                "auth_type": "Automatic",
+                "address_space_size": "small",
+                "enable_backup": enable_backup,
+                "delete_backups_on_uninstall": True,
+            },
+        }
+
+        workspace_path, workspace_id = await post_resource(
+            payload,
+            strings.API_WORKSPACES,
+            access_token=admin_token,
+            verify=verify,
+        )
+
+        async with AsyncClient(verify=verify) as client:
+            workspace = await get_workspace(client, workspace_id, get_auth_header(admin_token))
+
+        assert workspace["deploymentStatus"] == strings.RESOURCE_STATUS_DEPLOYED
+
+        properties = workspace.get("properties", {})
+        backup_output_properties = [
+            "backup_vault_name",
+            "vm_backup_policy_id",
+            "fileshare_backup_policy_id",
+        ]
+
+        for prop in backup_output_properties:
+            value = properties.get(prop)
+            if expected_backup_outputs:
+                assert value, f"Expected non-empty workspace property '{prop}' when backup is enabled"
+            else:
+                assert not value, f"Expected empty workspace property '{prop}' when backup is disabled"
+
+    finally:
+        if workspace_path:
+            await clean_up_test_workspace(pre_created_workspace_id="", workspace_path=workspace_path, verify=verify)

--- a/templates/workspaces/airlock-import-review/porter.yaml
+++ b/templates/workspaces/airlock-import-review/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-airlock-import-review
-version: 0.15.0
+version: 0.16.0
 description: "A workspace to do Airlock Data Import Reviews for Azure TRE"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -123,6 +123,10 @@ parameters:
     type: boolean
     default: true
     description: "Enable backups for the workspace, including VMs and shared storage."
+  - name: delete_backups_on_uninstall
+    type: boolean
+    default: false
+    description: "When deleting the workspace, also delete the backups (Recovery Services Vault and its recovery points). When false the vault and its resource group are retained so the backed up data is kept."
   - name: enable_cmk_encryption
     type: boolean
     default: false
@@ -313,6 +317,20 @@ upgrade:
         register-aad-application: "${ bundle.parameters.register_aad_application }"
 
 uninstall:
+  - exec:
+      description: "Handle backup resources before tearing down the workspace"
+      command: ./remove_backup.sh
+      arguments:
+        - ${ bundle.parameters.tfstate_resource_group_name }
+        - ${ bundle.parameters.tfstate_storage_account_name }
+        - ${ bundle.parameters.tfstate_container_name }
+        - ${ bundle.parameters.tre_id }
+        - ${ bundle.parameters.id }
+        - ${ bundle.parameters.enable_backup }
+        - ${ bundle.parameters.delete_backups_on_uninstall }
+      envs:
+        ARM_USE_AZUREAD: "true"
+        ARM_USE_OIDC: "true"
   - terraform:
       description: "Tear down workspace"
       vars:

--- a/templates/workspaces/airlock-import-review/template_schema.json
+++ b/templates/workspaces/airlock-import-review/template_schema.json
@@ -64,6 +64,29 @@
     {
       "if": {
         "properties": {
+          "enable_backup": {
+            "const": true
+          }
+        },
+        "required": [
+          "enable_backup"
+        ]
+      },
+      "then": {
+        "properties": {
+          "delete_backups_on_uninstall": {
+            "type": "boolean",
+            "title": "Delete Backups on Deletion",
+            "description": "When the workspace is deleted, also delete its backups: the backup containers are unregistered and the Recovery Services Vault (with its recovery points) is deleted. When unchecked, protection is stopped but the vault and its resource group are retained so the backed up data is kept.",
+            "default": false,
+            "updateable": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
           "address_space_size": {
             "enum": [
               "custom"
@@ -180,6 +203,7 @@
       "overview",
       "app_service_plan_sku",
       "enable_backup",
+      "delete_backups_on_uninstall",
       "address_space_size",
       "address_spaces",
       "auth_type",

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 2.8.4
+version: 2.10.0
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -141,6 +141,10 @@ parameters:
     type: boolean
     default: true
     description: "Enable backups for the workspace, including the vm's & shared storage."
+  - name: delete_backups_on_uninstall
+    type: boolean
+    default: false
+    description: "When deleting the workspace, also delete the backups (Recovery Services Vault and its recovery points). When false the vault and its resource group are retained so the backed up data is kept."
   - name: enable_dns_policy
     type: boolean
     default: false
@@ -377,6 +381,21 @@ upgrade:
         register-aad-application: "${ bundle.parameters.register_aad_application }"
 
 uninstall:
+  - exec:
+      description: "Handle backup resources before tearing down the workspace"
+      command: ./remove_backup.sh
+      arguments:
+        - ${ bundle.parameters.tfstate_resource_group_name }
+        - ${ bundle.parameters.tfstate_storage_account_name }
+        - ${ bundle.parameters.tfstate_container_name }
+        - ${ bundle.parameters.tre_id }
+        - ${ bundle.parameters.id }
+        - ${ bundle.parameters.enable_backup }
+        - ${ bundle.parameters.delete_backups_on_uninstall }
+        - ${ bundle.parameters.workspace_subscription_id }
+      envs:
+        ARM_USE_AZUREAD: "true"
+        ARM_USE_OIDC: "true"
   - terraform:
       description: "Tear down workspace"
       vars:

--- a/templates/workspaces/base/remove_backup.sh
+++ b/templates/workspaces/base/remove_backup.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# Uncomment this line to see each command for debugging (careful: this will show secrets!)
+# set -o xtrace
+
+# Runs during workspace 'uninstall', before Terraform destroys the workspace. Azure
+# secure-by-default keeps soft delete enabled on Recovery Services Vaults, so Terraform
+# cannot tear down a vault that still has (soft-)protected items.
+#   delete_backups_on_uninstall=true  - stop protection with data deletion, unregister
+#       the backup containers and delete the vault, then let Terraform destroy the
+#       workspace (including its resource group).
+#   delete_backups_on_uninstall=false - stop protection but keep the recovery points,
+#       then remove the vault, its resource group and the backup resources from the
+#       Terraform state so they are retained.
+
+MGMT_RESOURCE_GROUP_NAME=$1
+MGMT_STORAGE_ACCOUNT_NAME=$2
+TF_STATE_CONTAINER_NAME=$3
+TRE_ID=$4
+WORKSPACE_ID=$5
+ENABLE_BACKUP=$6
+DELETE_BACKUPS=$7
+WORKSPACE_SUBSCRIPTION_ID=${8:-}
+
+ENABLE_BACKUP=$(echo "${ENABLE_BACKUP}" | tr '[:upper:]' '[:lower:]')
+DELETE_BACKUPS=$(echo "${DELETE_BACKUPS}" | tr '[:upper:]' '[:lower:]')
+
+if [ "${ENABLE_BACKUP}" != "true" ]; then
+  echo "Backup is not enabled for this workspace - nothing to do."
+  exit 0
+fi
+
+short_workspace_id="${WORKSPACE_ID: -4}"
+vault_name="arsv-${TRE_ID}-ws-${short_workspace_id}"
+# The vault lives in the workspace resource group.
+vault_resource_group="rg-${TRE_ID}-ws-${short_workspace_id}"
+
+echo "Authenticating using the managed identity..."
+az login --identity --output none
+# When the workspace is not deployed to a dedicated subscription it lives in the same
+# subscription as the rest of the TRE (ARM_SUBSCRIPTION_ID). Select the subscription
+# explicitly so the vault lookup below does not run against the managed identity's
+# arbitrary default subscription.
+target_subscription_id="${WORKSPACE_SUBSCRIPTION_ID:-${ARM_SUBSCRIPTION_ID:-}}"
+if [ -n "${target_subscription_id}" ]; then
+  az account set --subscription "${target_subscription_id}"
+fi
+
+# If the vault no longer exists there is nothing to clean up. Only a genuine
+# 'not found' response is treated as "nothing to do" - any other error (for example
+# a permissions or throttling problem) must fail the script so we do not silently skip
+# the cleanup and leave the workspace stuck in a 'Deleting' state.
+if vault_show_error="$(az backup vault show --name "${vault_name}" --resource-group "${vault_resource_group}" --output none 2>&1)"; then
+  echo "Recovery Services Vault ${vault_name} found in resource group ${vault_resource_group}."
+elif echo "${vault_show_error}" | grep -qiE "ResourceNotFound|ResourceGroupNotFound|was not found|could not be found|does not exist"; then
+  echo "Recovery Services Vault ${vault_name} was not found - nothing to do."
+  exit 0
+else
+  echo "Error querying Recovery Services Vault ${vault_name}: ${vault_show_error}" >&2
+  exit 1
+fi
+
+if [ "${DELETE_BACKUPS}" == "true" ]; then
+  delete_backup_data="true"
+  echo "delete_backups_on_uninstall is enabled - protection will be stopped, backups deleted and the vault removed."
+else
+  delete_backup_data="false"
+  echo "delete_backups_on_uninstall is disabled - protection will be stopped but the recovery points and vault retained."
+fi
+
+backup_management_types=(AzureStorage AzureIaasVM)
+
+stop_protection() {
+  local bmt=$1 items attempt
+  if ! items=$(az backup item list --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+    --backup-management-type "${bmt}" --query "[].[properties.containerName, name, properties.protectionState]" --output tsv); then
+    echo "Error: failed to list ${bmt} backup items in vault ${vault_name}. Aborting so the uninstall can be retried." >&2
+    exit 1
+  fi
+  [ -z "${items}" ] && return 0
+  while IFS=$'\t' read -r container_name item_name protection_state; do
+    [ -z "${item_name}" ] && continue
+    # Already stopped - keep the script idempotent across the second pass and re-runs.
+    [ "${protection_state}" == "ProtectionStopped" ] && continue
+    for attempt in $(seq 1 5); do
+      echo "Disabling protection for '${item_name}' (delete-backup-data=${delete_backup_data}, attempt ${attempt})..."
+      if az backup protection disable --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+        --backup-management-type "${bmt}" --container-name "${container_name}" --item-name "${item_name}" \
+        --delete-backup-data "${delete_backup_data}" --yes --output none; then
+        break
+      fi
+      if [ "${attempt}" -eq 5 ]; then
+        echo "Error: could not disable protection for '${item_name}' after ${attempt} attempts. Aborting so the uninstall can be retried." >&2
+        exit 1
+      fi
+      sleep 15
+    done
+  done <<< "${items}"
+}
+
+for bmt in "${backup_management_types[@]}"; do
+  stop_protection "${bmt}"
+done
+
+# Remove any Azure Backup lock on the workspace storage account. Only locks scoped
+# directly to the account are removed; the scope match is case-insensitive because
+# Azure lower-cases segments of the lock id.
+subscription_id=$(az account show --query "id" --output tsv)
+storage_account_id="/subscriptions/${subscription_id}/resourceGroups/${vault_resource_group}/providers/Microsoft.Storage/storageAccounts/stgws${short_workspace_id}"
+storage_account_id_lower=$(echo "${storage_account_id}" | tr '[:upper:]' '[:lower:]')
+if ! lock_ids=$(az lock list --resource "${storage_account_id}" --query "[].id" --output tsv); then
+  echo "Error: failed to list resource locks on the workspace storage account. Aborting so the uninstall can be retried." >&2
+  exit 1
+fi
+while IFS= read -r lock_id; do
+  [ -z "${lock_id}" ] && continue
+  case "$(echo "${lock_id}" | tr '[:upper:]' '[:lower:]')" in
+    "${storage_account_id_lower}/"*)
+      echo "Deleting resource lock ${lock_id}..."
+      az lock delete --ids "${lock_id}" --output none || echo "Warning: could not delete lock ${lock_id}."
+      ;;
+  esac
+done <<< "${lock_ids}"
+
+for bmt in "${backup_management_types[@]}"; do
+  stop_protection "${bmt}"
+done
+
+pushd terraform > /dev/null
+
+terraform init -input=false -backend=true -reconfigure \
+  -backend-config="resource_group_name=${MGMT_RESOURCE_GROUP_NAME}" \
+  -backend-config="storage_account_name=${MGMT_STORAGE_ACCOUNT_NAME}" \
+  -backend-config="container_name=${TF_STATE_CONTAINER_NAME}" \
+  -backend-config="key=${TRE_ID}-ws-${WORKSPACE_ID}"
+
+backup_resources=(
+  "azurerm_backup_protected_file_share.file_share[0]"
+  "azurerm_backup_container_storage_account.storage_account[0]"
+  "module.backup[0].azurerm_backup_policy_file_share.file_share_policy"
+  "module.backup[0].azurerm_backup_policy_vm.vm_policy"
+  "module.backup[0].azurerm_recovery_services_vault.vault"
+)
+
+remove_from_state() {
+  local state resource
+  state="$(terraform state list)"
+  for resource in "$@"; do
+    if echo "${state}" | grep -qxF "${resource}"; then
+      echo "Removing ${resource} from the Terraform state..."
+      terraform state rm "${resource}"
+    fi
+  done
+}
+
+if [ "${DELETE_BACKUPS}" == "true" ]; then
+  # Unregister the backup containers and delete the vault (retried because the
+  # unregister can briefly return CloudInternalError), then let Terraform destroy the
+  # rest of the workspace including its resource group.
+  vault_url="https://management.azure.com/subscriptions/${subscription_id}/resourceGroups/${vault_resource_group}/providers/Microsoft.RecoveryServices/vaults/${vault_name}?api-version=2025-08-01"
+  for _ in $(seq 1 20); do
+    for bmt in "${backup_management_types[@]}"; do
+      for container in $(az backup container list --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+        --backup-management-type "${bmt}" --query "[?properties.registrationStatus=='Registered'].name" --output tsv 2>/dev/null || true); do
+        echo "Unregistering backup container '${container}'..."
+        az backup container unregister --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+          --backup-management-type "${bmt}" --container-name "${container}" --yes --output none 2>/dev/null || true
+      done
+    done
+    az rest --method delete --url "${vault_url}" --output none 2>/dev/null || true
+    if ! az backup vault show --name "${vault_name}" --resource-group "${vault_resource_group}" --output none 2>/dev/null; then
+      echo "Recovery Services Vault ${vault_name} deleted."
+      break
+    fi
+    sleep 15
+  done
+  if az backup vault show --name "${vault_name}" --resource-group "${vault_resource_group}" --output none 2>/dev/null; then
+    echo "Error: Recovery Services Vault ${vault_name} could not be deleted." >&2
+    exit 1
+  fi
+  remove_from_state "${backup_resources[@]}"
+  popd > /dev/null
+  echo "Vault deleted. Terraform will destroy the remaining workspace resources, including the resource group."
+else
+  remove_from_state "${backup_resources[@]}" "azurerm_resource_group.ws"
+  popd > /dev/null
+  echo "Backup resources retained. Terraform will delete the other workspace resources and leave the vault and its resource group in place."
+fi

--- a/templates/workspaces/base/remove_backup.sh
+++ b/templates/workspaces/base/remove_backup.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# Uncomment this line to see each command for debugging (careful: this will show secrets!)
+# set -o xtrace
+
+# Runs during workspace 'uninstall', before Terraform destroys the workspace. Azure
+# secure-by-default keeps soft delete enabled on Recovery Services Vaults, so Terraform
+# cannot tear down a vault that still has (soft-)protected items.
+#   delete_backups_on_uninstall=true  - stop protection with data deletion, unregister
+#       the backup containers and delete the vault, then let Terraform destroy the
+#       workspace (including its resource group).
+#   delete_backups_on_uninstall=false - stop protection but keep the recovery points,
+#       then remove the vault, its resource group and the backup resources from the
+#       Terraform state so they are retained.
+
+MGMT_RESOURCE_GROUP_NAME=$1
+MGMT_STORAGE_ACCOUNT_NAME=$2
+TF_STATE_CONTAINER_NAME=$3
+TRE_ID=$4
+WORKSPACE_ID=$5
+ENABLE_BACKUP=$6
+DELETE_BACKUPS=$7
+WORKSPACE_SUBSCRIPTION_ID=${8:-}
+
+ENABLE_BACKUP=$(echo "${ENABLE_BACKUP}" | tr '[:upper:]' '[:lower:]')
+DELETE_BACKUPS=$(echo "${DELETE_BACKUPS}" | tr '[:upper:]' '[:lower:]')
+
+if [ "${ENABLE_BACKUP}" != "true" ]; then
+  echo "Backup is not enabled for this workspace - nothing to do."
+  exit 0
+fi
+
+short_workspace_id="${WORKSPACE_ID: -4}"
+vault_name="arsv-${TRE_ID}-ws-${short_workspace_id}"
+# The vault lives in the workspace resource group.
+vault_resource_group="rg-${TRE_ID}-ws-${short_workspace_id}"
+
+echo "Authenticating using the managed identity..."
+az login --identity --output none
+# When the workspace is not deployed to a dedicated subscription it lives in the same
+# subscription as the rest of the TRE (ARM_SUBSCRIPTION_ID). Select the subscription
+# explicitly so the vault lookup below does not run against the managed identity's
+# arbitrary default subscription.
+target_subscription_id="${WORKSPACE_SUBSCRIPTION_ID:-${ARM_SUBSCRIPTION_ID:-}}"
+if [ -n "${target_subscription_id}" ]; then
+  az account set --subscription "${target_subscription_id}"
+fi
+
+# If the vault no longer exists there is nothing to clean up. Only a genuine
+# 'not found' response is treated as "nothing to do" - any other error (for example
+# a permissions or throttling problem) must fail the script so we do not silently skip
+# the cleanup and leave the workspace stuck in a 'Deleting' state.
+if vault_show_error="$(az backup vault show --name "${vault_name}" --resource-group "${vault_resource_group}" --output none 2>&1)"; then
+  echo "Recovery Services Vault ${vault_name} found in resource group ${vault_resource_group}."
+elif echo "${vault_show_error}" | grep -qiE "ResourceNotFound|ResourceGroupNotFound|was not found|could not be found|does not exist"; then
+  echo "Recovery Services Vault ${vault_name} was not found - nothing to do."
+  exit 0
+else
+  echo "Error querying Recovery Services Vault ${vault_name}: ${vault_show_error}" >&2
+  exit 1
+fi
+
+if [ "${DELETE_BACKUPS}" == "true" ]; then
+  delete_backup_data="true"
+  echo "delete_backups_on_uninstall is enabled - protection will be stopped, backups deleted and the vault removed."
+else
+  delete_backup_data="false"
+  echo "delete_backups_on_uninstall is disabled - protection will be stopped but the recovery points and vault retained."
+fi
+
+backup_management_types=(AzureStorage AzureIaasVM)
+
+stop_protection() {
+  local bmt=$1 items
+  if ! items=$(az backup item list --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+    --backup-management-type "${bmt}" --query "[].[properties.containerName, name]" --output tsv); then
+    echo "Error: failed to list ${bmt} backup items in vault ${vault_name}. Aborting so the uninstall can be retried." >&2
+    exit 1
+  fi
+  [ -z "${items}" ] && return 0
+  while IFS=$'\t' read -r container_name item_name; do
+    [ -z "${item_name}" ] && continue
+    echo "Disabling protection for '${item_name}' (delete-backup-data=${delete_backup_data})..."
+    az backup protection disable --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+      --backup-management-type "${bmt}" --container-name "${container_name}" --item-name "${item_name}" \
+      --delete-backup-data "${delete_backup_data}" --yes --output none || echo "Warning: could not disable protection for '${item_name}'."
+  done <<< "${items}"
+}
+
+for bmt in "${backup_management_types[@]}"; do
+  stop_protection "${bmt}"
+done
+
+# Remove any Azure Backup lock on the workspace storage account. Only locks scoped
+# directly to the account are removed; the scope match is case-insensitive because
+# Azure lower-cases segments of the lock id.
+subscription_id=$(az account show --query "id" --output tsv)
+storage_account_id="/subscriptions/${subscription_id}/resourceGroups/${vault_resource_group}/providers/Microsoft.Storage/storageAccounts/stgws${short_workspace_id}"
+storage_account_id_lower=$(echo "${storage_account_id}" | tr '[:upper:]' '[:lower:]')
+if ! lock_ids=$(az lock list --resource "${storage_account_id}" --query "[].id" --output tsv); then
+  echo "Error: failed to list resource locks on the workspace storage account. Aborting so the uninstall can be retried." >&2
+  exit 1
+fi
+while IFS= read -r lock_id; do
+  [ -z "${lock_id}" ] && continue
+  case "$(echo "${lock_id}" | tr '[:upper:]' '[:lower:]')" in
+    "${storage_account_id_lower}/"*)
+      echo "Deleting resource lock ${lock_id}..."
+      az lock delete --ids "${lock_id}" --output none || echo "Warning: could not delete lock ${lock_id}."
+      ;;
+  esac
+done <<< "${lock_ids}"
+
+for bmt in "${backup_management_types[@]}"; do
+  stop_protection "${bmt}"
+done
+
+pushd terraform > /dev/null
+
+terraform init -input=false -backend=true -reconfigure \
+  -backend-config="resource_group_name=${MGMT_RESOURCE_GROUP_NAME}" \
+  -backend-config="storage_account_name=${MGMT_STORAGE_ACCOUNT_NAME}" \
+  -backend-config="container_name=${TF_STATE_CONTAINER_NAME}" \
+  -backend-config="key=${TRE_ID}-ws-${WORKSPACE_ID}"
+
+backup_resources=(
+  "azurerm_backup_protected_file_share.file_share[0]"
+  "azurerm_backup_container_storage_account.storage_account[0]"
+  "module.backup[0].azurerm_backup_policy_file_share.file_share_policy"
+  "module.backup[0].azurerm_backup_policy_vm.vm_policy"
+  "module.backup[0].azurerm_recovery_services_vault.vault"
+)
+
+remove_from_state() {
+  local state resource
+  state="$(terraform state list)"
+  for resource in "$@"; do
+    if echo "${state}" | grep -qxF "${resource}"; then
+      echo "Removing ${resource} from the Terraform state..."
+      terraform state rm "${resource}"
+    fi
+  done
+}
+
+if [ "${DELETE_BACKUPS}" == "true" ]; then
+  # Unregister the backup containers and delete the vault (retried because the
+  # unregister can briefly return CloudInternalError), then let Terraform destroy the
+  # rest of the workspace including its resource group.
+  vault_url="https://management.azure.com/subscriptions/${subscription_id}/resourceGroups/${vault_resource_group}/providers/Microsoft.RecoveryServices/vaults/${vault_name}?api-version=2025-08-01"
+  for _ in $(seq 1 20); do
+    for bmt in "${backup_management_types[@]}"; do
+      for container in $(az backup container list --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+        --backup-management-type "${bmt}" --query "[?properties.registrationStatus=='Registered'].name" --output tsv 2>/dev/null || true); do
+        echo "Unregistering backup container '${container}'..."
+        az backup container unregister --vault-name "${vault_name}" --resource-group "${vault_resource_group}" \
+          --backup-management-type "${bmt}" --container-name "${container}" --yes --output none 2>/dev/null || true
+      done
+    done
+    az rest --method delete --url "${vault_url}" --output none 2>/dev/null || true
+    if ! az backup vault show --name "${vault_name}" --resource-group "${vault_resource_group}" --output none 2>/dev/null; then
+      echo "Recovery Services Vault ${vault_name} deleted."
+      break
+    fi
+    sleep 15
+  done
+  if az backup vault show --name "${vault_name}" --resource-group "${vault_resource_group}" --output none 2>/dev/null; then
+    echo "Error: Recovery Services Vault ${vault_name} could not be deleted." >&2
+    exit 1
+  fi
+  remove_from_state "${backup_resources[@]}"
+  popd > /dev/null
+  echo "Vault deleted. Terraform will destroy the remaining workspace resources, including the resource group."
+else
+  remove_from_state "${backup_resources[@]}" "azurerm_resource_group.ws"
+  popd > /dev/null
+  echo "Backup resources retained. Terraform will delete the other workspace resources and leave the vault and its resource group in place."
+fi

--- a/templates/workspaces/base/template_schema.json
+++ b/templates/workspaces/base/template_schema.json
@@ -101,6 +101,29 @@
     {
       "if": {
         "properties": {
+          "enable_backup": {
+            "const": true
+          }
+        },
+        "required": [
+          "enable_backup"
+        ]
+      },
+      "then": {
+        "properties": {
+          "delete_backups_on_uninstall": {
+            "type": "boolean",
+            "title": "Delete Backups on Deletion",
+            "description": "When the workspace is deleted, also delete its backups: the backup containers are unregistered and the Recovery Services Vault (with its recovery points) is deleted. When unchecked, protection is stopped but the vault and its resource group are retained so the backed up data is kept.",
+            "default": false,
+            "updateable": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
           "enable_airlock": {
             "const": true
           }
@@ -351,6 +374,7 @@
       "client_id",
       "client_secret",
       "enable_backup",
+      "delete_backups_on_uninstall",
       "enable_airlock",
       "configure_review_vms",
       "airlock_review_config",

--- a/templates/workspaces/unrestricted/porter.yaml
+++ b/templates/workspaces/unrestricted/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-unrestricted
-version: 0.13.7
+version: 0.14.0
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -125,7 +125,7 @@ parameters:
   - name: aad_redirect_uris
     type: string
     description: "List of redirect URIs in {name:value} format"
-    default: "W10="  # b64 for []
+    default: "W10=" # b64 for []
   - name: app_service_plan_sku
     type: string
     description: "The SKU used when deploying an Azure App Service Plan"
@@ -137,6 +137,10 @@ parameters:
     type: boolean
     default: true
     description: "Enable backups for the workspace, including the vm's & shared storage."
+  - name: delete_backups_on_uninstall
+    type: boolean
+    default: false
+    description: "When deleting the workspace, also delete the backups (Recovery Services Vault and its recovery points). When false the vault and its resource group are retained so the backed up data is kept."
   - name: enable_dns_policy
     type: boolean
     default: false
@@ -367,6 +371,21 @@ upgrade:
         register-aad-application: "${ bundle.parameters.register_aad_application }"
 
 uninstall:
+  - exec:
+      description: "Handle backup resources before tearing down the workspace"
+      command: ./remove_backup.sh
+      arguments:
+        - ${ bundle.parameters.tfstate_resource_group_name }
+        - ${ bundle.parameters.tfstate_storage_account_name }
+        - ${ bundle.parameters.tfstate_container_name }
+        - ${ bundle.parameters.tre_id }
+        - ${ bundle.parameters.id }
+        - ${ bundle.parameters.enable_backup }
+        - ${ bundle.parameters.delete_backups_on_uninstall }
+        - ${ bundle.parameters.workspace_subscription_id }
+      envs:
+        ARM_USE_AZUREAD: "true"
+        ARM_USE_OIDC: "true"
   - terraform:
       description: "Tear down workspace"
       vars:

--- a/templates/workspaces/unrestricted/template_schema.json
+++ b/templates/workspaces/unrestricted/template_schema.json
@@ -86,6 +86,29 @@
     {
       "if": {
         "properties": {
+          "enable_backup": {
+            "const": true
+          }
+        },
+        "required": [
+          "enable_backup"
+        ]
+      },
+      "then": {
+        "properties": {
+          "delete_backups_on_uninstall": {
+            "type": "boolean",
+            "title": "Delete Backups on Deletion",
+            "description": "When the workspace is deleted, also delete its backups: the backup containers are unregistered and the Recovery Services Vault (with its recovery points) is deleted. When unchecked, protection is stopped but the vault and its resource group are retained so the backed up data is kept.",
+            "default": false,
+            "updateable": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
           "address_space_size": {
             "enum": [
               "custom"
@@ -233,6 +256,7 @@
       "client_id",
       "client_secret",
       "enable_backup",
+      "delete_backups_on_uninstall",
       "*"
     ]
   },


### PR DESCRIPTION


## What is being addressed



Workspace deletion fails when backup is enabled due to the inability to disable Recovery Services Vault soft delete. The deletion process hangs, leaving the workspace in a **Deleting** state.



## How is this addressed



- Introduced a `delete_backups_on_uninstall` flag to manage backup deletion behavior during workspace uninstallation.

- Updated the `remove_backup.sh` script to handle backup resource cleanup based on the new flag.

- Ensured that the soft delete feature remains enabled, as Azure does not allow disabling it.

- Enhanced documentation to clarify the behavior of the new flag and its implications.

- Updated the CHANGELOG and incremented the template version to reflect these changes.

