### PR TITLE
Close async ServiceBusClient instances in receive loops

### DIFF
--- a/api_app/service_bus/airlock_request_status_update.py
+++ b/api_app/service_bus/airlock_request_status_update.py
@@ -27,12 +27,16 @@ class AirlockStatusUpdater():
         self.airlock_request_repo = await AirlockRequestRepository.create()
         self.workspace_repo = await WorkspaceRepository.create()
 
-    async def receive_messages(self):
+    async def receive_messages(self, keep_running=None):
+        if keep_running is None:
+            def keep_running():
+                return True
+
         with tracer.start_as_current_span("airlock_receive_messages"):
             last_heartbeat_time = 0
             polling_count = 0
 
-            while True:
+            while keep_running():
                 try:
                     current_time = time.time()
                     polling_count += 1
@@ -43,21 +47,23 @@ class AirlockStatusUpdater():
                         polling_count = 0
 
                     async with credentials.get_credential_async_context() as credential:
-                        service_bus_client = ServiceBusClient(config.SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE, credential)
-                        receiver = service_bus_client.get_queue_receiver(queue_name=config.SERVICE_BUS_STEP_RESULT_QUEUE)
-                        logger.debug(f"Looking for new messages on {config.SERVICE_BUS_STEP_RESULT_QUEUE} queue...")
-                        async with receiver:
-                            received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=1)
-                            for msg in received_msgs:
-                                async with AutoLockRenewer() as renewer:
-                                    renewer.register(receiver, msg, max_lock_renewal_duration=60)
-                                    complete_message = await self.process_message(msg)
-                                    if complete_message:
-                                        await receiver.complete_message(msg)
-                                    else:
-                                        # could have been any kind of transient issue, we'll abandon back to the queue, and retry
-                                        await receiver.abandon_message(msg)
+                        async with ServiceBusClient(config.SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE, credential) as service_bus_client:
+                            receiver = service_bus_client.get_queue_receiver(queue_name=config.SERVICE_BUS_STEP_RESULT_QUEUE)
+                            logger.debug(f"Looking for new messages on {config.SERVICE_BUS_STEP_RESULT_QUEUE} queue...")
+                            async with receiver:
+                                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=1)
+                                for msg in received_msgs:
+                                    async with AutoLockRenewer() as renewer:
+                                        renewer.register(receiver, msg, max_lock_renewal_duration=60)
+                                        complete_message = await self.process_message(msg)
+                                        if complete_message:
+                                            await receiver.complete_message(msg)
+                                        else:
+                                            # could have been any kind of transient issue, we'll abandon back to the queue, and retry
+                                            await receiver.abandon_message(msg)
 
+                        if not keep_running():
+                            break
                         await asyncio.sleep(10)
 
                 except OperationTimeoutError:

--- a/api_app/service_bus/deployment_status_updater.py
+++ b/api_app/service_bus/deployment_status_updater.py
@@ -36,12 +36,16 @@ class DeploymentStatusUpdater():
     def run(self, *args, **kwargs):
         asyncio.run(self.receive_messages())
 
-    async def receive_messages(self):
+    async def receive_messages(self, keep_running=None):
+        if keep_running is None:
+            def keep_running():
+                return True
+
         with tracer.start_as_current_span("deployment_status_receive_messages"):
             last_heartbeat_time = 0
             polling_count = 0
 
-            while True:
+            while keep_running():
                 try:
                     current_time = time.time()
                     polling_count += 1
@@ -52,22 +56,22 @@ class DeploymentStatusUpdater():
                         polling_count = 0
 
                     async with credentials.get_credential_async_context() as credential:
-                        service_bus_client = ServiceBusClient(config.SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE, credential)
+                        async with ServiceBusClient(config.SERVICE_BUS_FULLY_QUALIFIED_NAMESPACE, credential) as service_bus_client:
 
