### PR TITLE
Add user picker for 'Assign to user' option in Guacamole Windows and Linux VM create forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **BREAKING CHANGES**
 
 ENHANCEMENTS:
+* Add user picker for 'Assign to user' option in Guacamole Windows and Linux VM create forms ([#5053](https://github.com/microsoft/AzureTRE/issues/5053))
 
 ## (0.29.0) (August 14, 2026)
 **BREAKING CHANGES**

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.4.5
+version: 1.4.6
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -232,9 +232,9 @@
         "properties": {
           "owner_id": {
             "type": "string",
-            "title": "Owner ID",
-            "description": "Enter the Object ID of the user you want to assign this VM to.",
-            "default": false,
+            "title": "Owner",
+            "description": "Select the user you want to assign this VM to.",
+            "minLength": 1,
             "updateable": false
           }
         },
@@ -247,6 +247,9 @@
   "uiSchema": {
     "admin_username": {
       "classNames": "tre-hidden"
+    },
+    "owner_id": {
+      "ui:widget": "WorkspaceUserPicker"
     }
   }
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 3.0.2
+version: 3.0.3
 description: "An Azure TRE User Resource Template for Guacamole (Windows 11 or Windows Server 2025)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -266,9 +266,9 @@
         "properties": {
           "owner_id": {
             "type": "string",
-            "title": "Owner ID",
-            "description": "Enter the Object ID of the user you want to assign this VM to.",
-            "default": false,
+            "title": "Owner",
+            "description": "Select the user you want to assign this VM to.",
+            "minLength": 1,
             "updateable": false
           }
         },
@@ -281,6 +281,9 @@
   "uiSchema": {
     "admin_username": {
       "classNames": "tre-hidden"
+    },
+    "owner_id": {
+      "ui:widget": "WorkspaceUserPicker"
     }
   }
 }

--- a/ui/app/package-lock.json
+++ b/ui/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tre-ui",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tre-ui",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "dependencies": {
         "@azure/msal-browser": "^2.35.0",
         "@azure/msal-react": "^1.5.12",

--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/ui/app/src/components/shared/create-update-resource/CreateUpdateResource.tsx
+++ b/ui/app/src/components/shared/create-update-resource/CreateUpdateResource.tsx
@@ -75,6 +75,7 @@ export const CreateUpdateResource: React.FunctionComponent<CreateUpdateResourceP
   let templateGetPath;
 
   let workspaceApplicationIdURI = undefined;
+  let workspaceId = undefined;
   switch (props.resourceType) {
     case ResourceType.Workspace:
       templateListPath = ApiEndpoint.WorkspaceTemplates;
@@ -91,7 +92,7 @@ export const CreateUpdateResource: React.FunctionComponent<CreateUpdateResourceP
     case ResourceType.UserResource:
       if (props.parentResource) {
         // If we are creating a user resource, parent resource must have a workspaceId
-        const workspaceId = (props.parentResource as WorkspaceService).workspaceId;
+        workspaceId = (props.parentResource as WorkspaceService).workspaceId;
         templateListPath = `${ApiEndpoint.Workspaces}/${workspaceId}/${ApiEndpoint.WorkspaceServiceTemplates}/${props.parentResource.templateName}/${ApiEndpoint.UserResourceTemplates}`;
         templateGetPath = `${ApiEndpoint.WorkspaceServiceTemplates}/${props.parentResource.templateName}/${ApiEndpoint.UserResourceTemplates}`;
         workspaceApplicationIdURI = props.workspaceApplicationIdURI;
@@ -159,6 +160,7 @@ export const CreateUpdateResource: React.FunctionComponent<CreateUpdateResourceP
           resourcePath={resourcePath}
           onCreateResource={resourceCreating}
           workspaceApplicationIdURI={props.workspaceApplicationIdURI}
+          workspaceId={workspaceId}
           updateResource={props.updateResource}
         />
       );

--- a/ui/app/src/components/shared/create-update-resource/ResourceForm.tsx
+++ b/ui/app/src/components/shared/create-update-resource/ResourceForm.tsx
@@ -10,6 +10,11 @@ import { APIError } from "../../../models/exceptions";
 import { ExceptionLayout } from "../ExceptionLayout";
 import { ResourceTemplate, sanitiseTemplateForRJSF } from "../../../models/resourceTemplate";
 import validator from "@rjsf/validator-ajv8";
+import { WorkspaceUserPickerWidget } from "./WorkspaceUserPickerWidget";
+
+const widgets = {
+  WorkspaceUserPicker: WorkspaceUserPickerWidget,
+};
 
 interface ResourceFormProps {
   templateName: string;
@@ -18,6 +23,7 @@ interface ResourceFormProps {
   updateResource?: Resource;
   onCreateResource: (operation: Operation) => void;
   workspaceApplicationIdURI?: string;
+  workspaceId?: string;
 }
 
 export const ResourceForm: React.FunctionComponent<ResourceFormProps> = (props: ResourceFormProps) => {
@@ -164,6 +170,8 @@ export const ResourceForm: React.FunctionComponent<ResourceFormProps> = (props: 
                 schema={template}
                 formData={formData}
                 uiSchema={uiSchema}
+                widgets={widgets}
+                formContext={{ workspaceId: props.workspaceId, workspaceApplicationIdURI: props.workspaceApplicationIdURI }}
                 validator={validator}
                 onSubmit={(e: any) => createUpdateResource(e.formData)}
               />

--- a/ui/app/src/components/shared/create-update-resource/WorkspaceUserPickerWidget.tsx
+++ b/ui/app/src/components/shared/create-update-resource/WorkspaceUserPickerWidget.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useState } from "react";
+import { ComboBox, IComboBox, IComboBoxOption, MessageBar, MessageBarType } from "@fluentui/react";
+import { WidgetProps } from "@rjsf/utils";
+import { useAccount, useMsal } from "@azure/msal-react";
+import { HttpMethod, useAuthApiCall } from "../../../hooks/useAuthApiCall";
+import { ApiEndpoint } from "../../../models/apiEndpoints";
+
+interface WorkspaceUser {
+  id: string;
+  displayName: string;
+  userPrincipalName: string;
+}
+
+export const WorkspaceUserPickerWidget: React.FunctionComponent<WidgetProps> = (props) => {
+  const { id, value, required, disabled, readonly, onChange, label } = props;
+  const workspaceId = props.formContext?.workspaceId;
+  const workspaceApplicationIdURI = props.formContext?.workspaceApplicationIdURI;
+  const apiCall = useAuthApiCall();
+  const { accounts } = useMsal();
+  const currentAccount = useAccount(accounts[0] || {});
+  const [options, setOptions] = useState<IComboBoxOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    const getWorkspaceUsers = async () => {
+      try {
+        const response = await apiCall(
+          `${ApiEndpoint.Workspaces}/${workspaceId}/${ApiEndpoint.Users}`,
+          HttpMethod.Get,
+          workspaceApplicationIdURI,
+        );
+        const users = response.users as WorkspaceUser[];
+        const currentUserId = currentAccount?.localAccountId.split(".")[0];
+        setOptions(
+          users
+            .filter((user) => user.id !== currentUserId)
+            .map((user) => ({
+              key: user.id,
+              text: `${user.displayName} (${user.userPrincipalName})`,
+            })),
+        );
+      } catch (err: any) {
+        setErrorMessage("Unable to load the list of workspace users.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (workspaceId) getWorkspaceUsers();
+  }, [apiCall, workspaceId, workspaceApplicationIdURI, currentAccount?.localAccountId]);
+
+  const handleChange = useCallback(
+    (_event: React.FormEvent<IComboBox>, option?: IComboBoxOption) => {
+      onChange(option ? (option.key as string) : undefined);
+    },
+    [onChange],
+  );
+
+  if (errorMessage) {
+    return <MessageBar messageBarType={MessageBarType.error}>{errorMessage}</MessageBar>;
+  }
+
+  const noUsersFound = !loading && options.length === 0;
+
+  let placeholder = "Select a user";
+  if (loading) placeholder = "Loading workspace users...";
+  else if (noUsersFound) placeholder = "No other workspace users found";
+
+  return (
+    <ComboBox
+      id={id}
+      label={label}
+      required={required}
+      disabled={disabled || readonly || noUsersFound}
+      allowFreeform={false}
+      autoComplete="on"
+      selectedKey={value || null}
+      options={options}
+      placeholder={placeholder}
+      onChange={handleChange}
+    />
+  );
+};


### PR DESCRIPTION
This pull request introduces a user-friendly user picker for the "Assign to user" option in the Guacamole Windows and Linux VM creation forms. The main enhancement is the addition of a `WorkspaceUserPicker` widget, which allows users to select from a list of workspace users instead of manually entering a user ID. This improves usability and reduces errors when assigning VMs.

**User Assignment Improvements:**

* Added a `WorkspaceUserPicker` widget to the Guacamole Windows and Linux VM resource forms, allowing users to select a workspace user from a dropdown instead of entering an Object ID. (`ui/app/src/components/shared/create-update-resource/WorkspaceUserPickerWidget.tsx`, `templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json`, `templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json`, [[1]](diffhunk://#diff-751c14e7e8bd4e8ace19e4a733b8ec7a16bf1bcbd5e3197b0d004c3cd72ecddeR250-R252) [[2]](diffhunk://#diff-a289cbd9c2288fab357d36d8f11c9e4946833236fa66ee6b277e9dc58e952e1fR284-R286) [[3]](diffhunk://#diff-c3d47a1305f784cb71eaa5fca4b1cf27bdbee1a1b1fe842722389a6a7720d6e4R1-R84)
* Updated the `owner_id` property in the VM templates to use the new user picker, including schema and UI changes for better validation and display. (`templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json`, `templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json`, [[1]](diffhunk://#diff-751c14e7e8bd4e8ace19e4a733b8ec7a16bf1bcbd5e3197b0d004c3cd72ecddeL235-R237) [[2]](diffhunk://#diff-a289cbd9c2288fab357d36d8f11c9e4946833236fa66ee6b277e9dc58e952e1fL269-R271)

**UI and Integration Updates:**

* Passed necessary context (`workspaceId`, `workspaceApplicationIdURI`) through form components to support the user picker widget. (`ui/app/src/components/shared/create-update-resource/CreateUpdateResource.tsx`, `ui/app/src/components/shared/create-update-resource/ResourceForm.tsx`, [[1]](diffhunk://#diff-e44314c84e86f1fbb2a8ae987c1d318a7480ba9760371d8bc228f674d8211addR163) [[2]](diffhunk://#diff-5fc4bdfc8113f3b34c3a80cba7debaa71003a59d481d97ab5bf08fc796638c22R26) [[3]](diffhunk://#diff-5fc4bdfc8113f3b34c3a80cba7debaa71003a59d481d97ab5bf08fc796638c22R173-R174)
* Registered the new widget with the form library to ensure it is rendered where specified in the UI schema. (`ui/app/src/components/shared/create-update-resource/ResourceForm.tsx`, [ui/app/src/components/shared/create-update-resource/ResourceForm.tsxR13-R17](diffhunk://#diff-5fc4bdfc8113f3b34c3a80cba7debaa71003a59d481d97ab5bf08fc796638c22R13-R17))

**Versioning and Documentation:**

* Bumped version numbers for the affected templates and UI package to reflect the changes. (`templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml`, `templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml`, `ui/app/package.json`, `ui/app/package-lock.json`, [[1]](diffhunk://#diff-4589ba058f171b6abe6a2f1311b9eeddde74523dbe16b6b7897fd04e13ca204eL4-R4) [[2]](diffhunk://#diff-59decdd2cf905eff9eb002a114d03be96a3f2bb003fe59519dbe81d9fe1730d7L4-R4) [[3]](diffhunk://#diff-0a6637811fcc3124b582b865f37568eb534ff809e1d6cff932600352a4bd91b4L3-R3) [[4]](diffhunk://#diff-0d64d69dfdf0d3ef09930dbd7390f7277cab1dc6a3169ce3613ec15acc0f4475L3-R9)
* Updated the changelog to document the new user picker enhancement. (`CHANGELOG.md`, [CHANGELOG.mdR6](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6))