### PR TITLE
Fix AzureML compute user storage access and browser app firewall rules

### DIFF
--- a/templates/workspace_services/azureml/template_schema.json
+++ b/templates/workspace_services/azureml/template_schema.json
@@ -226,6 +226,7 @@
                   "source_addresses": "{{ resource.properties.workspace_address_spaces }}",
                   "target_fqdns": [
                     "aadcdn.msauth.net",
+                    "*.instances.azureml.ms",
                     "{{ resource.properties.aml_fqdn }}",
                     "automlresources-prod.azureedge.net"
                   ],
@@ -371,6 +372,7 @@
                   "source_addresses": "{{ resource.properties.workspace_address_spaces }}",
                   "target_fqdns": [
                     "aadcdn.msauth.net",
+                    "*.instances.azureml.ms",
                     "{{ resource.properties.aml_fqdn }}",
                     "automlresources-prod.azureedge.net"
                   ],

--- a/templates/workspace_services/azureml/user_resources/aml_compute/terraform/compute.tf
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/terraform/compute.tf
@@ -28,4 +28,21 @@ resource "azapi_resource" "compute_instance" {
   }
 
   lifecycle { ignore_changes = [tags] }
+
+  depends_on = [
+    azurerm_role_assignment.user_storage_blob_data_contributor,
+    azurerm_role_assignment.user_storage_file_data_contributor
+  ]
+}
+
+resource "azurerm_role_assignment" "user_storage_blob_data_contributor" {
+  scope              = data.azurerm_storage_account.aml.id
+  role_definition_id = data.azurerm_role_definition.storage_blob_data_contributor.id
+  principal_id       = var.user_object_id
+}
+
+resource "azurerm_role_assignment" "user_storage_file_data_contributor" {
+  scope              = data.azurerm_storage_account.aml.id
+  role_definition_id = data.azurerm_role_definition.storage_file_data_contributor.id
+  principal_id       = var.user_object_id
 }

--- a/templates/workspace_services/azureml/user_resources/aml_compute/terraform/data.tf
+++ b/templates/workspace_services/azureml/user_resources/aml_compute/terraform/data.tf
@@ -17,3 +17,16 @@ data "azurerm_machine_learning_workspace" "workspace" {
   name                = local.aml_workspace_name
   resource_group_name = data.azurerm_resource_group.ws.name
 }
+
+data "azurerm_storage_account" "aml" {
+  name                = lower(replace("stg${substr(local.service_resource_name_suffix, -8, -1)}", "-", ""))
+  resource_group_name = data.azurerm_resource_group.ws.name
+}
+
+data "azurerm_role_definition" "storage_blob_data_contributor" {
+  name = "Storage Blob Data Contributor"
+}
+
+data "azurerm_role_definition" "storage_file_data_contributor" {
+  name = "Storage File Data Privileged Contributor"
+}


### PR DESCRIPTION
Addresses #4898.

The AzureML service template creates an identity-based workspace with `systemDatastoresAuthMode = "identity"` on a storage account where shared key access is disabled. The AML compute user resource created only the personal compute instance, so the assigned user did not receive storage data-plane access to the workspace storage account. The AzureML firewall pipeline also allowed the client to reach AML Studio but omitted compute-application endpoints such as `*.instances.azureml.ms`, which affected browser-based Terminal, Notebook, Jupyter, and JupyterLab flows.

This change adds storage role-definition lookups in the AML compute user-resource Terraform and assigns the requested `user_object_id` Blob Data Contributor and Storage File Data Privileged Contributor on the parent workspace storage account before creating the compute instance. It also updates the AzureML workspace service pipeline client application rule for install and upgrade so workspace clients can reach AML compute application FQDNs, including `*.instances.azureml.ms`, over the ports used by AML browser applications.

Shared-key access remains disabled, and the existing private-network compute posture is preserved.

Files modified:
- `templates/workspace_services/azureml/template_schema.json`
- `templates/workspace_services/azureml/user_resources/aml_compute/terraform/compute.tf`
- `templates/workspace_services/azureml/user_resources/aml_compute/terraform/data.tf`

`ruff check templates/workspace_services/azureml/user_resources/aml_compute/terraform/compute.tf templates/workspace_services/azureml/user_resources/aml_compute/terraform/data.tf` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
