### PR TITLE
chore: update andstor/file-existence-action to v3.1.0

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: "Check pytest failure file existence"
         id: check_api_test_result
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "test-results/pytest_api_unit_failed"
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: "Check maven failure file existence"
         id: check_maven_test_result
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "test-results/guacamole_package_failed"
 
@@ -234,7 +234,7 @@ jobs:
 
       - name: "Check pytest failure file existence"
         id: check_airlock_processor_test_result
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: "test-results/pytest_airlock_processor_unit_failed"
 


### PR DESCRIPTION
# Resolves #4941

## What is being addressed

The GitHub Actions workflow currently uses an older pinned version of `andstor/file-existence-action`, which relies on the deprecated Node.js 20 runtime. This updates the action to the `v3.1.0` release.

## How is this addressed

- Updated all occurrences of `andstor/file-existence-action` in `.github/workflows/build_docker_images.yml` to the pinned commit for `v3.1.0`.
- Preserved the repository's practice of pinning GitHub Actions to commit SHAs.
- No documentation updates were required.
- No CHANGELOG or template version updates were necessary.