### PR TITLE
Update README for unmaintained MKDocs v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Azure TRE documentation site**: <https://microsoft.github.io/AzureTRE/>
 
+Note: when building the documentation site, pin MkDocs to `mkdocs<2.0.0` until the project has moved to a supported alternative.
+
 ## Background
 <img alt="Azure TRE logo" align="right" src="./docs/assets/azure-tre-logo.svg" width="33%" />
 


### PR DESCRIPTION
Addresses #5006.

Evidence:
- MKDocs v1 is no longer maintained.
- README.md was updated with 2 added lines and no removals.

`ruff check README.md` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