-                        logger.debug(f"Looking for new messages on {config.SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE} queue...")
-                        # max_wait_time=1 -> don't hold the session open after processing of the message has finished
-                        async with service_bus_client.get_queue_receiver(queue_name=config.SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE, max_wait_time=1, session_id=NEXT_AVAILABLE_SESSION) as receiver:
-                            logger.info(f"Got a session containing messages: {receiver.session.session_id}")
-                            async with AutoLockRenewer() as renewer:
-                                renewer.register(receiver, receiver.session, max_lock_renewal_duration=60)
-                                async for msg in receiver:
-                                    complete_message = await self.process_message(msg)
-                                    if complete_message:
-                                        await receiver.complete_message(msg)
-                                    else:
-                                        # could have been any kind of transient issue, we'll abandon back to the queue, and retry
-                                        await receiver.abandon_message(msg)
-                            logger.info(f"Closing session: {receiver.session.session_id}")
+                            logger.debug(f"Looking for new messages on {config.SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE} queue...")
+                            # max_wait_time=1 -> don't hold the session open after processing of the message has finished
+                            async with service_bus_client.get_queue_receiver(queue_name=config.SERVICE_BUS_DEPLOYMENT_STATUS_UPDATE_QUEUE, max_wait_time=1, session_id=NEXT_AVAILABLE_SESSION) as receiver:
+                                logger.info(f"Got a session containing messages: {receiver.session.session_id}")
+                                async with AutoLockRenewer() as renewer:
+                                    renewer.register(receiver, receiver.session, max_lock_renewal_duration=60)
+                                    async for msg in receiver:
+                                        complete_message = await self.process_message(msg)
+                                        if complete_message:
+                                            await receiver.complete_message(msg)
+                                        else:
+                                            # could have been any kind of transient issue, we'll abandon back to the queue, and retry
+                                            await receiver.abandon_message(msg)
+                                logger.info(f"Closing session: {receiver.session.session_id}")
 
                 except OperationTimeoutError:
                     # Timeout occurred whilst connecting to a session - this is expected and indicates no non-empty sessions are available

--- a/api_app/tests_ma/test_service_bus/test_airlock_request_status_update.py
+++ b/api_app/tests_ma/test_service_bus/test_airlock_request_status_update.py
@@ -3,7 +3,7 @@ from fastapi import HTTPException, status
 import pytest
 import time
 
-from mock import AsyncMock, patch
+from mock import AsyncMock, MagicMock, patch
 from service_bus.airlock_request_status_update import AirlockStatusUpdater
 from models.domain.events import AirlockNotificationUserData, AirlockFile
 from models.domain.airlock_request import AirlockRequest, AirlockRequestStatus, AirlockRequestType
@@ -102,6 +102,39 @@ class ServiceBusReceivedMessageMock:
 
     def __str__(self):
         return self.message
+
+
+def run_once():
+    calls = iter([True, False])
+    return lambda: next(calls)
+
+
+@patch('service_bus.airlock_request_status_update.credentials.get_credential_async_context')
+@patch('service_bus.airlock_request_status_update.ServiceBusClient')
+async def test_receive_messages_closes_service_bus_client_after_one_polling_iteration(sb_client, get_credential):
+    credential_context = MagicMock()
+    credential_context.__aenter__ = AsyncMock(return_value=MagicMock())
+    credential_context.__aexit__ = AsyncMock(return_value=None)
+    get_credential.return_value = credential_context
+
+    service_bus_client_context = MagicMock()
+    service_bus_client = MagicMock()
+    service_bus_client_context.__aenter__ = AsyncMock(return_value=service_bus_client)
+    service_bus_client_context.__aexit__ = AsyncMock(return_value=None)
+    sb_client.return_value = service_bus_client_context
+
+    receiver_context = MagicMock()
+    receiver = MagicMock()
+    receiver.receive_messages = AsyncMock(return_value=[])
+    receiver_context.__aenter__ = AsyncMock(return_value=receiver)
+    receiver_context.__aexit__ = AsyncMock(return_value=None)
+    service_bus_client.get_queue_receiver.return_value = receiver_context
+
+    airlockStatusUpdater = AirlockStatusUpdater()
+    await airlockStatusUpdater.receive_messages(keep_running=run_once())
+
+    service_bus_client_context.__aexit__.assert_awaited_once()
+    receiver_context.__aexit__.assert_awaited_once()
 
 
 @patch("event_grid.helpers.EventGridPublisherClient")

