### PR TITLE
Delete Databricks workspaces before TRE resource group cleanup

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -185,6 +185,26 @@ function purge_container_repositories() {
   done
 }
 
+function delete_databricks_workspaces() {
+  local rg=$1
+
+  local workspaces
+  workspaces=$(az databricks workspace list --resource-group "$rg" --query [].name --output tsv)
+
+  local workspace
+  for workspace in $workspaces; do
+    echo "Deleting Databricks workspace ${workspace} in resource group ${rg}"
+    az databricks workspace delete --resource-group "$rg" --name "$workspace" --yes
+  done
+}
+
+# Databricks creates managed resource groups with deny assignments. Delete the
+# owning workspaces first so those deny assignments are removed before group deletion.
+echo "${matching_resource_groups}" |
+while read -r rg_item; do
+  delete_databricks_workspaces "$rg_item"
+done
+
 # this will find the mgmt, core resource groups as well as any workspace ones
 # we are reverse-sorting to first delete the workspace groups (might not be
 # good enough because we use no-wait sometimes)


### PR DESCRIPTION
`make tre-destroy` can fail when a TRE includes Azure Databricks because `destroy_env_no_terraform.sh` deletes prefix-matched resource groups directly with `az group delete`. Databricks managed resource groups are protected by a Databricks system deny assignment, so deleting those groups before the owning `Microsoft.Databricks/workspaces` resource is removed can return `DenyAssignmentAuthorizationFailed`.

This updates `devops/scripts/destroy_env_no_terraform.sh` to enumerate Databricks workspaces in each matched TRE resource group with `az databricks workspace list` and delete them with `az databricks workspace delete --yes` before the existing resource-group deletion loop runs. Workspace deletion stays synchronous even when the script is invoked with `--no-wait`, so the deny assignment is removed before managed resource group cleanup is attempted.

Existing lock removal, ACR repository purge, and resource group deletion behavior are otherwise unchanged.

Fixes #4776

`ruff check devops/scripts/destroy_env_no_terraform.sh` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
