### PR TITLE
Delete Databricks workspaces before TRE resource groups

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -185,6 +185,26 @@ function purge_container_repositories() {
   done
 }
 
+function delete_databricks_workspaces() {
+  local rg=$1
+
+  local workspaces
+  workspaces=$(az databricks workspace list --resource-group "$rg" --query [].name --output tsv)
+
+  local workspace
+  for workspace in $workspaces; do
+    echo "Deleting Databricks workspace ${workspace} in resource group ${rg}"
+    az databricks workspace delete --resource-group "$rg" --name "$workspace" --yes
+  done
+}
+
+# Databricks creates managed resource groups with deny assignments that are
+# removed only when the owning workspace is deleted.
+echo "${matching_resource_groups}" |
+while read -r rg_item; do
+  delete_databricks_workspaces "$rg_item"
+done
+
 # this will find the mgmt, core resource groups as well as any workspace ones
 # we are reverse-sorting to first delete the workspace groups (might not be
 # good enough because we use no-wait sometimes)


### PR DESCRIPTION
Issue #4680 reports that Airlock VMs are available to create in the base workspace.

`make tre-destroy` sources `devops/scripts/destroy_env_no_terraform.sh`, which deletes every resource group whose name starts with the core TRE resource group prefix. Databricks workspace services create a separate managed resource group protected by a system deny assignment owned by the Databricks workspace. Deleting that managed resource group directly fails until the owning `Microsoft.Databricks/workspaces` resource in the workspace resource group is deleted first, because only workspace deletion removes the deny assignment.

This updates `devops/scripts/destroy_env_no_terraform.sh` to resolve the matching TRE resource groups once, then delete any Databricks workspaces found in those groups with `az databricks workspace list/delete` before the existing resource group deletion loop. The existing reverse-sorted resource group deletion behavior remains in place after this pre-cleanup, so Databricks-managed resource group deny assignments have been removed before `az group delete` runs.

`ruff check devops/scripts/destroy_env_no_terraform.sh` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