--- a/api_app/tests_ma/test_service_bus/test_deployment_status_update.py
+++ b/api_app/tests_ma/test_service_bus/test_deployment_status_update.py
@@ -79,6 +79,23 @@ class ServiceBusReceivedMessageMock:
         return self.message
 
 
+class EmptyAsyncReceiver:
+    def __init__(self):
+        self.session = MagicMock()
+        self.session.session_id = "test_session_id"
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+def run_once():
+    calls = iter([True, False])
+    return lambda: next(calls)
+
+
 def create_sample_workspace_object(workspace_id):
     return Workspace(
         id=workspace_id,
@@ -114,6 +131,38 @@ def create_sample_operation(resource_id, request_action):
             )
         ]
     )
+
+
+@patch('service_bus.deployment_status_updater.credentials.get_credential_async_context')
+@patch('service_bus.deployment_status_updater.AutoLockRenewer')
+@patch('service_bus.deployment_status_updater.ServiceBusClient')
+async def test_receive_messages_closes_service_bus_client_after_one_polling_iteration(sb_client, auto_lock_renewer, get_credential):
+    credential_context = MagicMock()
+    credential_context.__aenter__ = AsyncMock(return_value=MagicMock())
+    credential_context.__aexit__ = AsyncMock(return_value=None)
+    get_credential.return_value = credential_context
+
+    service_bus_client_context = MagicMock()
+    service_bus_client = MagicMock()
+    service_bus_client_context.__aenter__ = AsyncMock(return_value=service_bus_client)
+    service_bus_client_context.__aexit__ = AsyncMock(return_value=None)
+    sb_client.return_value = service_bus_client_context
+
+    receiver_context = MagicMock()
+    receiver_context.__aenter__ = AsyncMock(return_value=EmptyAsyncReceiver())
+    receiver_context.__aexit__ = AsyncMock(return_value=None)
+    service_bus_client.get_queue_receiver.return_value = receiver_context
+
+    renewer_context = MagicMock()
+    renewer_context.__aenter__ = AsyncMock(return_value=MagicMock())
+    renewer_context.__aexit__ = AsyncMock(return_value=None)
+    auto_lock_renewer.return_value = renewer_context
+
+    status_updater = DeploymentStatusUpdater()
+    await status_updater.receive_messages(keep_running=run_once())
+
+    service_bus_client_context.__aexit__.assert_awaited_once()
+    receiver_context.__aexit__.assert_awaited_once()
 
 
 @pytest.mark.parametrize("payload", test_data)


### PR DESCRIPTION
The API background Service Bus listeners created a new `azure.servicebus.aio.ServiceBusClient` on every poll iteration, but only the queue receiver was managed with `async with`. That left the parent client outside an async context manager and without an explicit close, so reconnect or error paths could leave AMQP connections, channels, and sockets open until process cleanup.

This change wraps each newly constructed async `ServiceBusClient` in an async context manager before creating queue receivers, while preserving the existing credential and receiver context-manager nesting.

It also adds an optional `keep_running` predicate to the receive loops so tests can stop after a single poll iteration without changing production behavior.

Focused async tests mock `ServiceBusClient` and assert its async context exits after one receive attempt, including the empty/no-message path.

Fixes #4977

`ruff check api_app/service_bus/airlock_request_status_update.py api_app/service_bus/deployment_status_updater.py api_app/tests_ma/test_service_bus/test_airlock_request_status_update.py api_app/tests_ma/test_service_bus/test_deployment_status_update.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
