### PR TITLE
Show the user's TRE and workspace roles in the UI user menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **BREAKING CHANGES**
 
 ENHANCEMENTS:
+* Show the roles held by the signed-in user in the UI user menu, for both the TRE and the current workspace, so that a hidden feature can be told apart from a role assignment that has not taken effect ([#5051](https://github.com/microsoft/AzureTRE/issues/5051))
 
 ## (0.29.0) (August 14, 2026)
 **BREAKING CHANGES**

--- a/docs/tre-developers/ui.md
+++ b/docs/tre-developers/ui.md
@@ -36,6 +36,8 @@ When the user navigates into a Workspace, the client will request an access toke
 Workspace app registrations may be reused across multiple workspaces in development scenarios.
 From this access token we can find the Workspace-level roles the user is in (`WorkspaceOwner` / `WorkspaceResearcher`). These are in turn used to show/hide features of the UI.
 
+The roles from both token types are also shown to the user in the user menu in the top navigation bar, under `TRE roles` and `Workspace roles`. The workspace section only appears on a workspace route, and shows `None assigned` when the user holds no role in that workspace, which is the case for a `TREAdmin` viewing a workspace they are not a member of. The menu reads the same role claims that `SecuredByRole` gates on, so what it shows always matches what the UI lets the user do.
+
 ### React Contexts
 The React Context API is a clean way to handle a limited amount of global state, and is used for a few scenarios in this project:
 - TRE Roles Context: A context provides details of the base TRE roles a user is in, which can be consumed anywhere throughout the app

--- a/ui/app/package-lock.json
+++ b/ui/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tre-ui",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tre-ui",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "dependencies": {
         "@azure/msal-browser": "^2.35.0",
         "@azure/msal-react": "^1.5.12",

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -90,7 +90,7 @@ export const App: React.FunctionComponent = () => {
                   />
                   <Stack styles={stackStyles} className="tre-root">
                     <Stack.Item grow className="tre-top-nav">
-                      <TopNav />
+                      <TopNav workspaceRoles={workspaceRoles} />
                     </Stack.Item>
                     <Stack.Item grow={100} className="tre-body">
                       <GenericErrorBoundary>

--- a/ui/app/src/components/shared/TopNav.tsx
+++ b/ui/app/src/components/shared/TopNav.tsx
@@ -5,7 +5,13 @@ import { UserMenu } from "./UserMenu";
 import { NotificationPanel } from "./notifications/NotificationPanel";
 import config from "../../config.json";
 
-export const TopNav: React.FunctionComponent = () => {
+interface TopNavProps {
+  // Passed through to the user menu, which sits outside the WorkspaceContext
+  // provider and so cannot read the workspace roles itself.
+  workspaceRoles?: Array<string>;
+}
+
+export const TopNav: React.FunctionComponent<TopNavProps> = (props: TopNavProps) => {
   return (
     <>
       <div className={contentClass}>
@@ -29,7 +35,7 @@ export const TopNav: React.FunctionComponent = () => {
             <NotificationPanel />
           </Stack.Item>
           <Stack.Item grow>
-            <UserMenu />
+            <UserMenu workspaceRoles={props.workspaceRoles} />
           </Stack.Item>
         </Stack>
       </div>

--- a/ui/app/src/components/shared/UserMenu.test.tsx
+++ b/ui/app/src/components/shared/UserMenu.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { UserMenu } from "./UserMenu";
+import { AppRolesContext } from "../../contexts/AppRolesContext";
+import { RoleName, WorkspaceRoleName } from "../../models/roleNames";
 
 // Mock MSAL
 const mockLogout = vi.fn();
@@ -36,7 +39,12 @@ vi.mock("@fluentui/react", () => {
       {menuProps && (
         <div data-testid="menu-items">
           {menuProps.items.map((item: any) => (
-            <button key={item.key} data-testid={`menu-item-${item.key}`} onClick={item.onClick}>
+            <button
+              key={item.key}
+              data-testid={`menu-item-${item.key}`}
+              data-type={item.itemType}
+              onClick={item.onClick}
+            >
               {item.text}
             </button>
           ))}
@@ -46,8 +54,8 @@ vi.mock("@fluentui/react", () => {
   );
   PrimaryButton.displayName = "PrimaryButton";
 
-  const Persona = ({ text, size, imageAlt }: any) => (
-    <div data-testid="persona" data-size={size} data-alt={imageAlt}>
+  const Persona = ({ text, secondaryText, size, imageAlt }: any) => (
+    <div data-testid="persona" data-size={size} data-alt={imageAlt} data-secondary-text={secondaryText}>
       {text}
     </div>
   );
@@ -58,9 +66,25 @@ vi.mock("@fluentui/react", () => {
     Persona,
     PersonaSize: {
       size32: "size32",
+      size40: "size40",
+    },
+    getTheme: () => ({ palette: { white: "#ffffff" } }),
+    ContextualMenuItemType: {
+      Normal: 0,
+      Divider: 1,
+      Header: 2,
     },
   };
 });
+
+const renderUserMenu = (appRoles: Array<string> = [], route: string = "/", workspaceRoles?: Array<string>) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <AppRolesContext.Provider value={{ roles: appRoles, setAppRoles: () => {} }}>
+        <UserMenu workspaceRoles={workspaceRoles} />
+      </AppRolesContext.Provider>
+    </MemoryRouter>,
+  );
 
 describe("UserMenu Component", () => {
   beforeEach(() => {
@@ -70,25 +94,14 @@ describe("UserMenu Component", () => {
   });
 
   it("renders user menu with persona", () => {
-    render(<UserMenu />);
+    renderUserMenu();
 
     expect(screen.getByTestId("primary-button")).toBeInTheDocument();
     expect(screen.getByTestId("persona")).toBeInTheDocument();
-    // User name is passed as text prop to the mocked Persona component
-    const persona = screen.getByTestId("persona");
-    expect(persona).toBeInTheDocument();
-  });
-
-  it("displays user name in persona", () => {
-    render(<UserMenu />);
-
-    const persona = screen.getByTestId("persona");
-    // Just verify the persona component is rendered - the mock doesn't render text content
-    expect(persona).toBeInTheDocument();
   });
 
   it("applies correct styling to button", () => {
-    render(<UserMenu />);
+    renderUserMenu();
 
     const button = screen.getByTestId("primary-button");
     expect(button).toHaveStyle({
@@ -98,50 +111,133 @@ describe("UserMenu Component", () => {
   });
 
   it("renders logout menu item", () => {
-    render(<UserMenu />);
+    renderUserMenu();
 
     expect(screen.getByTestId("menu-item-logout")).toBeInTheDocument();
     expect(screen.getByText("Logout")).toBeInTheDocument();
   });
 
   it("calls logout when logout menu item is clicked", () => {
-    render(<UserMenu />);
+    renderUserMenu();
 
-    const logoutItem = screen.getByTestId("menu-item-logout");
-    fireEvent.click(logoutItem);
+    fireEvent.click(screen.getByTestId("menu-item-logout"));
 
     expect(mockLogout).toHaveBeenCalledTimes(1);
   });
 
   it("has correct CSS class", () => {
-    render(<UserMenu />);
+    renderUserMenu();
 
     const container = screen.getByTestId("primary-button").parentElement;
     expect(container).toHaveClass("tre-user-menu");
   });
 
   it("configures menu with correct directional hint", () => {
-    render(<UserMenu />);
+    renderUserMenu();
 
     const button = screen.getByTestId("primary-button");
     expect(button).toHaveAttribute("data-menu", "true");
   });
 
-  it("sets correct persona size", () => {
-    render(<UserMenu />);
+  // size40 is the smallest Fluent persona size that renders secondary text,
+  // which is where the role summary goes. Dropping below it hides the summary.
+  it("sets a persona size that renders the secondary text", () => {
+    renderUserMenu();
 
     const persona = screen.getByTestId("persona");
-    expect(persona).toHaveAttribute("data-size", "size32");
+    expect(persona).toHaveAttribute("data-size", "size40");
   });
 
   it("handles no account gracefully", () => {
     mockAccounts = [];
     mockCurrentAccount = null;
 
-    render(<UserMenu />);
+    renderUserMenu();
 
     // Should still render the menu structure
     expect(screen.getByTestId("primary-button")).toBeInTheDocument();
     expect(screen.getByTestId("persona")).toBeInTheDocument();
+  });
+
+  it("lists the TRE roles the user holds, with display names", () => {
+    renderUserMenu([RoleName.TREAdmin, RoleName.TREUser]);
+
+    expect(screen.getByTestId("menu-item-tre-roles-header")).toHaveTextContent("TRE roles");
+    expect(screen.getByTestId(`menu-item-tre-roles-${RoleName.TREAdmin}`)).toHaveTextContent("TRE Administrator");
+    expect(screen.getByTestId(`menu-item-tre-roles-${RoleName.TREUser}`)).toHaveTextContent("TRE User");
+  });
+
+  it("summarises a single TRE role on the persona outside a workspace", () => {
+    renderUserMenu([RoleName.TREAdmin]);
+
+    expect(screen.getByTestId("persona")).toHaveAttribute("data-secondary-text", "TRE Administrator");
+  });
+
+  it("counts the remaining roles rather than listing them all", () => {
+    renderUserMenu([RoleName.TREUser, RoleName.TREAdmin]);
+
+    expect(screen.getByTestId("persona")).toHaveAttribute("data-secondary-text", "TRE Administrator +1 more");
+  });
+
+  // The token lists roles in no guaranteed order, so the one role that fits must
+  // be picked by privilege rather than by position.
+  it("names the most privileged role first regardless of token order", () => {
+    renderUserMenu([RoleName.TREUser], "/workspaces/ws-id", [
+      WorkspaceRoleName.WorkspaceResearcher,
+      WorkspaceRoleName.WorkspaceOwner,
+      WorkspaceRoleName.AirlockManager,
+    ]);
+
+    expect(screen.getByTestId("persona")).toHaveAttribute("data-secondary-text", "Workspace Owner +2 more");
+  });
+
+  it("shows an explicit message when the user holds no TRE role", () => {
+    renderUserMenu([]);
+
+    expect(screen.getByTestId("menu-item-tre-roles-none")).toHaveTextContent("None assigned");
+    expect(screen.getByTestId("persona")).toHaveAttribute("data-secondary-text", "No roles assigned");
+  });
+
+  it("does not show a workspace section outside a workspace", () => {
+    renderUserMenu([RoleName.TREUser]);
+
+    expect(screen.queryByTestId("menu-item-workspace-roles-header")).not.toBeInTheDocument();
+  });
+
+  it("lists the workspace roles the user holds when viewing a workspace", () => {
+    renderUserMenu([RoleName.TREUser], "/workspaces/ws-id", [
+      WorkspaceRoleName.WorkspaceOwner,
+      WorkspaceRoleName.AirlockManager,
+    ]);
+
+    expect(screen.getByTestId("menu-item-workspace-roles-header")).toHaveTextContent("Workspace roles");
+    expect(screen.getByTestId(`menu-item-workspace-roles-${WorkspaceRoleName.WorkspaceOwner}`)).toHaveTextContent(
+      "Workspace Owner",
+    );
+    expect(screen.getByTestId(`menu-item-workspace-roles-${WorkspaceRoleName.AirlockManager}`)).toHaveTextContent(
+      "Airlock Manager",
+    );
+  });
+
+  it("summarises the workspace roles on the persona inside a workspace", () => {
+    renderUserMenu([RoleName.TREUser], "/workspaces/ws-id", [WorkspaceRoleName.WorkspaceResearcher]);
+
+    expect(screen.getByTestId("persona")).toHaveAttribute("data-secondary-text", "Workspace Researcher");
+  });
+
+  // A TRE Admin gets into a workspace on a core token and holds no workspace
+  // role there. The section must still appear, otherwise this looks the same as
+  // not being in a workspace.
+  it("shows an empty workspace section for a TRE Admin with no workspace role", () => {
+    renderUserMenu([RoleName.TREAdmin], "/workspaces/ws-id", []);
+
+    expect(screen.getByTestId("menu-item-workspace-roles-none")).toHaveTextContent("None assigned");
+    expect(screen.getByTestId("persona")).toHaveAttribute("data-secondary-text", "TRE Administrator");
+  });
+
+  it("falls back to the raw value for a role with no display name", () => {
+    renderUserMenu(["SomeNewRole"]);
+
+    expect(screen.getByTestId("menu-item-tre-roles-SomeNewRole")).toHaveTextContent("SomeNewRole");
   });
 });

--- a/ui/app/src/components/shared/UserMenu.tsx
+++ b/ui/app/src/components/shared/UserMenu.tsx
@@ -1,15 +1,84 @@
-import React from "react";
-import { IContextualMenuProps, Persona, PersonaSize, PrimaryButton } from "@fluentui/react";
+import React, { useContext } from "react";
+import {
+  ContextualMenuItemType,
+  getTheme,
+  IContextualMenuItem,
+  IContextualMenuProps,
+  Persona,
+  PersonaSize,
+  PrimaryButton,
+} from "@fluentui/react";
 import { useAccount, useMsal } from "@azure/msal-react";
+import { useLocation } from "react-router-dom";
+import { AppRolesContext } from "../../contexts/AppRolesContext";
+import { getRoleDisplayName, orderRoles } from "../../models/roleNames";
 
-export const UserMenu: React.FunctionComponent = () => {
+interface UserMenuProps {
+  // Roles the user holds in the workspace they are currently viewing. Empty
+  // outside a workspace: WorkspaceProvider clears them when it unmounts.
+  workspaceRoles?: Array<string>;
+}
+
+// One menu section per role scope. An explicit "None assigned" entry keeps the
+// section present when the user holds no role in that scope, which is the state
+// that is otherwise indistinguishable from a role that has not taken effect yet.
+const roleMenuSection = (key: string, title: string, roles: Array<string>): Array<IContextualMenuItem> => {
+  const section: Array<IContextualMenuItem> = [
+    { key: `${key}-divider`, itemType: ContextualMenuItemType.Divider },
+    { key: `${key}-header`, itemType: ContextualMenuItemType.Header, text: title },
+  ];
+
+  if (roles.length === 0) {
+    return [...section, { key: `${key}-none`, text: "None assigned" }];
+  }
+
+  return [
+    ...section,
+    ...orderRoles(roles).map((role) => ({
+      key: `${key}-${role}`,
+      text: getRoleDisplayName(role),
+      iconProps: { iconName: "Contact" },
+    })),
+  ];
+};
+
+const theme = getTheme();
+
+export const UserMenu: React.FunctionComponent<UserMenuProps> = (props: UserMenuProps) => {
   const { instance, accounts } = useMsal();
   const account = useAccount(accounts[0] || {});
+  const appRoles = useContext(AppRolesContext);
+  const location = useLocation();
+
+  const workspaceRoles = props.workspaceRoles ?? [];
+  // The workspace roles section is shown for any workspace route, including when
+  // the user holds no role there. That is the TRE Admin case, and hiding the
+  // section would make it look the same as not being in a workspace at all.
+  const inWorkspace = location.pathname.startsWith("/workspaces/");
+
+  // Both scopes are listed in the menu, but the button itself has room for one
+  // line only, so it shows the roles for the scope the user is looking at. A TRE
+  // Admin viewing a workspace holds no workspace role, and falls back to the
+  // core roles rather than being told that no role is assigned.
+  const summaryRoles = orderRoles(workspaceRoles.length > 0 ? workspaceRoles : appRoles.roles);
+
+  // Listing every role here either overflows the bar or gets cut off mid word,
+  // and a clipped list does not say how much it left out. Name the most
+  // privileged role in full and count the rest; the menu has the full list.
+  const roleSummary =
+    summaryRoles.length === 0
+      ? "No roles assigned"
+      : summaryRoles.length === 1
+        ? getRoleDisplayName(summaryRoles[0])
+        : `${getRoleDisplayName(summaryRoles[0])} +${summaryRoles.length - 1} more`;
 
   const menuProps: IContextualMenuProps = {
     shouldFocusOnMount: true,
     directionalHint: 6, // bottom right edge
     items: [
+      ...roleMenuSection("tre-roles", "TRE roles", appRoles.roles),
+      ...(inWorkspace ? roleMenuSection("workspace-roles", "Workspace roles", workspaceRoles) : []),
+      { key: "logout-divider", itemType: ContextualMenuItemType.Divider },
       {
         key: "logout",
         text: "Logout",
@@ -24,7 +93,17 @@ export const UserMenu: React.FunctionComponent = () => {
   return (
     <div className="tre-user-menu">
       <PrimaryButton menuProps={menuProps} style={{ background: "none", border: "none" }}>
-        <Persona text={account?.name} size={PersonaSize.size32} imageAlt={account?.name} />
+        <Persona
+          text={account?.name}
+          secondaryText={roleSummary}
+          // size40 is the smallest size at which Fluent renders the secondary
+          // text line, which is what carries the role summary.
+          size={PersonaSize.size40}
+          imageAlt={account?.name}
+          // Bounded so that a user holding several roles cannot push the rest of
+          // the top bar off screen. Fluent truncates what does not fit.
+          styles={{ root: { maxWidth: 240 }, secondaryText: { color: theme.palette.white } }}
+        />
       </PrimaryButton>
     </div>
   );

--- a/ui/app/src/models/roleNames.ts
+++ b/ui/app/src/models/roleNames.ts
@@ -8,3 +8,38 @@ export enum WorkspaceRoleName {
   WorkspaceResearcher = "WorkspaceResearcher",
   AirlockManager = "AirlockManager",
 }
+
+// Display names for the app roles defined in the core and workspace app
+// registrations. Tokens carry the raw role value, which is what the RBAC checks
+// compare against, but it is not what we want to put in front of a user.
+const roleDisplayNames: Record<string, string> = {
+  [RoleName.TREAdmin]: "TRE Administrator",
+  [RoleName.TREUser]: "TRE User",
+  [WorkspaceRoleName.WorkspaceOwner]: "Workspace Owner",
+  [WorkspaceRoleName.WorkspaceResearcher]: "Workspace Researcher",
+  [WorkspaceRoleName.AirlockManager]: "Airlock Manager",
+};
+
+// Falls back to the raw value so that a role added to an app registration
+// without a matching entry here is still shown rather than silently dropped.
+export const getRoleDisplayName = (role: string): string => roleDisplayNames[role] ?? role;
+
+// Most to least privileged, within each scope. A token lists roles in no
+// guaranteed order, so anywhere only one role fits we want it to be the one
+// that says the most about what the user can do. Unlisted roles sort last.
+const rolePrecedence: Array<string> = [
+  RoleName.TREAdmin,
+  RoleName.TREUser,
+  WorkspaceRoleName.WorkspaceOwner,
+  WorkspaceRoleName.AirlockManager,
+  WorkspaceRoleName.WorkspaceResearcher,
+];
+
+export const orderRoles = (roles: Array<string>): Array<string> =>
+  [...roles].sort((a, b) => {
+    const rank = (role: string) => {
+      const i = rolePrecedence.indexOf(role);
+      return i === -1 ? rolePrecedence.length : i;
+    };
+    return rank(a) - rank(b);
+  });


### PR DESCRIPTION
# Resolves #5051

## What is being addressed

The UI knows the roles of the user, but it does not show them. The core roles are
in `AppRolesContext` and the workspace roles are in `WorkspaceContext`. The
components that read them use them only to select which elements to show.

Thus two different conditions look the same. `SecuredByRole` removes an element
fully when the user does not have the role and the caller gives no error message.
A Researcher who does not see the "Create new" button cannot find the cause. The
cause can be the Researcher role, which is correct. The cause can also be a role
assignment that is not yet in effect.

This also makes tests more difficult. Each role sees a different page, so you must
test a change to a controlled function with each role. Today you change the app
role assignment in Entra ID, open the UI again, and then look at the buttons to
decide if the new role is in effect.

## How is this addressed

The user menu now shows the roles that the user has.

- The menu button shows a summary line below the name. The user does not have to
  open the menu to see it.
- The menu lists `TRE roles`. On a workspace route it also lists
  `Workspace roles`.
- A scope with no roles shows `None assigned`. The UI does not show an empty
  area. This condition is the most difficult one to find today.
- The UI shows a display name for each role. `TREAdmin` becomes
  `TRE Administrator`. An unknown value keeps its raw text, so a new app role is
  still shown.

The button has room for one line. Thus the summary gives the name of one role and
counts the others: `Workspace Owner +2 more`. A token lists the roles in no
guaranteed order, so the roles are sorted first and the summary names the most
privileged one. The same order applies to the menu.

Inside a workspace the summary gives the workspace roles. A TRE Admin has no
workspace role there, so the summary falls back to the core roles instead of
`No roles assigned`.

`TopNav` takes the workspace roles as a property, because it is outside the
`WorkspaceContext` provider and cannot read them. The state is already in
`App`, and `WorkspaceProvider` clears it when it unmounts.

The menu reads the same token claims that `SecuredByRole` uses. It does not read
Entra ID. Thus the menu and the available functions always agree. A difference
would show that the browser has an old token, which is useful data.

## Screenshots

One role, and more than one role:

![Role summary on the menu button](https://raw.githubusercontent.com/JayDoubleu/AzureTRE/a4e2717a5870ad83708cee7a2333af9df0a037ee/role-summary-overflow.jpg)

A TRE Admin in a workspace with no workspace role, and a user with no roles:

![Empty role states](https://raw.githubusercontent.com/JayDoubleu/AzureTRE/a4e2717a5870ad83708cee7a2333af9df0a037ee/role-summary-empty-states.jpg)

The menu open, for a user with all three workspace roles:

![User menu open](https://raw.githubusercontent.com/JayDoubleu/AzureTRE/a4e2717a5870ad83708cee7a2333af9df0a037ee/role-menu-open.jpg)

The screenshots come from a preview harness that renders the component with a
stub in place of MSAL. The harness is not part of this change.

## Checks

- `npx vitest run`: 27 files and 250 tests pass. `UserMenu.tsx` and
  `roleNames.ts` are at 100% for statements, branches, functions and lines.
- `npx eslint .` is clean. `npx prettier --check src` is clean.
  `npm run build` passes.
- `ui/app/package.json` moves to 0.8.32. There is a CHANGELOG entry, and the
  AuthN + AuthZ section of `docs/tre-developers/ui.md` is updated.

## Open points

- The role entries are menu items with no action. A read-only section in a
  contextual menu is not a usual use of the control. I can move the roles to a
  callout or a panel if that is better.
- The persona is now `size40`, because Fluent does not show the secondary text
  below that size. The bar is 50px high, so the bar itself does not change.
- The workspace roles are empty for a moment while a workspace loads. The menu
  shows `None assigned` until the roles arrive.
- The role items carry a `Contact` icon. No icon shows at present, because the
  app does not call `initializeIcons()`. The `SignOut` icon on the Logout item
  has the same condition. This is not new, and it is not part of this change.
