### PR TITLE
Delete Databricks workspaces before TRE resource groups

### DIFF
--- a/devops/scripts/destroy_env_no_terraform.sh
+++ b/devops/scripts/destroy_env_no_terraform.sh
@@ -185,6 +185,24 @@ function purge_container_repositories() {
   done
 }
 
+function delete_databricks_workspaces() {
+  local rg=$1
+
+  local workspaces
+  workspaces=$(az databricks workspace list --resource-group "$rg" --query [].name --output tsv)
+
+  local workspace
+  for workspace in $workspaces; do
+    echo "Deleting Databricks workspace ${workspace} in resource group ${rg}..."
+    az databricks workspace delete --resource-group "$rg" --name "$workspace" --yes
+  done
+}
+
+echo "${matching_resource_groups}" |
+while read -r rg_item; do
+  delete_databricks_workspaces "$rg_item"
+done
+
 # this will find the mgmt, core resource groups as well as any workspace ones
 # we are reverse-sorting to first delete the workspace groups (might not be
 # good enough because we use no-wait sometimes)


### PR DESCRIPTION
Addresses #4752.

`make tre-destroy` delegates to `devops/scripts/destroy_env_no_terraform.sh`, which deleted every TRE-prefixed resource group directly. Azure Databricks creates a system deny assignment on its managed resource group, and that deny assignment is only removed when the owning Databricks workspace is deleted through the Databricks workspace API. Deleting the resource group first can hit `DenyAssignmentAuthorizationFailed`.

This change adds a small helper in the destroy script that lists Databricks workspaces in each matching TRE resource group and deletes them with `az databricks workspace delete --yes` before any resource group deletion starts. It reuses the existing resolved `matching_resource_groups` list so core, workspace, service, and Databricks managed resource groups are handled consistently.

The rest of the destroy flow is unchanged, including lock cleanup, ACR repository purge, key vault cleanup, and `--no-wait` behavior for resource group deletion.

`ruff check devops/scripts/destroy_env_no_terraform.sh` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
